### PR TITLE
ci: publish ut result in comments

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -25,14 +25,14 @@ jobs:
 #        if: always()
 #        run: |
 #          bash steps/sql_sdk_c_ut.sh 0 sql_sdk_test
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+      - name: upload Unit Test Results
         if: always()
+        uses: actions/upload-artifact@v2
         with:
-          files: reports/*.xml
-          comment_title: Test Report
-          report_individual_runs: true
-          check_run_annotations: all tests, skipped tests
+          name: linux-ut-result-cpp-${{ github.sha }}
+          path: |
+            reports/*.xml
+
       - name: cleanup
         if: always()
         run: |
@@ -56,14 +56,13 @@ jobs:
       - name: run sql_sdk_test
         run: |
           bash steps/ut.sh sql_sdk_test 0
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+      - name: upload Unit Test Results
         if: always()
+        uses: actions/upload-artifact@v2
         with:
-          files: reports/*.xml
-          comment_title: Test Report
-          report_individual_runs: true
-          check_run_annotations: all tests, skipped tests
+          name: linux-ut-result-cpp-${{ github.sha }} # the same name?
+          path: |
+            reports/*.xml
       - name: cleanup
         if: always()
         run: |
@@ -87,16 +86,35 @@ jobs:
       - name: run sql_sdk_test
         run: |
           bash steps/ut.sh sql_cluster_test 0
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+      - name: upload Unit Test Results
         if: always()
+        uses: actions/upload-artifact@v2
         with:
-          files: reports/*.xml
-          comment_title: Test Report
-          report_individual_runs: true
-          check_run_annotations: all tests, skipped tests
+          name: linux-ut-result-cpp-${{ github.sha }}
+          path: |
+            reports/*.xml
       - name: cleanup
         if: always()
         run: |
           source /etc/profile.d/enable-rh.sh
           git clean -dfx
+
+  publish-test-results:
+    runs-on: ubuntu-latest
+    needs: ["cpp_ut", "sql_sdk_test", "sql_cluster_test"]
+    # the action will only run on 4paradigm/fedb's context, not for fork repo or dependabot
+    if: >
+      always() && github.event_name == 'push' || (
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.sender.login != 'dependabot[bot]' )
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+
+      - name: Publish Linux UT Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          files: linux-ut-result-*/**/*.xml
+          check_name: Linux Test Report
+          comment_title: Linux Test Report
+          

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -7,7 +7,7 @@ jobs:
   cpp_ut:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4paradigm/centos6_gcc7_hybridsql:0.1.1
+      image: ghcr.io/4paradigm/hybridsql:0.2.0
     steps:
       - uses: actions/checkout@v1
       - name: uncompress_thirdparty
@@ -25,14 +25,13 @@ jobs:
 #        if: always()
 #        run: |
 #          bash steps/sql_sdk_c_ut.sh 0 sql_sdk_test
-      - name: upload Unit Test Results
+      - name: upload unit test results
         if: always()
         uses: actions/upload-artifact@v2
         with:
           name: linux-ut-result-cpp-${{ github.sha }}
           path: |
             reports/*.xml
-
       - name: cleanup
         if: always()
         run: |
@@ -42,7 +41,7 @@ jobs:
   sql_sdk_test:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4paradigm/centos6_gcc7_hybridsql:0.1.1
+      image: ghcr.io/4paradigm/hybridsql:0.2.0
     steps:
       - uses: actions/checkout@v1
       - name: uncompress_thirdparty
@@ -56,11 +55,11 @@ jobs:
       - name: run sql_sdk_test
         run: |
           bash steps/ut.sh sql_sdk_test 0
-      - name: upload Unit Test Results
+      - name: upload unit test results
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: linux-ut-result-cpp-${{ github.sha }} # the same name?
+          name: linux-ut-result-cpp-sdk-${{ github.sha }} # the same name?
           path: |
             reports/*.xml
       - name: cleanup
@@ -72,7 +71,7 @@ jobs:
   sql_cluster_test:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4paradigm/centos6_gcc7_hybridsql:0.1.1
+      image: ghcr.io/4paradigm/hybridsql:0.2.0
     steps:
       - uses: actions/checkout@v1
       - name: uncompress_thirdparty
@@ -86,11 +85,11 @@ jobs:
       - name: run sql_sdk_test
         run: |
           bash steps/ut.sh sql_cluster_test 0
-      - name: upload Unit Test Results
+      - name: upload unit test results
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: linux-ut-result-cpp-${{ github.sha }}
+          name: linux-ut-result-cpp-cluster-${{ github.sha }}
           path: |
             reports/*.xml
       - name: cleanup
@@ -117,4 +116,3 @@ jobs:
           files: linux-ut-result-*/**/*.xml
           check_name: Linux Test Report
           comment_title: Linux Test Report
-          

--- a/.github/workflows/publish-test-result-from-fork.yml
+++ b/.github/workflows/publish-test-result-from-fork.yml
@@ -3,7 +3,7 @@ name: publish-test-result-from-fork
 on:
   # the action will only run on dependabot/fork pull request
   workflow_run:
-    workflows: ["FEDB CI"]
+    workflows: ["cicd"]
     types:
       - completed
 

--- a/.github/workflows/publish-test-result-from-fork.yml
+++ b/.github/workflows/publish-test-result-from-fork.yml
@@ -1,0 +1,61 @@
+name: publish-test-result-from-fork
+
+on:
+  # the action will only run on dependabot/fork pull request
+  workflow_run:
+    workflows: ["FEDB CI"]
+    types:
+      - completed
+
+jobs:
+  test-results:
+    name: Test Results
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.conclusion != 'skipped' && (
+         github.event.sender.login == 'dependabot[bot]' ||
+         github.event.workflow_run.head_repository.full_name != github.repository
+      )
+    steps:
+      - name: Download Artifacts
+        uses: actions/github-script@v3
+        with:
+          script: |
+            var fs = require('fs');
+            var path = require('path');
+            var artifacts_path = path.join('${{github.workspace}}', 'artifacts')
+            fs.mkdirSync(artifacts_path, { recursive: true })
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{ github.event.workflow_run.id }},
+            });
+            for (const artifact of artifacts.data.artifacts) {
+               var download = await github.actions.downloadArtifact({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  artifact_id: artifact.id,
+                  archive_format: 'zip',
+               });
+               var artifact_path = path.join(artifacts_path, `${artifact.name}.zip`)
+               fs.writeFileSync(artifact_path, Buffer.from(download.data));
+               console.log(`Downloaded ${artifact_path}`);
+            }
+      - name: Extract Artifacts
+        run: |
+          for file in artifacts/*.zip
+          do
+            if [ -f "$file" ]
+            then
+              dir="${file/%.zip/}"
+              mkdir -p "$dir"
+              unzip -d "$dir" "$file"
+            fi
+          done
+      - name: Publish Linux UT Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          files: artifacts/linux-ut-result-*/**/*.xml
+          check_name: Linux Test Report
+          comment_title: Linux Test Report


### PR DESCRIPTION
Closes #63 
Ref https://github.com/4paradigm/HybridSE/commit/b6b990ba4c3360fe695d4c42b36b0d226b72428e
Reports of ut are updated as artifacts, and publish actions are different between different kinds of pull request, from same repo or forked/dependent-bot repo.
Report action will active after the merge of this commit.

