### PR TITLE
fix: fix end2end test cases which may reuse the same spark session

### DIFF
--- a/java/openmldb-batch/pom.xml
+++ b/java/openmldb-batch/pom.xml
@@ -99,7 +99,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
+			<version>4.13.2</version>
 		</dependency>
 
 		<!-- Spark -->
@@ -238,10 +238,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<!-- Refer to issue in https://issues.apache.org/jira/browse/SUREFIRE-1443 -->
-				<version>2.21.0</version>
+				<version>3.0.0-M5</version>
 				<configuration>
+					<!-- Make sure the SparkSession is unique for each unit test -->
+					<reuseForks>false</reuseForks>
+					<forkCount>4</forkCount>
 					<skipAfterFailureCount>1</skipAfterFailureCount>
+					<skipTests>false</skipTests>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -286,6 +289,9 @@
 						</goals>
 					</execution>
 				</executions>
+				<configuration>
+					<forkMode>never</forkMode>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -372,7 +378,7 @@
 					<verbose>false</verbose>
 					<failOnViolation>true</failOnViolation>
 					<includeTestSourceDirectory>true</includeTestSourceDirectory>
-					<failOnWarning>true</failOnWarning>
+					<failOnWarning>false</failOnWarning>
 					<sourceDirectory>${project.basedir}/src/main/scala</sourceDirectory>
 					<testSourceDirectory>${project.basedir}/src/test/scala</testSourceDirectory>
 					<configLocation>${project.basedir}/scala_style.xml</configLocation>

--- a/java/openmldb-batch/pom.xml
+++ b/java/openmldb-batch/pom.xml
@@ -240,8 +240,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>3.0.0-M5</version>
 				<configuration>
-					<!-- Make sure the SparkSession is unique for each unit test -->
-					<reuseForks>false</reuseForks>
+					<!-- <reuseForks>false</reuseForks> -->
 					<forkCount>4</forkCount>
 					<skipAfterFailureCount>1</skipAfterFailureCount>
 					<skipTests>false</skipTests>
@@ -290,7 +289,7 @@
 					</execution>
 				</executions>
 				<configuration>
-					<forkMode>never</forkMode>
+					<!-- <forkMode>never</forkMode> -->
 				</configuration>
 			</plugin>
 			<plugin>

--- a/java/openmldb-batch/pom.xml
+++ b/java/openmldb-batch/pom.xml
@@ -240,6 +240,9 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<!-- Refer to issue in https://issues.apache.org/jira/browse/SUREFIRE-1443 -->
 				<version>2.21.0</version>
+				<configuration>
+					<skipAfterFailureCount>1</skipAfterFailureCount>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>net.alchim31.maven</groupId>

--- a/java/openmldb-batch/pom.xml
+++ b/java/openmldb-batch/pom.xml
@@ -377,7 +377,7 @@
 					<verbose>false</verbose>
 					<failOnViolation>true</failOnViolation>
 					<includeTestSourceDirectory>true</includeTestSourceDirectory>
-					<failOnWarning>false</failOnWarning>
+					<failOnWarning>true</failOnWarning>
 					<sourceDirectory>${project.basedir}/src/main/scala</sourceDirectory>
 					<testSourceDirectory>${project.basedir}/src/test/scala</testSourceDirectory>
 					<configLocation>${project.basedir}/scala_style.xml</configLocation>

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/OpenmldbBatchConfig.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/OpenmldbBatchConfig.scala
@@ -26,9 +26,6 @@ class OpenmldbBatchConfig extends Serializable {
   @ConfigOption(name="openmldb.groupby.partitions", doc="Default partition number used in group by")
   var groupbyPartitions: Int = -1
 
-  @ConfigOption(name="openmldb.dbName", doc="Database name")
-  var configDBName = "spark_db"
-
   @ConfigOption(name="spark.sql.session.timeZone")
   var timeZone = "Asia/Shanghai"
 

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/OpenmldbBatchConfig.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/OpenmldbBatchConfig.scala
@@ -119,8 +119,7 @@ class OpenmldbBatchConfig extends Serializable {
   var disableOpenmldb = false
 
   // HybridSE dynamic library path
-  // TODO: Support this when upgrading hybridse-sdk to 0.1.4
-  //@ConfigOption(name="openmldb.hybridse.jsdk.path", doc="The path of HybridSE jsdk core file path")
+  @ConfigOption(name="openmldb.hybridse.jsdk.path", doc="The path of HybridSE jsdk core file path")
   var hybridseJsdkLibraryPath = ""
 
   @ConfigOption("openmldb.enable.hive.metastore", "Need to set hive.metastore.uris")

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/SparkPlanner.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/SparkPlanner.scala
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory
 import scala.collection.mutable
 
 
-class SparkPlanner(session: SparkSession, config: OpenmldbBatchConfig) {
+class SparkPlanner(session: SparkSession, config: OpenmldbBatchConfig, dbName: String) {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 
@@ -46,12 +46,16 @@ class SparkPlanner(session: SparkSession, config: OpenmldbBatchConfig) {
   if (config.hybridseJsdkLibraryPath.equals("")) {
     HybridSeLibrary.initCore()
   } else {
-    //HybridSeLibrary.initCore(config.hybridseJsdkLibraryPath)
+    HybridSeLibrary.initCore(config.hybridseJsdkLibraryPath)
   }
   Engine.InitializeGlobalLLVM()
 
   def this(session: SparkSession) = {
-    this(session, OpenmldbBatchConfig.fromSparkSession(session))
+    this(session, session.conf.get("spark.app.name"))
+  }
+
+  def this(session: SparkSession, dbName: String) = {
+    this(session, OpenmldbBatchConfig.fromSparkSession(session), dbName)
   }
 
   def plan(sql: String, tableDict: Map[String, DataFrame]): SparkInstance = {

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/SparkPlanner.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/SparkPlanner.scala
@@ -52,7 +52,7 @@ class SparkPlanner(session: SparkSession, config: OpenmldbBatchConfig) {
 
   def plan(sql: String, tableDict: Map[String, DataFrame]): SparkInstance = {
     // Translation state
-    val planCtx = new PlanContext(sql, session, this, config)
+    val planCtx = new PlanContext(config.configDBName + "-" + sql, session, this, config)
 
     // Set input tables
     tableDict.foreach {

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/GroupByAggregationPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/GroupByAggregationPlan.scala
@@ -94,7 +94,7 @@ object GroupByAggregationPlan {
         if (hybridseJsdkLibraryPath.equals("")) {
           JitManager.initJitModule(tag, buffer)
         } else {
-          //JitManager.initJitModule(tag, buffer, hybridseJsdkLibraryPath)
+          JitManager.initJitModule(tag, buffer, hybridseJsdkLibraryPath)
         }
 
         val jit = JitManager.getJit(tag)

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/JoinPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/JoinPlan.scala
@@ -245,7 +245,7 @@ object JoinPlan {
       if (hybridseJsdkLibraryPath.equals("")) {
         JitManager.initJitModule(moduleTag, buffer)
       } else {
-        //JitManager.initJitModule(moduleTag, buffer, hybridseJsdkLibraryPath)
+        JitManager.initJitModule(moduleTag, buffer, hybridseJsdkLibraryPath)
       }
 
       JitManager.getJit(moduleTag)

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/RowProjectPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/RowProjectPlan.scala
@@ -78,7 +78,7 @@ object RowProjectPlan {
         if (hybridseJsdkLibraryPath.equals("")) {
           JitManager.initJitModule(tag, buffer)
         } else {
-          //JitManager.initJitModule(tag, buffer, hybridseJsdkLibraryPath)
+          JitManager.initJitModule(tag, buffer, hybridseJsdkLibraryPath)
         }
 
         val jit = JitManager.getJit(tag)

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/utils/SparkUtil.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/utils/SparkUtil.scala
@@ -18,6 +18,7 @@ package com._4paradigm.openmldb.batch.utils
 
 import com._4paradigm.hybridse.sdk.HybridSeException
 import com._4paradigm.hybridse.node.JoinType
+import org.apache.log4j.{Level, Logger}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.functions.monotonically_increasing_id
@@ -139,7 +140,7 @@ object SparkUtil {
       }
     }
 
-    df1.except(df1).isEmpty && df2.except(df2).isEmpty
+    df1.except(df2).isEmpty && df2.except(df1).isEmpty
   }
 
   /** Use Java reflect to call private method to convert RDD[InternalRow] to DataFrame.
@@ -157,6 +158,11 @@ object SparkUtil {
         classOf[StructType], classOf[Boolean])
     internalCreateDataFrameMethod.invoke(spark, internalRowRdd, schema, false: java.lang.Boolean)
       .asInstanceOf[DataFrame]
+  }
+
+  def disableSparkLog(): Unit = {
+    Logger.getLogger("org").setLevel(Level.OFF);
+    Logger.getLogger("akka").setLevel(Level.OFF);
   }
 
 }

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/SameNameSqlIssue.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/SameNameSqlIssue.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 4Paradigm
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com._4paradigm.openmldb.batch.end2end
+
+import com._4paradigm.openmldb.batch.SparkTestSuite
+import com._4paradigm.openmldb.batch.api.OpenmldbSession
+import com._4paradigm.openmldb.batch.utils.SparkUtil
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+import org.apache.spark.sql.{Row, SparkSession}
+
+
+class SameNameSqlIssue extends SparkTestSuite {
+
+  test("Test end2end window aggregation") {
+
+    val sqlText = "SELECT id, user, trans_amount, trans_time + 1 FROM t1"
+
+    var spark = SparkSession.builder().master("local[*]").config("openmldb.dbName", "db1").getOrCreate()
+    var sess = new OpenmldbSession(spark)
+
+    var data = Seq(
+      Row(10, 222, 1000, 110))
+    var schema = StructType(List(
+      StructField("id", IntegerType),
+      StructField("user", IntegerType),
+      StructField("trans_amount", IntegerType),
+      StructField("trans_time", IntegerType)))
+    var df = spark.createDataFrame(spark.sparkContext.makeRDD(data), schema)
+
+    var expect = Seq(
+      Row(10, 222, 1000, 111))
+    var expectSchema = StructType(List(
+      StructField("id", IntegerType),
+      StructField("user", IntegerType),
+      StructField("trans_amount", IntegerType),
+      StructField("trans_time + 1", IntegerType)))
+    var expectDf = spark.createDataFrame(spark.sparkContext.makeRDD(expect), expectSchema)
+
+    sess.registerTable("t1", df)
+
+    var res = sess.sql(sqlText)
+    assert(SparkUtil.approximateDfEqual(expectDf, res.getSparkDf(), true))
+    spark.close()
+
+
+    spark = SparkSession.builder().master("local[*]").config("openmldb.dbName", "db2").getOrCreate()
+    sess = new OpenmldbSession(spark)
+
+    data = Seq(
+      Row(10, "weramy234124", 122000, 123423410))
+    schema = StructType(List(
+      StructField("id", IntegerType),
+      StructField("user", StringType),
+      StructField("trans_amount", IntegerType),
+      StructField("trans_time", IntegerType)))
+    df = spark.createDataFrame(spark.sparkContext.makeRDD(data), schema)
+
+    expect = Seq(
+      Row(10, "weramy234124", 122000, 123423411))
+    expectSchema = StructType(List(
+      StructField("id", IntegerType),
+      StructField("user", StringType),
+      StructField("trans_amount", IntegerType),
+      StructField("trans_time + 1", IntegerType)))
+    expectDf = spark.createDataFrame(spark.sparkContext.makeRDD(expect), expectSchema)
+
+    sess.registerTable("t1", df)
+    res = sess.sql(sqlText)
+    res.show();
+    assert(SparkUtil.approximateDfEqual(expectDf, res.getSparkDf(), true))
+    spark.close()
+
+  }
+
+}

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/SameNameSqlIssue.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/SameNameSqlIssue.scala
@@ -25,11 +25,12 @@ import org.apache.spark.sql.{Row, SparkSession}
 
 class SameNameSqlIssue extends SparkTestSuite {
 
-  test("Test end2end window aggregation") {
+  test("Test run same SQL in same process") {
 
-    val sqlText = "SELECT id, user, trans_amount, trans_time + 1 FROM t1"
+    val sqlText = "SELECT id, user, trans_amount, trans_time + 1 as trans_time_one FROM t1"
 
-    var spark = SparkSession.builder().master("local[*]").config("openmldb.dbName", "db1").getOrCreate()
+    // Run the first SQL
+    var spark = SparkSession.builder().master("local[*]").getOrCreate()
     var sess = new OpenmldbSession(spark)
 
     var data = Seq(
@@ -41,27 +42,18 @@ class SameNameSqlIssue extends SparkTestSuite {
       StructField("trans_time", IntegerType)))
     var df = spark.createDataFrame(spark.sparkContext.makeRDD(data), schema)
 
-    var expect = Seq(
-      Row(10, 222, 1000, 111))
-    var expectSchema = StructType(List(
-      StructField("id", IntegerType),
-      StructField("user", IntegerType),
-      StructField("trans_amount", IntegerType),
-      StructField("trans_time + 1", IntegerType)))
-    var expectDf = spark.createDataFrame(spark.sparkContext.makeRDD(expect), expectSchema)
-
+    df.createOrReplaceTempView("t1")
     sess.registerTable("t1", df)
 
-    var res = sess.sql(sqlText)
-    assert(SparkUtil.approximateDfEqual(expectDf, res.getSparkDf(), true))
+    assert(SparkUtil.approximateDfEqual(spark.sql(sqlText), sess.sql(sqlText).getSparkDf(), true))
     spark.close()
 
-
-    spark = SparkSession.builder().master("local[*]").config("openmldb.dbName", "db2").getOrCreate()
+    // Run the same SQL but different schema
+    spark = SparkSession.builder().master("local[*]").getOrCreate()
     sess = new OpenmldbSession(spark)
 
     data = Seq(
-      Row(10, "weramy234124", 122000, 123423410))
+      Row(10, "abc", 100, 200))
     schema = StructType(List(
       StructField("id", IntegerType),
       StructField("user", StringType),
@@ -69,19 +61,10 @@ class SameNameSqlIssue extends SparkTestSuite {
       StructField("trans_time", IntegerType)))
     df = spark.createDataFrame(spark.sparkContext.makeRDD(data), schema)
 
-    expect = Seq(
-      Row(10, "weramy234124", 122000, 123423411))
-    expectSchema = StructType(List(
-      StructField("id", IntegerType),
-      StructField("user", StringType),
-      StructField("trans_amount", IntegerType),
-      StructField("trans_time + 1", IntegerType)))
-    expectDf = spark.createDataFrame(spark.sparkContext.makeRDD(expect), expectSchema)
-
+    df.createOrReplaceTempView("t1")
     sess.registerTable("t1", df)
-    res = sess.sql(sqlText)
-    res.show();
-    assert(SparkUtil.approximateDfEqual(expectDf, res.getSparkDf(), true))
+
+    assert(SparkUtil.approximateDfEqual(spark.sql(sqlText), sess.sql(sqlText).getSparkDf(), true))
     spark.close()
 
   }

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/TestUnsafeRowOptimization.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/TestUnsafeRowOptimization.scala
@@ -16,20 +16,19 @@
 
 package com._4paradigm.openmldb.batch.end2end
 
+import com._4paradigm.openmldb.batch.SparkTestSuite
 import com._4paradigm.openmldb.batch.api.OpenmldbSession
 import com._4paradigm.openmldb.batch.utils.SparkUtil
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
-import org.apache.spark.sql.{Row, SparkSession}
-import org.scalatest.FunSuite
 
 
-class TestUnsafeRowOptimization extends FunSuite {
+class TestUnsafeRowOptimization extends SparkTestSuite {
 
   test("Test end2end UnsafeRow optimization") {
 
-    val spark = SparkSession.builder().master("local[*]")
-      .config("spark.openmldb.unsaferow.opt", true)
-      .getOrCreate()
+    getSparkSession.conf.set("spark.openmldb.unsaferow.opt", true)
+    val spark = getSparkSession
     val sess = new OpenmldbSession(spark)
 
     val data = Seq(

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/TestUnsafeRowProject.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/TestUnsafeRowProject.scala
@@ -16,20 +16,19 @@
 
 package com._4paradigm.openmldb.batch.end2end
 
+import com._4paradigm.openmldb.batch.SparkTestSuite
 import com._4paradigm.openmldb.batch.api.OpenmldbSession
 import com._4paradigm.openmldb.batch.utils.SparkUtil
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
-import org.apache.spark.sql.{Row, SparkSession}
-import org.scalatest.FunSuite
 
 
-class TestUnsafeRowProject extends FunSuite {
+class TestUnsafeRowProject extends SparkTestSuite {
 
   test("Test end2end UnsafeRow optimization for row project") {
 
-    val spark = SparkSession.builder().master("local[*]")
-      .config("spark.openmldb.unsaferow.opt", true)
-      .getOrCreate()
+    getSparkSession.conf.set("spark.openmldb.unsaferow.opt", true)
+    val spark = getSparkSession
     val sess = new OpenmldbSession(spark)
 
     val data = Seq(

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/TestWindow.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/TestWindow.scala
@@ -16,19 +16,18 @@
 
 package com._4paradigm.openmldb.batch.end2end
 
+import com._4paradigm.openmldb.batch.SparkTestSuite
 import com._4paradigm.openmldb.batch.api.OpenmldbSession
-import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 import com._4paradigm.openmldb.batch.utils.SparkUtil
-import org.apache.spark.sql.{Row, SparkSession}
-import org.scalatest.FunSuite
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
 
-class TestWindow extends FunSuite {
+class TestWindow extends SparkTestSuite {
 
   test("Test end2end window aggregation") {
 
-    val spark = SparkSession.builder().master("local[*]")
-      .getOrCreate()
+    val spark = getSparkSession
     val sess = new OpenmldbSession(spark)
 
     val data = Seq(

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/TestWindowSkewOptimization.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/TestWindowSkewOptimization.scala
@@ -16,20 +16,19 @@
 
 package com._4paradigm.openmldb.batch.end2end
 
+import com._4paradigm.openmldb.batch.SparkTestSuite
 import com._4paradigm.openmldb.batch.api.OpenmldbSession
 import com._4paradigm.openmldb.batch.utils.SparkUtil
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
-import org.apache.spark.sql.{Row, SparkSession}
-import org.scalatest.FunSuite
 
 
-class TestWindowSkewOptimization extends FunSuite {
+class TestWindowSkewOptimization extends SparkTestSuite {
 
   test("Test end2end window skew optimization") {
 
-    val spark = SparkSession.builder().master("local[*]")
-      .config("spark.openmldb.window.skew.opt", true)
-      .getOrCreate()
+    getSparkSession.conf.set("spark.openmldb.window.skew.opt", true)
+    val spark = getSparkSession
     val sess = new OpenmldbSession(spark)
 
     val data = Seq(

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/TestWindowSkewOptimizationWithSkewConfig.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/TestWindowSkewOptimizationWithSkewConfig.scala
@@ -16,21 +16,20 @@
 
 package com._4paradigm.openmldb.batch.end2end
 
+import com._4paradigm.openmldb.batch.SparkTestSuite
 import com._4paradigm.openmldb.batch.api.OpenmldbSession
 import com._4paradigm.openmldb.batch.utils.SparkUtil
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
-import org.apache.spark.sql.{Row, SaveMode, SparkSession}
-import org.scalatest.FunSuite
+import org.apache.spark.sql.{Row, SaveMode}
 
 
-class TestWindowSkewOptimizationWithSkewConfig extends FunSuite {
+class TestWindowSkewOptimizationWithSkewConfig extends SparkTestSuite {
 
   test("Test end2end window skew optimization") {
 
-    val spark = SparkSession.builder().master("local[*]")
-      .config("spark.openmldb.window.skew.opt", true)
-      .config("openmldb.window.skew.opt.config", "file:///tmp/window_skew_opt_config/")
-      .getOrCreate()
+    getSparkSession.conf.set("spark.openmldb.window.skew.opt", true)
+    getSparkSession.conf.set("openmldb.window.skew.opt.config", "file:///tmp/window_skew_opt_config/")
+    val spark = getSparkSession
     val sess = new OpenmldbSession(spark)
 
     val data = Seq(
@@ -53,7 +52,6 @@ class TestWindowSkewOptimizationWithSkewConfig extends FunSuite {
 
     sess.registerTable("t1", df)
     df.createOrReplaceTempView("t1")
-
 
     // Generate skew config
     val distributionData = Seq(

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/TestWindowUnion.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/TestWindowUnion.scala
@@ -16,18 +16,17 @@
 
 package com._4paradigm.openmldb.batch.end2end
 
+import com._4paradigm.openmldb.batch.SparkTestSuite
 import com._4paradigm.openmldb.batch.api.OpenmldbSession
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
-import org.apache.spark.sql.{Row, SparkSession}
-import org.scalatest.FunSuite
 
 
-class TestWindowUnion extends FunSuite {
+class TestWindowUnion extends SparkTestSuite {
 
   test("Test end2end window union") {
 
-    val spark = SparkSession.builder().master("local[*]")
-      .getOrCreate()
+    val spark = getSparkSession
     val sess = new OpenmldbSession(spark)
 
     val data = Seq(


### PR DESCRIPTION

* Config skipAfterFailureCount for `mvn test`
* Fix the Spark util to check if dataframes are equal
* Update the  end2end unit tests to use the new SparkSession
* Add the utility method to disable Spark log
* Add the unit test for `approximateDfEqual`
