### PR TITLE
fix: fix error in doBatchRowRequestdoBatchRowRequest - wrong variable assignned

### DIFF
--- a/python/openmldb/driver.py
+++ b/python/openmldb/driver.py
@@ -219,7 +219,7 @@ class Driver(object):
             colName = schema.GetColumnName(i)
             if colName in commonCol:
                 commonCols.AddCommonColumnIdx(i)
-                commonColAddCount+=1
+                commnColAddCount+=1
         if commnColAddCount != len(commonCol):
             return False, "some common col is not in table schema"
         requestRowBatch = sql_router_sdk.SQLRequestRowBatch(schema, commonCols)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- The commit message follows our guidelines
- Tests for the changes have been added (for bug fixes / features)
- Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug in Python driver, due to wrong variable assign.


* **What is the current behavior?** (You can also link to an open issue here)
No variable with the current name exist, in the Python driver there are 2 very similar variable: "commonCols" and "commnColAddCount" which led to the mistakes.


* **What is the new behavior (if this is a feature change)?**
I reckon a bug (or hidden bug) might be fix.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
It should fix a bug, so it should be a positve change.


* **Other information**:
