### PR TITLE
fix: fix some code implementation in window skew optimization

### DIFF
--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/api/OpenmldbSession.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/api/OpenmldbSession.scala
@@ -63,6 +63,15 @@ class OpenmldbSession {
   }
 
   /**
+   * Get the config of Openmldb session.
+   *
+   * @return
+   */
+  def getOpenmldbBatchConfig: OpenmldbBatchConfig = {
+    this.config
+  }
+
+  /**
    * Get or create the Spark session.
    *
    * @return

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/WindowAggPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/WindowAggPlan.scala
@@ -165,10 +165,10 @@ object WindowAggPlan {
     // 1. Analyze the data distribution
     val distributionDf = if (ctx.getConf.windowSkewOptConfig.equals("")) {
       // Do not use skew config
-      val partitionColName = "_PARTITION_" + uniqueNamePostfix
+      val partitionKeyColName = "_PARTITION_KEY_" + uniqueNamePostfix
 
       val distributionDf = SkewDataFrameUtils.genDistributionDf(inputDf, quantile.intValue(), repartitionColIndexes,
-        orderByColIndex, partitionColName, greaterFlagColName, countColName)
+        orderByColIndex, partitionKeyColName, greaterFlagColName, countColName)
       logger.info("Generate distribution dataframe")
 
       if (ctx.getConf.windowSkewOptCache) {

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/WindowAggPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/WindowAggPlan.scala
@@ -172,8 +172,6 @@ object WindowAggPlan {
         orderByColIndex, partitionColName, greaterFlagColName, countColName)
       logger.info("Generate distribution dataframe")
 
-      distributionDf.show()
-
       if (ctx.getConf.windowSkewOptCache) {
         distributionDf.cache()
       }
@@ -197,8 +195,6 @@ object WindowAggPlan {
       val addColumnsDf = SkewDataFrameUtils.genAddColumnsDf(inputDf, distributionDf, quantile.intValue(),
         repartitionColIndexes, orderByColIndex, partColName, originalPartColName, countColName)
       logger.info("Generate percentile_tag dataframe")
-
-      addColumnsDf.show()
 
       addColumnsDf
     } else {
@@ -248,8 +244,6 @@ object WindowAggPlan {
       minCount, windowAggConfig.rowPreceding, windowAggConfig.startOffset)
     logger.info("Generate union dataframe")
 
-    unionDf.show()
-
     // 4. Repartition and order by
     val repartitionCols = mutable.ArrayBuffer[Column]()
     repartitionCols += addColumnsDf(partColName)
@@ -268,8 +262,6 @@ object WindowAggPlan {
 
     val sortedDf = repartitionDf.sortWithinPartitions(sortedByCols: _*)
     logger.info("Generate repartition and orderby dataframe")
-
-    sortedDf.show()
 
     sortedDf
   }

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/WindowAggPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/WindowAggPlan.scala
@@ -205,7 +205,7 @@ object WindowAggPlan {
       val distributionMap = Map(distributionCollect.map(p => (p.get(0), p.get(1))): _*)
 
       val outputSchema = inputDf.schema.add("_PART_", IntegerType, false)
-        .add("_EXPAND_", IntegerType, false)
+        .add("_ORIGINAL_PART_", IntegerType, false)
 
       val outputRdd = inputDf.rdd.map(row => {
         // Combine the repartition keys to one string which is equal to the first column of skew config
@@ -221,9 +221,9 @@ object WindowAggPlan {
         }
 
         val partValue = if (condition <= 0) {
-          2
-        } else {
           1
+        } else {
+          2
         }
 
         Row.fromSeq(row.toSeq :+ partValue :+ partValue)

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/utils/SkewDataFrameUtils.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/utils/SkewDataFrameUtils.scala
@@ -58,7 +58,8 @@ object SkewDataFrameUtils {
     val inputDfJoinCol = SparkColumnUtil.getColumnFromIndex(inputDf, repartitionColIndex(0))
     val distributionDfJoinCol = SparkColumnUtil.getColumnFromIndex(distributionDropCountDf, 0)
 
-    var joinDf = inputDf.join(distributionDropCountDf, inputDfJoinCol === distributionDfJoinCol, "left")
+    var joinDf = inputDf.join(distributionDropCountDf.hint("broadcast"),
+      inputDfJoinCol === distributionDfJoinCol, "left")
 
     // Select * and case when(...) from joinDf
     val inputDfPercentileCol = SparkColumnUtil.getColumnFromIndex(inputDf, percentileColIndex)

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/TestWindowSkewOptimizationWithSkewConfig.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/TestWindowSkewOptimizationWithSkewConfig.scala
@@ -19,7 +19,7 @@ package com._4paradigm.openmldb.batch.end2end
 import com._4paradigm.openmldb.batch.SparkTestSuite
 import com._4paradigm.openmldb.batch.api.OpenmldbSession
 import com._4paradigm.openmldb.batch.utils.SparkUtil
-import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{BooleanType, IntegerType, LongType, StringType, StructField, StructType}
 import org.apache.spark.sql.{Row, SaveMode}
 
 
@@ -53,13 +53,19 @@ class TestWindowSkewOptimizationWithSkewConfig extends SparkTestSuite {
     sess.registerTable("t1", df)
     df.createOrReplaceTempView("t1")
 
+    val partitionColName = "_PARTITION_" + sess.getOpenmldbBatchConfig.windowSkewOptPostfix
+    val greaterFlagColName = "_GREATER_FLAG_" + sess.getOpenmldbBatchConfig.windowSkewOptPostfix
+    val countColName = "_COUNT_" + sess.getOpenmldbBatchConfig.windowSkewOptPostfix
+
     // Generate skew config
     val distributionData = Seq(
-      Row("tom", 5),
-      Row("amy", 6))
+      Row("tom", 5, true, 5.toLong),
+      Row("amy", 6, true, 5.toLong))
     val distributionSchema = StructType(List(
-      StructField("user", StringType),
-      StructField("percentile_1", IntegerType)))
+      StructField(partitionColName, StringType),
+      StructField("percentile_1", IntegerType),
+      StructField(greaterFlagColName, BooleanType),
+      StructField(countColName, LongType)))
     val distributionDf = spark.createDataFrame(spark.sparkContext.makeRDD(distributionData), distributionSchema)
     distributionDf.write.mode(SaveMode.Overwrite).parquet("file:///tmp/window_skew_opt_config/")
 

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/utils/TestSkewDataFrameUtils.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/utils/TestSkewDataFrameUtils.scala
@@ -42,9 +42,9 @@ class TestSkewDataFrameUtils extends SparkTestSuite {
   val quantile = 2
   val repartitionColIndex: mutable.ArrayBuffer[Int] = mutable.ArrayBuffer(0)
   val percentileColIndex = 1
-  val partitionColName = "_PARTITION_"
-  val expandColName = "_EXPAND_"
-  val partColName = "_PART_"
+  val partitionColName = "_PARTITION_KEY_"
+  val originalPartColName = "_ORIGINAL_PART_ID_"
+  val partColName = "_PART_ID_"
   val greaterFlagColName = "_GREATER_FLAG_"
   val countColName = "_COUNT_"
 
@@ -76,22 +76,22 @@ class TestSkewDataFrameUtils extends SparkTestSuite {
     val distributionDf = genDistributionDf(inputDf, quantile, repartitionColIndex, percentileColIndex,
       partitionColName, greaterFlagColName, countColName)
     val resultDf = genAddColumnsDf(inputDf, distributionDf, quantile, repartitionColIndex,
-      percentileColIndex, partColName, expandColName, countColName)
+      percentileColIndex, partColName, originalPartColName, countColName)
 
     val compareData = Seq(
-      Row(550, 5, 1, 1),
-      Row(550, 4, 2, 2),
-      Row(550, 3, 2, 2),
-      Row(50, 2, 1, 1),
-      Row(50, 1, 2, 2),
-      Row(50, 0, 2, 2)
+      Row(550, 5, 2, 2),
+      Row(550, 4, 1, 1),
+      Row(550, 3, 1, 1),
+      Row(50, 2, 2, 2),
+      Row(50, 1, 1, 1),
+      Row(50, 0, 1, 1)
     )
 
     val compareSchema = StructType(List(
       StructField("col0", IntegerType),
       StructField("col1", IntegerType),
       StructField(partColName, IntegerType),
-      StructField(expandColName, IntegerType)
+      StructField(originalPartColName, IntegerType)
     ))
 
     val compareDf = spark.createDataFrame(spark.sparkContext.makeRDD(compareData), compareSchema)
@@ -105,27 +105,27 @@ class TestSkewDataFrameUtils extends SparkTestSuite {
     val distributionDf = genDistributionDf(inputDf, quantile, repartitionColIndex, percentileColIndex,
       partitionColName, greaterFlagColName, countColName)
     val addColumnDf = genAddColumnsDf(inputDf, distributionDf, quantile, repartitionColIndex,
-      percentileColIndex, partColName, expandColName, countColName)
-    val resultDf = genUnionDf(addColumnDf, quantile, partColName, expandColName, 0, 0, 0)
+      percentileColIndex, partColName, originalPartColName, countColName)
+    val resultDf = genUnionDf(addColumnDf, quantile, partColName, originalPartColName, 0, 0, 0)
 
     val compareData = Seq(
-      Row(50, 1, 1, 2),
-      Row(50, 0, 1, 2),
-      Row(550, 4, 1, 2),
-      Row(550, 3, 1, 2),
-      Row(550, 5, 1, 1),
-      Row(550, 4, 2, 2),
-      Row(550, 3, 2, 2),
-      Row(50, 2, 1, 1),
-      Row(50, 1, 2, 2),
-      Row(50, 0, 2, 2)
+      Row(50, 1, 2, 1),
+      Row(50, 0, 2, 1),
+      Row(550, 4, 2, 1),
+      Row(550, 3, 2, 1),
+      Row(550, 5, 2, 2),
+      Row(550, 4, 1, 1),
+      Row(550, 3, 1, 1),
+      Row(50, 2, 2, 2),
+      Row(50, 1, 1, 1),
+      Row(50, 0, 1, 1)
     )
 
     val compareSchema = StructType(List(
       StructField("col0", IntegerType),
       StructField("col1", IntegerType),
       StructField(partColName, IntegerType),
-      StructField(expandColName, IntegerType)
+      StructField(originalPartColName, IntegerType)
     ))
 
     val compareDf = spark.createDataFrame(spark.sparkContext.makeRDD(compareData), compareSchema)

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/utils/TestSkewDataFrameUtils.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/utils/TestSkewDataFrameUtils.scala
@@ -75,7 +75,8 @@ class TestSkewDataFrameUtils extends SparkTestSuite {
     val inputDf = spark.createDataFrame(spark.sparkContext.makeRDD(data), schema)
     val distributionDf = genDistributionDf(inputDf, quantile, repartitionColIndex, percentileColIndex,
       partitionKeyColName, greaterFlagColName, countColName)
-    val resultDf = genAddColumnsDf(inputDf, distributionDf, quantile, repartitionColIndex,
+    val distributionDropColumnDf = distributionDf.drop(greaterFlagColName).drop(countColName)
+    val resultDf = genAddColumnsDf(inputDf, distributionDropColumnDf, quantile, repartitionColIndex,
       percentileColIndex, partIdColName, originalPartIdColName)
 
     val compareData = Seq(
@@ -104,7 +105,8 @@ class TestSkewDataFrameUtils extends SparkTestSuite {
     val inputDf = spark.createDataFrame(spark.sparkContext.makeRDD(data), schema)
     val distributionDf = genDistributionDf(inputDf, quantile, repartitionColIndex, percentileColIndex,
       partitionKeyColName, greaterFlagColName, countColName)
-    val addColumnDf = genAddColumnsDf(inputDf, distributionDf, quantile, repartitionColIndex,
+    val distributionDropColumnDf = distributionDf.drop(greaterFlagColName).drop(countColName)
+    val addColumnDf = genAddColumnsDf(inputDf, distributionDropColumnDf, quantile, repartitionColIndex,
       percentileColIndex, partIdColName, originalPartIdColName)
     val resultDf = genUnionDf(addColumnDf, quantile, partIdColName, originalPartIdColName, 0, 0, 0)
 

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/utils/TestSkewDataFrameUtils.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/utils/TestSkewDataFrameUtils.scala
@@ -42,9 +42,9 @@ class TestSkewDataFrameUtils extends SparkTestSuite {
   val quantile = 2
   val repartitionColIndex: mutable.ArrayBuffer[Int] = mutable.ArrayBuffer(0)
   val percentileColIndex = 1
-  val partitionColName = "_PARTITION_KEY_"
-  val originalPartColName = "_ORIGINAL_PART_ID_"
-  val partColName = "_PART_ID_"
+  val partitionKeyColName = "_PARTITION_KEY_"
+  val originalPartIdColName = "_ORIGINAL_PART_ID_"
+  val partIdColName = "_PART_ID_"
   val greaterFlagColName = "_GREATER_FLAG_"
   val countColName = "_COUNT_"
 
@@ -52,7 +52,7 @@ class TestSkewDataFrameUtils extends SparkTestSuite {
     val spark = getSparkSession
     val inputDf = spark.createDataFrame(spark.sparkContext.makeRDD(data), schema)
     val resultDf = genDistributionDf(inputDf, quantile, repartitionColIndex, percentileColIndex,
-      partitionColName, greaterFlagColName, countColName)
+      partitionKeyColName, greaterFlagColName, countColName)
 
     val compareData = Seq(
       Row(550, 4, true, 3),
@@ -60,7 +60,7 @@ class TestSkewDataFrameUtils extends SparkTestSuite {
     )
 
     val compareSchema = StructType(List(
-      StructField(partitionColName, IntegerType),
+      StructField(partitionKeyColName, IntegerType),
       StructField("percentile_1", IntegerType),
       StructField(greaterFlagColName, BooleanType),
       StructField(countColName, IntegerType)))
@@ -74,9 +74,9 @@ class TestSkewDataFrameUtils extends SparkTestSuite {
     val spark = getSparkSession
     val inputDf = spark.createDataFrame(spark.sparkContext.makeRDD(data), schema)
     val distributionDf = genDistributionDf(inputDf, quantile, repartitionColIndex, percentileColIndex,
-      partitionColName, greaterFlagColName, countColName)
+      partitionKeyColName, greaterFlagColName, countColName)
     val resultDf = genAddColumnsDf(inputDf, distributionDf, quantile, repartitionColIndex,
-      percentileColIndex, partColName, originalPartColName, countColName)
+      percentileColIndex, partIdColName, originalPartIdColName, countColName)
 
     val compareData = Seq(
       Row(550, 5, 2, 2),
@@ -90,8 +90,8 @@ class TestSkewDataFrameUtils extends SparkTestSuite {
     val compareSchema = StructType(List(
       StructField("col0", IntegerType),
       StructField("col1", IntegerType),
-      StructField(partColName, IntegerType),
-      StructField(originalPartColName, IntegerType)
+      StructField(partIdColName, IntegerType),
+      StructField(originalPartIdColName, IntegerType)
     ))
 
     val compareDf = spark.createDataFrame(spark.sparkContext.makeRDD(compareData), compareSchema)
@@ -103,10 +103,10 @@ class TestSkewDataFrameUtils extends SparkTestSuite {
     val spark = getSparkSession
     val inputDf = spark.createDataFrame(spark.sparkContext.makeRDD(data), schema)
     val distributionDf = genDistributionDf(inputDf, quantile, repartitionColIndex, percentileColIndex,
-      partitionColName, greaterFlagColName, countColName)
+      partitionKeyColName, greaterFlagColName, countColName)
     val addColumnDf = genAddColumnsDf(inputDf, distributionDf, quantile, repartitionColIndex,
-      percentileColIndex, partColName, originalPartColName, countColName)
-    val resultDf = genUnionDf(addColumnDf, quantile, partColName, originalPartColName, 0, 0, 0)
+      percentileColIndex, partIdColName, originalPartIdColName, countColName)
+    val resultDf = genUnionDf(addColumnDf, quantile, partIdColName, originalPartIdColName, 0, 0, 0)
 
     val compareData = Seq(
       Row(50, 1, 2, 1),
@@ -124,8 +124,8 @@ class TestSkewDataFrameUtils extends SparkTestSuite {
     val compareSchema = StructType(List(
       StructField("col0", IntegerType),
       StructField("col1", IntegerType),
-      StructField(partColName, IntegerType),
-      StructField(originalPartColName, IntegerType)
+      StructField(partIdColName, IntegerType),
+      StructField(originalPartIdColName, IntegerType)
     ))
 
     val compareDf = spark.createDataFrame(spark.sparkContext.makeRDD(compareData), compareSchema)

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/utils/TestSkewDataFrameUtils.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/utils/TestSkewDataFrameUtils.scala
@@ -76,7 +76,7 @@ class TestSkewDataFrameUtils extends SparkTestSuite {
     val distributionDf = genDistributionDf(inputDf, quantile, repartitionColIndex, percentileColIndex,
       partitionKeyColName, greaterFlagColName, countColName)
     val resultDf = genAddColumnsDf(inputDf, distributionDf, quantile, repartitionColIndex,
-      percentileColIndex, partIdColName, originalPartIdColName, countColName)
+      percentileColIndex, partIdColName, originalPartIdColName)
 
     val compareData = Seq(
       Row(550, 5, 2, 2),
@@ -105,7 +105,7 @@ class TestSkewDataFrameUtils extends SparkTestSuite {
     val distributionDf = genDistributionDf(inputDf, quantile, repartitionColIndex, percentileColIndex,
       partitionKeyColName, greaterFlagColName, countColName)
     val addColumnDf = genAddColumnsDf(inputDf, distributionDf, quantile, repartitionColIndex,
-      percentileColIndex, partIdColName, originalPartIdColName, countColName)
+      percentileColIndex, partIdColName, originalPartIdColName)
     val resultDf = genUnionDf(addColumnDf, quantile, partIdColName, originalPartIdColName, 0, 0, 0)
 
     val compareData = Seq(


### PR DESCRIPTION
- Delete some code implementation in window skew optimization with skew config
- Fix some unit tests

- In order to better understand the details of window skew optimization

> 1. Reverse order of column in window skew optimization's unionDf
> For example, “col3” is the time column. And “part” column is in the same order as the time column now.
> 
> > PREVIOUSLY：
> > <img width="320" alt="wecom-temp-0719afcc896cbc9ec3860c31098ce11d" src="https://user-images.githubusercontent.com/26684958/132465851-4ae4e983-3ed6-493f-91ad-94e6624c7aca.png">
> > NOW：
> > <img width="328" alt="wecom-temp-89ea01c49c83f17b848be7c9a14e67b8" src="https://user-images.githubusercontent.com/26684958/132465822-6c9e8d1d-d41c-4c97-bb47-c817edd0aba3.png">
> 
> 2. Rename "_EXPAND_" to "_ORIGINAL_PART_ID_"
> 3. Rename "_PART_" to "_PART_ID_"
> 4. Rename "_PARTITION_" to "_PARTITION_KEY_"




