### PR TITLE
feat: bump hadoop-common to 2.8.5 to avoid vulnerability

### DIFF
--- a/java/openmldb-batch/pom.xml
+++ b/java/openmldb-batch/pom.xml
@@ -179,7 +179,7 @@
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-common</artifactId>
-			<version>2.7.4</version>
+			<version>2.8.5</version>
 		</dependency>
 
 		<!-- Iceberg -->

--- a/java/openmldb-taskmanager/pom.xml
+++ b/java/openmldb-taskmanager/pom.xml
@@ -18,7 +18,7 @@
         <scala.version>2.12.8</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.1.2</spark.version>
-        <hadoop.version>2.7.4</hadoop.version>
+        <hadoop.version>2.8.5</hadoop.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
* Resolve https://github.com/4paradigm/OpenMLDB/issues/387