### PR TITLE
feat: update spark and hadoop version

### DIFF
--- a/java/openmldb-batch/pom.xml
+++ b/java/openmldb-batch/pom.xml
@@ -44,10 +44,10 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 		<scala.version>2.12.8</scala.version>
 		<scala.binary.version>2.12</scala.binary.version>
-		<spark.version>3.0.0</spark.version>
+		<spark.version>3.1.2</spark.version>
 		<spark.dependencyScope>provided</spark.dependencyScope>
-		<default.project.version>0.2.1</default.project.version>
-		<default.hybridse.sdk.version>0.3.0</default.hybridse.sdk.version>
+		<default.project.version>0.2.3</default.project.version>
+		<default.hybridse.sdk.version>0.2.3</default.hybridse.sdk.version>
 	</properties>
 
 	<profiles>
@@ -179,7 +179,7 @@
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-common</artifactId>
-			<version>2.7.4</version>
+			<version>3.3.1</version>
 		</dependency>
 
 		<!-- Iceberg -->

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/SparkPlanner.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/SparkPlanner.scala
@@ -267,7 +267,7 @@ class SparkPlanner(session: SparkSession, config: OpenmldbBatchConfig, dbName: S
       logger.info(s"Compute $rootKey ${i}th child: $key")
 
       val cacheDataPath = cacheDir + "/" + key + "/data"
-      val existCache = fileSystem.isDirectory(new Path(cacheDataPath)) &&
+      val existCache = fileSystem.getFileStatus(new Path(cacheDataPath)).isDirectory &&
         fileSystem.exists(new Path(cacheDataPath + "/_SUCCESS"))
       val childResult = if (existCache) {
         logger.info(s"Load cached $key: $cacheDataPath")


### PR DESCRIPTION
- In order to use percentile_approx in dataframe function, update Spark version to 3.1.2 
- Update Hadoop version to 3.3.1 to adapt Spark 3.1.2
- Fix isDirectory function which is obsolete
- Resolved https://github.com/4paradigm/OpenMLDB/issues/333