### PR TITLE
feat: support spark.master config to run job in yarn or local

### DIFF
--- a/java/openmldb-taskmanager/src/main/java/com/_4paradigm/openmldb/taskmanager/config/TaskManagerConfig.java
+++ b/java/openmldb-taskmanager/src/main/java/com/_4paradigm/openmldb/taskmanager/config/TaskManagerConfig.java
@@ -27,6 +27,7 @@ public class TaskManagerConfig {
     public static String ZK_ROOTPATH;
     public static int ZK_SESSION_TIMEOUT = 5000;
     public static String HIVE_METASTORE_ENDPOINT;
+    public static String SPARK_MASTER;
     public static String BATCHJOB_JAR_PATH;
     public static String SPARK_YARN_JARS;
 
@@ -42,6 +43,7 @@ public class TaskManagerConfig {
             ZK_CLUSTER = prop.getProperty("zookeeper.cluster");
             ZK_ROOTPATH = prop.getProperty("zookeeper.root_path");
             HIVE_METASTORE_ENDPOINT = prop.getProperty("hive.metastore.endpoint");
+            SPARK_MASTER = prop.getProperty("spark.master", "yarn");
             BATCHJOB_JAR_PATH = prop.getProperty("batchjob.jar.path");
             SPARK_YARN_JARS = prop.getProperty("spark.yarn.jars");
         } catch (Exception e) {

--- a/java/openmldb-taskmanager/src/main/resources/openmldb-taskmanager.properties
+++ b/java/openmldb-taskmanager/src/main/resources/openmldb-taskmanager.properties
@@ -11,4 +11,7 @@ hive.metastore.endpoint=thrift://m7-pce-dev01.4pd.io:9083
 
 batchjob.jar.path=hdfs:///Users/tobe/openmldb_batch_files/openmldb-batchjob-1.0-SNAPSHOT.jar
 
-spark.yarn.jars=hdfs:///Users/tobe/spark_300_jars/*
+# Spark Config
+spark.master=yarn
+# spark.yarn.jars=hdfs:///Users/tobe/spark_300_jars/*
+spark.yarn.jars=hdfs:///Users/tobe/openmldb_300_jars/*

--- a/java/openmldb-taskmanager/src/main/scala/com/_4paradigm/openmldb/taskmanager/SparkLauncherUtil.scala
+++ b/java/openmldb-taskmanager/src/main/scala/com/_4paradigm/openmldb/taskmanager/SparkLauncherUtil.scala
@@ -104,6 +104,7 @@ object SparkLauncherUtil {
         // For local mode, return when finished
         if((sparkAppHandle.getState == SparkAppHandle.State.SUBMITTED && sparkAppHandle.getAppId != null) || sparkAppHandle.getState.isFinal) {
           logger.info(s"Get Spark job state: ${sparkAppHandle.getState}")
+          logger.warn(sparkAppHandle.getError.toString)
           lock.countDown()
         }
       }

--- a/java/openmldb-taskmanager/src/main/scala/com/_4paradigm/openmldb/taskmanager/SparkLauncherUtil.scala
+++ b/java/openmldb-taskmanager/src/main/scala/com/_4paradigm/openmldb/taskmanager/SparkLauncherUtil.scala
@@ -33,13 +33,24 @@ object SparkLauncherUtil {
    * @return the SparkLauncher object
    */
   def createSparkLauncher(mainClass: String): SparkLauncher = {
-    new SparkLauncher()
+
+    val launcher = new SparkLauncher()
       .setAppResource(TaskManagerConfig.BATCHJOB_JAR_PATH)
       .setMainClass(mainClass)
-      .setMaster("yarn")
-      .setDeployMode("cluster")
-      .setConf("spark.yarn.jars", TaskManagerConfig.SPARK_YARN_JARS)
-      .setConf("spark.yarn.maxAppAttempts", "1")
+
+    TaskManagerConfig.SPARK_MASTER.toLowerCase match {
+      case "local" => {
+        launcher.setMaster("local")
+      }
+      case "yarn" => {
+        launcher.setMaster("yarn")
+          .setDeployMode("cluster")
+          .setConf("spark.yarn.jars", TaskManagerConfig.SPARK_YARN_JARS)
+          .setConf("spark.yarn.maxAppAttempts", "1")
+      }
+      case _ => throw new Exception(s"Unsupported Spark master ${TaskManagerConfig.SPARK_MASTER}")
+    }
+
   }
 
   /**

--- a/java/openmldb-taskmanager/src/main/scala/com/_4paradigm/openmldb/taskmanager/SparkLauncherUtil.scala
+++ b/java/openmldb-taskmanager/src/main/scala/com/_4paradigm/openmldb/taskmanager/SparkLauncherUtil.scala
@@ -100,7 +100,10 @@ object SparkLauncherUtil {
 
     val sparkAppHandle = sparkLauncher.startApplication(new SparkAppHandle.Listener() {
       override def stateChanged(sparkAppHandle: SparkAppHandle): Unit = {
-        if(sparkAppHandle.getState == SparkAppHandle.State.SUBMITTED && sparkAppHandle.getAppId != null) {
+        // For yarn-cluster return when get application id
+        // For local mode, return when finished
+        if((sparkAppHandle.getState == SparkAppHandle.State.SUBMITTED && sparkAppHandle.getAppId != null) || sparkAppHandle.getState.isFinal) {
+          logger.info(s"Get Spark job state: ${sparkAppHandle.getState}")
           lock.countDown()
         }
       }


### PR DESCRIPTION
* Support new config of `spark.master` and use `yarn` by default
* Support set Spark master as `local`
* Resolve https://github.com/4paradigm/OpenMLDB/issues/456 .