### PR TITLE
style: update hybridse header guard style

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -25,7 +25,6 @@ jobs:
           level: info
           reporter: github-pr-review
           flags: --linelength=120
-          filter: -build/header_guard
 
   detect-secrets:
     runs-on: ubuntu-latest

--- a/hybridse/CPPLINT.cfg
+++ b/hybridse/CPPLINT.cfg
@@ -1,2 +1,1 @@
 linelength=120
-filter=-build/header_guard

--- a/hybridse/examples/toydb/src/bm/client_bm_case.h
+++ b/hybridse/examples/toydb/src/bm/client_bm_case.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef EXAMPLES_TOYDB_SRC_BM_CLIENT_BM_CASE_H_
-#define EXAMPLES_TOYDB_SRC_BM_CLIENT_BM_CASE_H_
+#ifndef HYBRIDSE_EXAMPLES_TOYDB_SRC_BM_CLIENT_BM_CASE_H_
+#define HYBRIDSE_EXAMPLES_TOYDB_SRC_BM_CLIENT_BM_CASE_H_
 #include <stdio.h>
 #include <stdlib.h>
 #include "benchmark/benchmark.h"
@@ -45,4 +45,4 @@ void GROUPBY_CASE0_QUERY(benchmark::State *state_ptr, MODE mode,
 
 }  // namespace bm
 }  // namespace hybridse
-#endif  // EXAMPLES_TOYDB_SRC_BM_CLIENT_BM_CASE_H_
+#endif  // HYBRIDSE_EXAMPLES_TOYDB_SRC_BM_CLIENT_BM_CASE_H_

--- a/hybridse/examples/toydb/src/bm/engine_bm_case.h
+++ b/hybridse/examples/toydb/src/bm/engine_bm_case.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef EXAMPLES_TOYDB_SRC_BM_ENGINE_BM_CASE_H_
-#define EXAMPLES_TOYDB_SRC_BM_ENGINE_BM_CASE_H_
+#ifndef HYBRIDSE_EXAMPLES_TOYDB_SRC_BM_ENGINE_BM_CASE_H_
+#define HYBRIDSE_EXAMPLES_TOYDB_SRC_BM_ENGINE_BM_CASE_H_
 #include <string>
 #include "benchmark/benchmark.h"
 #include "case/sql_case.h"
@@ -117,4 +117,4 @@ void EngineBenchmarkOnCase(hybridse::sqlcase::SqlCase& sql_case,  // NOLINT
 
 }  // namespace bm
 }  // namespace hybridse
-#endif  // EXAMPLES_TOYDB_SRC_BM_ENGINE_BM_CASE_H_
+#endif  // HYBRIDSE_EXAMPLES_TOYDB_SRC_BM_ENGINE_BM_CASE_H_

--- a/hybridse/examples/toydb/src/bm/storage_bm_case.h
+++ b/hybridse/examples/toydb/src/bm/storage_bm_case.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef EXAMPLES_TOYDB_SRC_BM_STORAGE_BM_CASE_H_
-#define EXAMPLES_TOYDB_SRC_BM_STORAGE_BM_CASE_H_
+#ifndef HYBRIDSE_EXAMPLES_TOYDB_SRC_BM_STORAGE_BM_CASE_H_
+#define HYBRIDSE_EXAMPLES_TOYDB_SRC_BM_STORAGE_BM_CASE_H_
 #include <string>
 #include "benchmark/benchmark.h"
 #include "testing/toydb_engine_test_base.h"
@@ -32,4 +32,4 @@ void TabletWindowIterate(benchmark::State* state, MODE mode, int64_t data_size);
 void ArrayListIterate(benchmark::State* state, MODE mode, int64_t data_size);
 }  // namespace bm
 }  // namespace hybridse
-#endif  // EXAMPLES_TOYDB_SRC_BM_STORAGE_BM_CASE_H_
+#endif  // HYBRIDSE_EXAMPLES_TOYDB_SRC_BM_STORAGE_BM_CASE_H_

--- a/hybridse/examples/toydb/src/dbms/dbms_server_impl.h
+++ b/hybridse/examples/toydb/src/dbms/dbms_server_impl.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef EXAMPLES_TOYDB_SRC_DBMS_DBMS_SERVER_IMPL_H_
-#define EXAMPLES_TOYDB_SRC_DBMS_DBMS_SERVER_IMPL_H_
+#ifndef HYBRIDSE_EXAMPLES_TOYDB_SRC_DBMS_DBMS_SERVER_IMPL_H_
+#define HYBRIDSE_EXAMPLES_TOYDB_SRC_DBMS_DBMS_SERVER_IMPL_H_
 
 #include <map>
 #include <mutex>  // NOLINT (build/c++11)
@@ -78,4 +78,4 @@ class DBMSServerImpl : public DBMSServer {
 
 }  // namespace dbms
 }  // namespace hybridse
-#endif  // EXAMPLES_TOYDB_SRC_DBMS_DBMS_SERVER_IMPL_H_
+#endif  // HYBRIDSE_EXAMPLES_TOYDB_SRC_DBMS_DBMS_SERVER_IMPL_H_

--- a/hybridse/examples/toydb/src/sdk/result_set_impl.h
+++ b/hybridse/examples/toydb/src/sdk/result_set_impl.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef EXAMPLES_TOYDB_SRC_SDK_RESULT_SET_IMPL_H_
-#define EXAMPLES_TOYDB_SRC_SDK_RESULT_SET_IMPL_H_
+#ifndef HYBRIDSE_EXAMPLES_TOYDB_SRC_SDK_RESULT_SET_IMPL_H_
+#define HYBRIDSE_EXAMPLES_TOYDB_SRC_SDK_RESULT_SET_IMPL_H_
 
 #include <memory>
 #include <string>
@@ -87,4 +87,4 @@ class ResultSetImpl : public ResultSet {
 
 }  // namespace sdk
 }  // namespace hybridse
-#endif  // EXAMPLES_TOYDB_SRC_SDK_RESULT_SET_IMPL_H_
+#endif  // HYBRIDSE_EXAMPLES_TOYDB_SRC_SDK_RESULT_SET_IMPL_H_

--- a/hybridse/examples/toydb/src/storage/table_iterator.h
+++ b/hybridse/examples/toydb/src/storage/table_iterator.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef EXAMPLES_TOYDB_SRC_STORAGE_TABLE_ITERATOR_H_
-#define EXAMPLES_TOYDB_SRC_STORAGE_TABLE_ITERATOR_H_
+#ifndef HYBRIDSE_EXAMPLES_TOYDB_SRC_STORAGE_TABLE_ITERATOR_H_
+#define HYBRIDSE_EXAMPLES_TOYDB_SRC_STORAGE_TABLE_ITERATOR_H_
 
 #include <memory>
 #include <string>
@@ -155,4 +155,4 @@ class FullTableIterator : public ConstIterator<uint64_t, Row> {
 }  // namespace storage
 }  // namespace hybridse
 
-#endif  // EXAMPLES_TOYDB_SRC_STORAGE_TABLE_ITERATOR_H_
+#endif  // HYBRIDSE_EXAMPLES_TOYDB_SRC_STORAGE_TABLE_ITERATOR_H_

--- a/hybridse/examples/toydb/src/tablet/tablet_catalog.h
+++ b/hybridse/examples/toydb/src/tablet/tablet_catalog.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef EXAMPLES_TOYDB_SRC_TABLET_TABLET_CATALOG_H_
-#define EXAMPLES_TOYDB_SRC_TABLET_TABLET_CATALOG_H_
+#ifndef HYBRIDSE_EXAMPLES_TOYDB_SRC_TABLET_TABLET_CATALOG_H_
+#define HYBRIDSE_EXAMPLES_TOYDB_SRC_TABLET_TABLET_CATALOG_H_
 
 #include <map>
 #include <memory>
@@ -234,4 +234,4 @@ class TabletCatalog : public vm::Catalog {
 
 }  // namespace tablet
 }  // namespace hybridse
-#endif  // EXAMPLES_TOYDB_SRC_TABLET_TABLET_CATALOG_H_
+#endif  // HYBRIDSE_EXAMPLES_TOYDB_SRC_TABLET_TABLET_CATALOG_H_

--- a/hybridse/examples/toydb/src/tablet/tablet_internal_sdk.h
+++ b/hybridse/examples/toydb/src/tablet/tablet_internal_sdk.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef EXAMPLES_TOYDB_SRC_TABLET_TABLET_INTERNAL_SDK_H_
-#define EXAMPLES_TOYDB_SRC_TABLET_TABLET_INTERNAL_SDK_H_
+#ifndef HYBRIDSE_EXAMPLES_TOYDB_SRC_TABLET_TABLET_INTERNAL_SDK_H_
+#define HYBRIDSE_EXAMPLES_TOYDB_SRC_TABLET_TABLET_INTERNAL_SDK_H_
 
 #include <string>
 #include "brpc/channel.h"
@@ -39,4 +39,4 @@ class TabletInternalSDK {
 
 }  // namespace tablet
 }  // namespace hybridse
-#endif  // EXAMPLES_TOYDB_SRC_TABLET_TABLET_INTERNAL_SDK_H_
+#endif  // HYBRIDSE_EXAMPLES_TOYDB_SRC_TABLET_TABLET_INTERNAL_SDK_H_

--- a/hybridse/examples/toydb/src/tablet/tablet_server_impl.h
+++ b/hybridse/examples/toydb/src/tablet/tablet_server_impl.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef EXAMPLES_TOYDB_SRC_TABLET_TABLET_SERVER_IMPL_H_
-#define EXAMPLES_TOYDB_SRC_TABLET_TABLET_SERVER_IMPL_H_
+#ifndef HYBRIDSE_EXAMPLES_TOYDB_SRC_TABLET_TABLET_SERVER_IMPL_H_
+#define HYBRIDSE_EXAMPLES_TOYDB_SRC_TABLET_TABLET_SERVER_IMPL_H_
 
 #include <map>
 #include <memory>
@@ -99,4 +99,4 @@ class TabletServerImpl : public TabletServer {
 
 }  // namespace tablet
 }  // namespace hybridse
-#endif  // EXAMPLES_TOYDB_SRC_TABLET_TABLET_SERVER_IMPL_H_
+#endif  // HYBRIDSE_EXAMPLES_TOYDB_SRC_TABLET_TABLET_SERVER_IMPL_H_

--- a/hybridse/examples/toydb/src/testing/toydb_engine_test_base.h
+++ b/hybridse/examples/toydb/src/testing/toydb_engine_test_base.h
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef EXAMPLES_TOYDB_SRC_TESTING_TOYDB_ENGINE_TEST_BASE_H_
-#define EXAMPLES_TOYDB_SRC_TESTING_TOYDB_ENGINE_TEST_BASE_H_
+#ifndef HYBRIDSE_EXAMPLES_TOYDB_SRC_TESTING_TOYDB_ENGINE_TEST_BASE_H_
+#define HYBRIDSE_EXAMPLES_TOYDB_SRC_TESTING_TOYDB_ENGINE_TEST_BASE_H_
 
 #include <sqlite3.h>
 #include <map>
@@ -220,4 +220,4 @@ class ToydbBatchRequestEngineTestRunner : public BatchRequestEngineTestRunner {
 
 }  // namespace vm
 }  // namespace hybridse
-#endif  // EXAMPLES_TOYDB_SRC_TESTING_TOYDB_ENGINE_TEST_BASE_H_
+#endif  // HYBRIDSE_EXAMPLES_TOYDB_SRC_TESTING_TOYDB_ENGINE_TEST_BASE_H_

--- a/hybridse/include/base/fe_hash.h
+++ b/hybridse/include/base/fe_hash.h
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_BASE_FE_HASH_H_
-#define INCLUDE_BASE_FE_HASH_H_
+#ifndef HYBRIDSE_INCLUDE_BASE_FE_HASH_H_
+#define HYBRIDSE_INCLUDE_BASE_FE_HASH_H_
 
 #include <stdint.h>
 
@@ -102,4 +102,4 @@ __attribute__((unused)) static uint64_t MurmurHash64A(const void *key, int len,
 
 }  // namespace base
 }  // namespace hybridse
-#endif  // INCLUDE_BASE_FE_HASH_H_
+#endif  // HYBRIDSE_INCLUDE_BASE_FE_HASH_H_

--- a/hybridse/include/base/fe_object.h
+++ b/hybridse/include/base/fe_object.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_BASE_FE_OBJECT_H_
-#define INCLUDE_BASE_FE_OBJECT_H_
+#ifndef HYBRIDSE_INCLUDE_BASE_FE_OBJECT_H_
+#define HYBRIDSE_INCLUDE_BASE_FE_OBJECT_H_
 
 namespace hybridse {
 namespace base {
@@ -27,4 +27,4 @@ class FeBaseObject {
 
 }  // namespace base
 }  // namespace hybridse
-#endif  // INCLUDE_BASE_FE_OBJECT_H_
+#endif  // HYBRIDSE_INCLUDE_BASE_FE_OBJECT_H_

--- a/hybridse/include/base/fe_slice.h
+++ b/hybridse/include/base/fe_slice.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_BASE_FE_SLICE_H_
-#define INCLUDE_BASE_FE_SLICE_H_
+#ifndef HYBRIDSE_INCLUDE_BASE_FE_SLICE_H_
+#define HYBRIDSE_INCLUDE_BASE_FE_SLICE_H_
 #include <assert.h>
 #include <memory.h>
 #include <stddef.h>
@@ -166,4 +166,4 @@ class RefCountedSlice : public Slice {
 
 }  // namespace base
 }  // namespace hybridse
-#endif  // INCLUDE_BASE_FE_SLICE_H_
+#endif  // HYBRIDSE_INCLUDE_BASE_FE_SLICE_H_

--- a/hybridse/include/base/fe_status.h
+++ b/hybridse/include/base/fe_status.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_BASE_FE_STATUS_H_
-#define INCLUDE_BASE_FE_STATUS_H_
+#ifndef HYBRIDSE_INCLUDE_BASE_FE_STATUS_H_
+#define HYBRIDSE_INCLUDE_BASE_FE_STATUS_H_
 #include <string>
 #include "glog/logging.h"
 #include "proto/fe_common.pb.h"
@@ -121,4 +121,4 @@ std::ostream& operator<<(std::ostream& os, const Status& status);  // NOLINT
 
 }  // namespace base
 }  // namespace hybridse
-#endif  // INCLUDE_BASE_FE_STATUS_H_
+#endif  // HYBRIDSE_INCLUDE_BASE_FE_STATUS_H_

--- a/hybridse/include/base/iterator.h
+++ b/hybridse/include/base/iterator.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_BASE_ITERATOR_H_
-#define INCLUDE_BASE_ITERATOR_H_
+#ifndef HYBRIDSE_INCLUDE_BASE_ITERATOR_H_
+#define HYBRIDSE_INCLUDE_BASE_ITERATOR_H_
 #include <stdint.h>
 
 namespace hybridse {
@@ -96,4 +96,4 @@ class ConstIterator : public hybridse::base::AbstractIterator<K, V, const V&> {
 };
 }  // namespace base
 }  // namespace hybridse
-#endif  // INCLUDE_BASE_ITERATOR_H_
+#endif  // HYBRIDSE_INCLUDE_BASE_ITERATOR_H_

--- a/hybridse/include/base/mem_pool.h
+++ b/hybridse/include/base/mem_pool.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_BASE_MEM_POOL_H_
-#define INCLUDE_BASE_MEM_POOL_H_
+#ifndef HYBRIDSE_INCLUDE_BASE_MEM_POOL_H_
+#define HYBRIDSE_INCLUDE_BASE_MEM_POOL_H_
 #include <stddef.h>
 #include <stdint.h>
 #include <list>
@@ -99,4 +99,4 @@ class ByteMemoryPool {
 }  // namespace base
 }  // namespace hybridse
 
-#endif  // INCLUDE_BASE_MEM_POOL_H_
+#endif  // HYBRIDSE_INCLUDE_BASE_MEM_POOL_H_

--- a/hybridse/include/base/raw_buffer.h
+++ b/hybridse/include/base/raw_buffer.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_BASE_RAW_BUFFER_H_
-#define INCLUDE_BASE_RAW_BUFFER_H_
+#ifndef HYBRIDSE_INCLUDE_BASE_RAW_BUFFER_H_
+#define HYBRIDSE_INCLUDE_BASE_RAW_BUFFER_H_
 #include <assert.h>
 #include <stddef.h>
 #include <string.h>
@@ -45,4 +45,4 @@ struct RawBuffer {
 
 }  // namespace base
 }  // namespace hybridse
-#endif  // INCLUDE_BASE_RAW_BUFFER_H_
+#endif  // HYBRIDSE_INCLUDE_BASE_RAW_BUFFER_H_

--- a/hybridse/include/base/sig_trace.h
+++ b/hybridse/include/base/sig_trace.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_BASE_SIG_TRACE_H_
-#define INCLUDE_BASE_SIG_TRACE_H_
+#ifndef HYBRIDSE_INCLUDE_BASE_SIG_TRACE_H_
+#define HYBRIDSE_INCLUDE_BASE_SIG_TRACE_H_
 
 #include <dlfcn.h>
 #include <execinfo.h>
@@ -56,4 +56,4 @@ void FeSignalBacktraceHandler(int sig) {
 
 }  // namespace base
 }  // namespace hybridse
-#endif  // INCLUDE_BASE_SIG_TRACE_H_
+#endif  // HYBRIDSE_INCLUDE_BASE_SIG_TRACE_H_

--- a/hybridse/include/base/spin_lock.h
+++ b/hybridse/include/base/spin_lock.h
@@ -12,8 +12,8 @@
 //  are chosen so you can use std::unique_lock or std::lock_guard with it.
 //
 
-#ifndef INCLUDE_BASE_SPIN_LOCK_H_
-#define INCLUDE_BASE_SPIN_LOCK_H_
+#ifndef HYBRIDSE_INCLUDE_BASE_SPIN_LOCK_H_
+#define HYBRIDSE_INCLUDE_BASE_SPIN_LOCK_H_
 
 #include <atomic>
 #include <memory>
@@ -67,4 +67,4 @@ class SpinMutex {
 }  // namespace base
 }  // namespace hybridse
 
-#endif  // INCLUDE_BASE_SPIN_LOCK_H_
+#endif  // HYBRIDSE_INCLUDE_BASE_SPIN_LOCK_H_

--- a/hybridse/include/base/texttable.h
+++ b/hybridse/include/base/texttable.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_BASE_TEXTTABLE_H_
-#define INCLUDE_BASE_TEXTTABLE_H_
+#ifndef HYBRIDSE_INCLUDE_BASE_TEXTTABLE_H_
+#define HYBRIDSE_INCLUDE_BASE_TEXTTABLE_H_
 #include <iomanip>
 #include <iostream>
 #include <map>
@@ -75,4 +75,4 @@ class TextTable {
 
 }  // namespace base
 }  // namespace hybridse
-#endif  // INCLUDE_BASE_TEXTTABLE_H_
+#endif  // HYBRIDSE_INCLUDE_BASE_TEXTTABLE_H_

--- a/hybridse/include/case/sql_case.h
+++ b/hybridse/include/case/sql_case.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_CASE_SQL_CASE_H_
-#define INCLUDE_CASE_SQL_CASE_H_
+#ifndef HYBRIDSE_INCLUDE_CASE_SQL_CASE_H_
+#define HYBRIDSE_INCLUDE_CASE_SQL_CASE_H_
 #include <vm/catalog.h>
 #include <yaml-cpp/node/node.h>
 #include <yaml-cpp/yaml.h>
@@ -321,4 +321,4 @@ void InitCases(std::string yaml_path, std::vector<SqlCase>& cases, // NOLINT
                const std::vector<std::string>& filters);
 }  // namespace sqlcase
 }  // namespace hybridse
-#endif  // INCLUDE_CASE_SQL_CASE_H_
+#endif  // HYBRIDSE_INCLUDE_CASE_SQL_CASE_H_

--- a/hybridse/include/codec/fe_row_codec.h
+++ b/hybridse/include/codec/fe_row_codec.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_CODEC_FE_ROW_CODEC_H_
-#define INCLUDE_CODEC_FE_ROW_CODEC_H_
+#ifndef HYBRIDSE_INCLUDE_CODEC_FE_ROW_CODEC_H_
+#define HYBRIDSE_INCLUDE_CODEC_FE_ROW_CODEC_H_
 
 #include <map>
 #include <string>
@@ -219,4 +219,4 @@ class RowFormat {
 
 }  // namespace codec
 }  // namespace hybridse
-#endif  // INCLUDE_CODEC_FE_ROW_CODEC_H_
+#endif  // HYBRIDSE_INCLUDE_CODEC_FE_ROW_CODEC_H_

--- a/hybridse/include/codec/fe_row_selector.h
+++ b/hybridse/include/codec/fe_row_selector.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_CODEC_FE_ROW_SELECTOR_H_
-#define INCLUDE_CODEC_FE_ROW_SELECTOR_H_
+#ifndef HYBRIDSE_INCLUDE_CODEC_FE_ROW_SELECTOR_H_
+#define HYBRIDSE_INCLUDE_CODEC_FE_ROW_SELECTOR_H_
 
 #include <utility>
 #include <vector>
@@ -49,4 +49,4 @@ class RowSelector {
 
 }  // namespace codec
 }  // namespace hybridse
-#endif  // INCLUDE_CODEC_FE_ROW_SELECTOR_H_
+#endif  // HYBRIDSE_INCLUDE_CODEC_FE_ROW_SELECTOR_H_

--- a/hybridse/include/codec/fe_schema_codec.h
+++ b/hybridse/include/codec/fe_schema_codec.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_CODEC_FE_SCHEMA_CODEC_H_
-#define INCLUDE_CODEC_FE_SCHEMA_CODEC_H_
+#ifndef HYBRIDSE_INCLUDE_CODEC_FE_SCHEMA_CODEC_H_
+#define HYBRIDSE_INCLUDE_CODEC_FE_SCHEMA_CODEC_H_
 
 #include <cstring>
 #include <iostream>
@@ -122,4 +122,4 @@ class SchemaCodec {
 
 }  // namespace codec
 }  // namespace hybridse
-#endif  // INCLUDE_CODEC_FE_SCHEMA_CODEC_H_
+#endif  // HYBRIDSE_INCLUDE_CODEC_FE_SCHEMA_CODEC_H_

--- a/hybridse/include/codec/list_iterator_codec.h
+++ b/hybridse/include/codec/list_iterator_codec.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_CODEC_LIST_ITERATOR_CODEC_H_
-#define INCLUDE_CODEC_LIST_ITERATOR_CODEC_H_
+#ifndef HYBRIDSE_INCLUDE_CODEC_LIST_ITERATOR_CODEC_H_
+#define HYBRIDSE_INCLUDE_CODEC_LIST_ITERATOR_CODEC_H_
 #include <cstdint>
 #include <iostream>
 #include <memory>
@@ -489,4 +489,4 @@ class ColumnIterator : public ConstIterator<uint64_t, V> {
 }  // namespace codec
 }  // namespace hybridse
 
-#endif  // INCLUDE_CODEC_LIST_ITERATOR_CODEC_H_
+#endif  // HYBRIDSE_INCLUDE_CODEC_LIST_ITERATOR_CODEC_H_

--- a/hybridse/include/codec/row.h
+++ b/hybridse/include/codec/row.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_CODEC_ROW_H_
-#define INCLUDE_CODEC_ROW_H_
+#ifndef HYBRIDSE_INCLUDE_CODEC_ROW_H_
+#define HYBRIDSE_INCLUDE_CODEC_ROW_H_
 
 #include <cstdint>
 #include <map>
@@ -97,4 +97,4 @@ class Row {
 
 }  // namespace codec
 }  // namespace hybridse
-#endif  // INCLUDE_CODEC_ROW_H_
+#endif  // HYBRIDSE_INCLUDE_CODEC_ROW_H_

--- a/hybridse/include/codec/row_iterator.h
+++ b/hybridse/include/codec/row_iterator.h
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef INCLUDE_CODEC_ROW_ITERATOR_H_
-#define INCLUDE_CODEC_ROW_ITERATOR_H_
+#ifndef HYBRIDSE_INCLUDE_CODEC_ROW_ITERATOR_H_
+#define HYBRIDSE_INCLUDE_CODEC_ROW_ITERATOR_H_
 
 #include <memory>
 #include <string>
@@ -82,4 +82,4 @@ class WindowIterator {
 }  // namespace codec
 }  // namespace hybridse
 
-#endif  // INCLUDE_CODEC_ROW_ITERATOR_H_
+#endif  // HYBRIDSE_INCLUDE_CODEC_ROW_ITERATOR_H_

--- a/hybridse/include/codec/row_list.h
+++ b/hybridse/include/codec/row_list.h
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef INCLUDE_CODEC_ROW_LIST_H_
-#define INCLUDE_CODEC_ROW_LIST_H_
+#ifndef HYBRIDSE_INCLUDE_CODEC_ROW_LIST_H_
+#define HYBRIDSE_INCLUDE_CODEC_ROW_LIST_H_
 #include <memory>
 #include "codec/row_iterator.h"
 namespace hybridse {
@@ -64,4 +64,4 @@ class ListV {
 };
 }  // namespace codec
 }  // namespace hybridse
-#endif  // INCLUDE_CODEC_ROW_LIST_H_
+#endif  // HYBRIDSE_INCLUDE_CODEC_ROW_LIST_H_

--- a/hybridse/include/codec/type_codec.h
+++ b/hybridse/include/codec/type_codec.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_CODEC_TYPE_CODEC_H_
-#define INCLUDE_CODEC_TYPE_CODEC_H_
+#ifndef HYBRIDSE_INCLUDE_CODEC_TYPE_CODEC_H_
+#define HYBRIDSE_INCLUDE_CODEC_TYPE_CODEC_H_
 
 #include <stdint.h>
 #include <cstddef>
@@ -470,4 +470,4 @@ struct hash<hybridse::codec::StringRef> {
 
 }  // namespace std
 
-#endif  // INCLUDE_CODEC_TYPE_CODEC_H_
+#endif  // HYBRIDSE_INCLUDE_CODEC_TYPE_CODEC_H_

--- a/hybridse/include/node/batch_plan_node.h
+++ b/hybridse/include/node/batch_plan_node.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_NODE_BATCH_PLAN_NODE_H_
-#define INCLUDE_NODE_BATCH_PLAN_NODE_H_
+#ifndef HYBRIDSE_INCLUDE_NODE_BATCH_PLAN_NODE_H_
+#define HYBRIDSE_INCLUDE_NODE_BATCH_PLAN_NODE_H_
 
 #include <string>
 #include <vector>
@@ -109,4 +109,4 @@ class BatchPlanTree {
 }  // namespace node
 }  // namespace hybridse
 
-#endif  // INCLUDE_NODE_BATCH_PLAN_NODE_H_
+#endif  // HYBRIDSE_INCLUDE_NODE_BATCH_PLAN_NODE_H_

--- a/hybridse/include/node/expr_node.h
+++ b/hybridse/include/node/expr_node.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_NODE_EXPR_NODE_H_
-#define INCLUDE_NODE_EXPR_NODE_H_
+#ifndef HYBRIDSE_INCLUDE_NODE_EXPR_NODE_H_
+#define HYBRIDSE_INCLUDE_NODE_EXPR_NODE_H_
 
 #include <string>
 #include <vector>
@@ -82,4 +82,4 @@ class ExprAnalysisContext {
 
 }  // namespace node
 }  // namespace hybridse
-#endif  // INCLUDE_NODE_EXPR_NODE_H_
+#endif  // HYBRIDSE_INCLUDE_NODE_EXPR_NODE_H_

--- a/hybridse/include/node/node_base.h
+++ b/hybridse/include/node/node_base.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_NODE_NODE_BASE_H_
-#define INCLUDE_NODE_NODE_BASE_H_
+#ifndef HYBRIDSE_INCLUDE_NODE_NODE_BASE_H_
+#define HYBRIDSE_INCLUDE_NODE_NODE_BASE_H_
 
 #include <glog/logging.h>
 #include <sstream>
@@ -99,4 +99,4 @@ class NodeBase : public base::FeBaseObject {
 
 }  // namespace node
 }  // namespace hybridse
-#endif  // INCLUDE_NODE_NODE_BASE_H_
+#endif  // HYBRIDSE_INCLUDE_NODE_NODE_BASE_H_

--- a/hybridse/include/node/node_enum.h
+++ b/hybridse/include/node/node_enum.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_NODE_NODE_ENUM_H_
-#define INCLUDE_NODE_NODE_ENUM_H_
+#ifndef HYBRIDSE_INCLUDE_NODE_NODE_ENUM_H_
+#define HYBRIDSE_INCLUDE_NODE_NODE_ENUM_H_
 
 #include <string>
 #include "proto/fe_common.pb.h"
@@ -282,4 +282,4 @@ enum RoleType { kLeader, kFollower };
 }  // namespace node
 }  // namespace hybridse
 
-#endif  // INCLUDE_NODE_NODE_ENUM_H_
+#endif  // HYBRIDSE_INCLUDE_NODE_NODE_ENUM_H_

--- a/hybridse/include/node/node_manager.h
+++ b/hybridse/include/node/node_manager.h
@@ -18,8 +18,8 @@
 //     负责HybridSe的基础元件（SQLNode, PlanNode)的创建和销毁
 //     SQL的语法解析树、查询计划里面维护的只是这些节点的指针或者引用
 
-#ifndef INCLUDE_NODE_NODE_MANAGER_H_
-#define INCLUDE_NODE_NODE_MANAGER_H_
+#ifndef HYBRIDSE_INCLUDE_NODE_NODE_MANAGER_H_
+#define HYBRIDSE_INCLUDE_NODE_NODE_MANAGER_H_
 
 #include <ctype.h>
 #include <list>
@@ -383,4 +383,4 @@ class NodeManager {
 
 }  // namespace node
 }  // namespace hybridse
-#endif  // INCLUDE_NODE_NODE_MANAGER_H_
+#endif  // HYBRIDSE_INCLUDE_NODE_NODE_MANAGER_H_

--- a/hybridse/include/node/plan_node.h
+++ b/hybridse/include/node/plan_node.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_NODE_PLAN_NODE_H_
-#define INCLUDE_NODE_PLAN_NODE_H_
+#ifndef HYBRIDSE_INCLUDE_NODE_PLAN_NODE_H_
+#define HYBRIDSE_INCLUDE_NODE_PLAN_NODE_H_
 
 #include <glog/logging.h>
 #include <list>
@@ -520,4 +520,4 @@ void PrintPlanNode(std::ostream &output, const std::string &org_tab, const PlanN
 }  // namespace node
 }  // namespace hybridse
 
-#endif  // INCLUDE_NODE_PLAN_NODE_H_
+#endif  // HYBRIDSE_INCLUDE_NODE_PLAN_NODE_H_

--- a/hybridse/include/node/sql_node.h
+++ b/hybridse/include/node/sql_node.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_NODE_SQL_NODE_H_
-#define INCLUDE_NODE_SQL_NODE_H_
+#ifndef HYBRIDSE_INCLUDE_NODE_SQL_NODE_H_
+#define HYBRIDSE_INCLUDE_NODE_SQL_NODE_H_
 
 #include <glog/logging.h>
 
@@ -2466,4 +2466,4 @@ void PrintValue(std::ostream &output, const std::string &org_tab, const std::str
                 const std::string &item_name, bool last_child);
 }  // namespace node
 }  // namespace hybridse
-#endif  // INCLUDE_NODE_SQL_NODE_H_
+#endif  // HYBRIDSE_INCLUDE_NODE_SQL_NODE_H_

--- a/hybridse/include/node/type_node.h
+++ b/hybridse/include/node/type_node.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_NODE_TYPE_NODE_H_
-#define INCLUDE_NODE_TYPE_NODE_H_
+#ifndef HYBRIDSE_INCLUDE_NODE_TYPE_NODE_H_
+#define HYBRIDSE_INCLUDE_NODE_TYPE_NODE_H_
 
 #include <string>
 #include <vector>
@@ -142,4 +142,4 @@ class RowTypeNode : public TypeNode {
 
 }  // namespace node
 }  // namespace hybridse
-#endif  // INCLUDE_NODE_TYPE_NODE_H_
+#endif  // HYBRIDSE_INCLUDE_NODE_TYPE_NODE_H_

--- a/hybridse/include/passes/expression/expr_pass.h
+++ b/hybridse/include/passes/expression/expr_pass.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_PASSES_EXPRESSION_EXPR_PASS_H_
-#define INCLUDE_PASSES_EXPRESSION_EXPR_PASS_H_
+#ifndef HYBRIDSE_INCLUDE_PASSES_EXPRESSION_EXPR_PASS_H_
+#define HYBRIDSE_INCLUDE_PASSES_EXPRESSION_EXPR_PASS_H_
 
 #include <memory>
 #include <string>
@@ -84,4 +84,4 @@ class ExprReplacer {
 
 }  // namespace passes
 }  // namespace hybridse
-#endif  // INCLUDE_PASSES_EXPRESSION_EXPR_PASS_H_
+#endif  // HYBRIDSE_INCLUDE_PASSES_EXPRESSION_EXPR_PASS_H_

--- a/hybridse/include/passes/pass_base.h
+++ b/hybridse/include/passes/pass_base.h
@@ -17,8 +17,8 @@
 #include "base/fe_object.h"
 #include "base/fe_status.h"
 
-#ifndef INCLUDE_PASSES_PASS_BASE_H_
-#define INCLUDE_PASSES_PASS_BASE_H_
+#ifndef HYBRIDSE_INCLUDE_PASSES_PASS_BASE_H_
+#define HYBRIDSE_INCLUDE_PASSES_PASS_BASE_H_
 
 namespace hybridse {
 namespace passes {
@@ -34,4 +34,4 @@ class PassBase : public base::FeBaseObject {
 
 }  // namespace passes
 }  // namespace hybridse
-#endif  // INCLUDE_PASSES_PASS_BASE_H_
+#endif  // HYBRIDSE_INCLUDE_PASSES_PASS_BASE_H_

--- a/hybridse/include/plan/plan_api.h
+++ b/hybridse/include/plan/plan_api.h
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef INCLUDE_PLAN_PLAN_API_H_
-#define INCLUDE_PLAN_PLAN_API_H_
+#ifndef HYBRIDSE_INCLUDE_PLAN_PLAN_API_H_
+#define HYBRIDSE_INCLUDE_PLAN_PLAN_API_H_
 #include <string>
 #include "node/node_manager.h"
 namespace hybridse {
@@ -37,4 +37,4 @@ class PlanAPI {
 
 }  // namespace plan
 }  // namespace hybridse
-#endif  // INCLUDE_PLAN_PLAN_API_H_
+#endif  // HYBRIDSE_INCLUDE_PLAN_PLAN_API_H_

--- a/hybridse/include/sdk/base.h
+++ b/hybridse/include/sdk/base.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_SDK_BASE_H_
-#define INCLUDE_SDK_BASE_H_
+#ifndef HYBRIDSE_INCLUDE_SDK_BASE_H_
+#define HYBRIDSE_INCLUDE_SDK_BASE_H_
 
 #include <stdint.h>
 #include <memory>
@@ -143,4 +143,4 @@ class ProcedureInfo {
 
 }  // namespace sdk
 }  // namespace hybridse
-#endif  // INCLUDE_SDK_BASE_H_
+#endif  // HYBRIDSE_INCLUDE_SDK_BASE_H_

--- a/hybridse/include/sdk/base_impl.h
+++ b/hybridse/include/sdk/base_impl.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_SDK_BASE_IMPL_H_
-#define INCLUDE_SDK_BASE_IMPL_H_
+#ifndef HYBRIDSE_INCLUDE_SDK_BASE_IMPL_H_
+#define HYBRIDSE_INCLUDE_SDK_BASE_IMPL_H_
 
 #include <memory>
 #include <string>
@@ -77,4 +77,4 @@ class TableSetImpl : public TableSet {
 
 }  // namespace sdk
 }  // namespace hybridse
-#endif  // INCLUDE_SDK_BASE_IMPL_H_
+#endif  // HYBRIDSE_INCLUDE_SDK_BASE_IMPL_H_

--- a/hybridse/include/sdk/base_struct.h
+++ b/hybridse/include/sdk/base_struct.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_SDK_BASE_STRUCT_H_
-#define INCLUDE_SDK_BASE_STRUCT_H_
+#ifndef HYBRIDSE_INCLUDE_SDK_BASE_STRUCT_H_
+#define HYBRIDSE_INCLUDE_SDK_BASE_STRUCT_H_
 
 #include <stdint.h>
 #include <string.h>
@@ -277,4 +277,4 @@ inline const std::string DataTypeName(const DataType& type) {
 
 }  // namespace sdk
 }  // namespace hybridse
-#endif  // INCLUDE_SDK_BASE_STRUCT_H_
+#endif  // HYBRIDSE_INCLUDE_SDK_BASE_STRUCT_H_

--- a/hybridse/include/sdk/codec_sdk.h
+++ b/hybridse/include/sdk/codec_sdk.h
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_SDK_CODEC_SDK_H_
-#define INCLUDE_SDK_CODEC_SDK_H_
+#ifndef HYBRIDSE_INCLUDE_SDK_CODEC_SDK_H_
+#define HYBRIDSE_INCLUDE_SDK_CODEC_SDK_H_
 
 #include <vector>
 #include "butil/iobuf.h"
@@ -123,4 +123,4 @@ int32_t GetStrField(const butil::IOBuf& row, uint32_t str_field_offset,
 
 }  // namespace sdk
 }  // namespace hybridse
-#endif  // INCLUDE_SDK_CODEC_SDK_H_
+#endif  // HYBRIDSE_INCLUDE_SDK_CODEC_SDK_H_

--- a/hybridse/include/sdk/dbms_sdk.h
+++ b/hybridse/include/sdk/dbms_sdk.h
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_SDK_DBMS_SDK_H_
-#define INCLUDE_SDK_DBMS_SDK_H_
+#ifndef HYBRIDSE_INCLUDE_SDK_DBMS_SDK_H_
+#define HYBRIDSE_INCLUDE_SDK_DBMS_SDK_H_
 
 #include <memory>
 #include <string>
@@ -85,4 +85,4 @@ std::shared_ptr<DBMSSdk> CreateDBMSSdk(const std::string &endpoint);
 
 }  // namespace sdk
 }  // namespace hybridse
-#endif  // INCLUDE_SDK_DBMS_SDK_H_
+#endif  // HYBRIDSE_INCLUDE_SDK_DBMS_SDK_H_

--- a/hybridse/include/sdk/request_row.h
+++ b/hybridse/include/sdk/request_row.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_SDK_REQUEST_ROW_H_
-#define INCLUDE_SDK_REQUEST_ROW_H_
+#ifndef HYBRIDSE_INCLUDE_SDK_REQUEST_ROW_H_
+#define HYBRIDSE_INCLUDE_SDK_REQUEST_ROW_H_
 
 #include <string>
 #include <vector>
@@ -61,4 +61,4 @@ class RequestRow {
 
 }  // namespace sdk
 }  // namespace hybridse
-#endif  // INCLUDE_SDK_REQUEST_ROW_H_
+#endif  // HYBRIDSE_INCLUDE_SDK_REQUEST_ROW_H_

--- a/hybridse/include/sdk/result_set.h
+++ b/hybridse/include/sdk/result_set.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_SDK_RESULT_SET_H_
-#define INCLUDE_SDK_RESULT_SET_H_
+#ifndef HYBRIDSE_INCLUDE_SDK_RESULT_SET_H_
+#define HYBRIDSE_INCLUDE_SDK_RESULT_SET_H_
 
 #include <stdint.h>
 #include <string>
@@ -220,4 +220,4 @@ class ResultSet {
 
 }  // namespace sdk
 }  // namespace hybridse
-#endif  // INCLUDE_SDK_RESULT_SET_H_
+#endif  // HYBRIDSE_INCLUDE_SDK_RESULT_SET_H_

--- a/hybridse/include/sdk/tablet_sdk.h
+++ b/hybridse/include/sdk/tablet_sdk.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_SDK_TABLET_SDK_H_
-#define INCLUDE_SDK_TABLET_SDK_H_
+#ifndef HYBRIDSE_INCLUDE_SDK_TABLET_SDK_H_
+#define HYBRIDSE_INCLUDE_SDK_TABLET_SDK_H_
 
 #include <memory>
 #include <string>
@@ -63,4 +63,4 @@ std::shared_ptr<TabletSdk> CreateTabletSdk(const std::string& endpoint);
 
 }  // namespace sdk
 }  // namespace hybridse
-#endif  // INCLUDE_SDK_TABLET_SDK_H_
+#endif  // HYBRIDSE_INCLUDE_SDK_TABLET_SDK_H_

--- a/hybridse/include/vm/catalog.h
+++ b/hybridse/include/vm/catalog.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_VM_CATALOG_H_
-#define INCLUDE_VM_CATALOG_H_
+#ifndef HYBRIDSE_INCLUDE_VM_CATALOG_H_
+#define HYBRIDSE_INCLUDE_VM_CATALOG_H_
 #include <map>
 #include <memory>
 #include <set>
@@ -495,4 +495,4 @@ class Catalog {
 }  // namespace vm
 }  // namespace hybridse
 
-#endif  // INCLUDE_VM_CATALOG_H_
+#endif  // HYBRIDSE_INCLUDE_VM_CATALOG_H_

--- a/hybridse/include/vm/engine.h
+++ b/hybridse/include/vm/engine.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_VM_ENGINE_H_
-#define INCLUDE_VM_ENGINE_H_
+#ifndef HYBRIDSE_INCLUDE_VM_ENGINE_H_
+#define HYBRIDSE_INCLUDE_VM_ENGINE_H_
 
 #include <map>
 #include <memory>
@@ -450,4 +450,4 @@ class LocalTablet : public Tablet {
 
 }  // namespace vm
 }  // namespace hybridse
-#endif  // INCLUDE_VM_ENGINE_H_
+#endif  // HYBRIDSE_INCLUDE_VM_ENGINE_H_

--- a/hybridse/include/vm/engine_context.h
+++ b/hybridse/include/vm/engine_context.h
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef INCLUDE_VM_ENGINE_CONTEXT_H_
-#define INCLUDE_VM_ENGINE_CONTEXT_H_
+#ifndef HYBRIDSE_INCLUDE_VM_ENGINE_CONTEXT_H_
+#define HYBRIDSE_INCLUDE_VM_ENGINE_CONTEXT_H_
 #include <map>
 #include <memory>
 #include <set>
@@ -102,4 +102,4 @@ class JitOptions {
 };
 }  // namespace vm
 }  // namespace hybridse
-#endif  // INCLUDE_VM_ENGINE_CONTEXT_H_
+#endif  // HYBRIDSE_INCLUDE_VM_ENGINE_CONTEXT_H_

--- a/hybridse/include/vm/mem_catalog.h
+++ b/hybridse/include/vm/mem_catalog.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_VM_MEM_CATALOG_H_
-#define INCLUDE_VM_MEM_CATALOG_H_
+#ifndef HYBRIDSE_INCLUDE_VM_MEM_CATALOG_H_
+#define HYBRIDSE_INCLUDE_VM_MEM_CATALOG_H_
 
 #include <deque>
 #include <functional>
@@ -774,4 +774,4 @@ int8_t* RowGetSlice(int8_t* row_ptr, size_t idx);
 size_t RowGetSliceSize(int8_t* row_ptr, size_t idx);
 }  // namespace vm
 }  // namespace hybridse
-#endif  // INCLUDE_VM_MEM_CATALOG_H_
+#endif  // HYBRIDSE_INCLUDE_VM_MEM_CATALOG_H_

--- a/hybridse/include/vm/physical_op.h
+++ b/hybridse/include/vm/physical_op.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_VM_PHYSICAL_OP_H_
-#define INCLUDE_VM_PHYSICAL_OP_H_
+#ifndef HYBRIDSE_INCLUDE_VM_PHYSICAL_OP_H_
+#define HYBRIDSE_INCLUDE_VM_PHYSICAL_OP_H_
 #include <list>
 #include <memory>
 #include <set>
@@ -1627,4 +1627,4 @@ static Status ReplaceComponentExpr(const Component &component,
 
 }  // namespace vm
 }  // namespace hybridse
-#endif  // INCLUDE_VM_PHYSICAL_OP_H_
+#endif  // HYBRIDSE_INCLUDE_VM_PHYSICAL_OP_H_

--- a/hybridse/include/vm/router.h
+++ b/hybridse/include/vm/router.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_VM_ROUTER_H_
-#define INCLUDE_VM_ROUTER_H_
+#ifndef HYBRIDSE_INCLUDE_VM_ROUTER_H_
+#define HYBRIDSE_INCLUDE_VM_ROUTER_H_
 
 #include <string>
 #include "vm/physical_op.h"
@@ -45,4 +45,4 @@ class Router {
 
 }  // namespace vm
 }  // namespace hybridse
-#endif  // INCLUDE_VM_ROUTER_H_
+#endif  // HYBRIDSE_INCLUDE_VM_ROUTER_H_

--- a/hybridse/include/vm/schemas_context.h
+++ b/hybridse/include/vm/schemas_context.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_VM_SCHEMAS_CONTEXT_H_
-#define INCLUDE_VM_SCHEMAS_CONTEXT_H_
+#ifndef HYBRIDSE_INCLUDE_VM_SCHEMAS_CONTEXT_H_
+#define HYBRIDSE_INCLUDE_VM_SCHEMAS_CONTEXT_H_
 #include <map>
 #include <set>
 #include <string>
@@ -247,4 +247,4 @@ class SchemasContext {
 }  // namespace vm
 }  // namespace hybridse
 
-#endif  // INCLUDE_VM_SCHEMAS_CONTEXT_H_
+#endif  // HYBRIDSE_INCLUDE_VM_SCHEMAS_CONTEXT_H_

--- a/hybridse/src/base/fe_linenoise.h
+++ b/hybridse/src/base/fe_linenoise.h
@@ -36,8 +36,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SRC_BASE_FE_LINENOISE_H_
-#define SRC_BASE_FE_LINENOISE_H_
+#ifndef HYBRIDSE_SRC_BASE_FE_LINENOISE_H_
+#define HYBRIDSE_SRC_BASE_FE_LINENOISE_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -77,4 +77,4 @@ void linenoisePrintKeyCodes(void);
 }
 #endif
 
-#endif  // SRC_BASE_FE_LINENOISE_H_
+#endif  // HYBRIDSE_SRC_BASE_FE_LINENOISE_H_

--- a/hybridse/src/base/graph.h
+++ b/hybridse/src/base/graph.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_BASE_GRAPH_H_
-#define SRC_BASE_GRAPH_H_
+#ifndef HYBRIDSE_SRC_BASE_GRAPH_H_
+#define HYBRIDSE_SRC_BASE_GRAPH_H_
 #include <iostream>
 #include <unordered_map>
 #include <utility>
@@ -141,4 +141,4 @@ int Graph<V, H, E>::VertexSize() {
 }  // namespace base
 }  // namespace hybridse
 
-#endif  // SRC_BASE_GRAPH_H_
+#endif  // HYBRIDSE_SRC_BASE_GRAPH_H_

--- a/hybridse/src/base/parquet_util.h
+++ b/hybridse/src/base/parquet_util.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_BASE_PARQUET_UTIL_H_
-#define SRC_BASE_PARQUET_UTIL_H_
+#ifndef HYBRIDSE_SRC_BASE_PARQUET_UTIL_H_
+#define HYBRIDSE_SRC_BASE_PARQUET_UTIL_H_
 
 #include "glog/logging.h"
 #include "parquet/schema.h"
@@ -116,4 +116,4 @@ inline bool MapParquetType(const parquet::ColumnDescriptor* column_desc,
 
 }  // namespace base
 }  // namespace hybridse
-#endif  // SRC_BASE_PARQUET_UTIL_H_
+#endif  // HYBRIDSE_SRC_BASE_PARQUET_UTIL_H_

--- a/hybridse/src/benchmark/udf_bm_case.h
+++ b/hybridse/src/benchmark/udf_bm_case.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_BENCHMARK_UDF_BM_CASE_H_
-#define SRC_BENCHMARK_UDF_BM_CASE_H_
+#ifndef HYBRIDSE_SRC_BENCHMARK_UDF_BM_CASE_H_
+#define HYBRIDSE_SRC_BENCHMARK_UDF_BM_CASE_H_
 #include <string>
 #include "benchmark/benchmark.h"
 #include "vm/mem_catalog.h"
@@ -55,4 +55,4 @@ void RequestUnionWindowExcludeCurrentTime(benchmark::State* state, MODE mode,
                                           int64_t data_size);
 }  // namespace bm
 }  // namespace hybridse
-#endif  // SRC_BENCHMARK_UDF_BM_CASE_H_
+#endif  // HYBRIDSE_SRC_BENCHMARK_UDF_BM_CASE_H_

--- a/hybridse/src/case/case_data_mock.h
+++ b/hybridse/src/case/case_data_mock.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CASE_CASE_DATA_MOCK_H_
-#define SRC_CASE_CASE_DATA_MOCK_H_
+#ifndef HYBRIDSE_SRC_CASE_CASE_DATA_MOCK_H_
+#define HYBRIDSE_SRC_CASE_CASE_DATA_MOCK_H_
 
 #include <memory>
 #include <random>
@@ -103,4 +103,4 @@ class CaseSchemaMock {
 }  // namespace sqlcase
 }  // namespace hybridse
 
-#endif  // SRC_CASE_CASE_DATA_MOCK_H_
+#endif  // HYBRIDSE_SRC_CASE_CASE_DATA_MOCK_H_

--- a/hybridse/src/cmd/version.h.in
+++ b/hybridse/src/cmd/version.h.in
@@ -14,14 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef HYBRIDSE_FE_VERSION_H_
-#define HYBRIDSE_FE_VERSION_H_
+#ifndef HYBRIDSE_HYBRIDSE_FE_VERSION_H_
+#define HYBRIDSE_HYBRIDSE_FE_VERSION_H_
 
 #define HYBRIDSE_VERSION_MAJOR @HYBRIDSE_VERSION_MAJOR@
 #define HYBRIDSE_VERSION_MEDIUM @HYBRIDSE_VERSION_MEDIUM@
 #define HYBRIDSE_VERSION_MINOR @HYBRIDSE_VERSION_MINOR@
 #define HYBRIDSE_VERSION_BUG @HYBRIDSE_VERSION_BUG@
 
-#endif  // HYBRIDSE_FE_VERSION_H_ 
+#endif  // HYBRIDSE_HYBRIDSE_FE_VERSION_H_ 
 
 /* vim: set expandtab ts=4 sw=4 sts=4 tw=100: */

--- a/hybridse/src/codegen/aggregate_ir_builder.h
+++ b/hybridse/src/codegen/aggregate_ir_builder.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_AGGREGATE_IR_BUILDER_H_
-#define SRC_CODEGEN_AGGREGATE_IR_BUILDER_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_AGGREGATE_IR_BUILDER_H_
+#define HYBRIDSE_SRC_CODEGEN_AGGREGATE_IR_BUILDER_H_
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -114,4 +114,4 @@ class AggregateIRBuilder {
 
 }  // namespace codegen
 }  // namespace hybridse
-#endif  // SRC_CODEGEN_AGGREGATE_IR_BUILDER_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_AGGREGATE_IR_BUILDER_H_

--- a/hybridse/src/codegen/arithmetic_expr_ir_builder.h
+++ b/hybridse/src/codegen/arithmetic_expr_ir_builder.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_ARITHMETIC_EXPR_IR_BUILDER_H_
-#define SRC_CODEGEN_ARITHMETIC_EXPR_IR_BUILDER_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_ARITHMETIC_EXPR_IR_BUILDER_H_
+#define HYBRIDSE_SRC_CODEGEN_ARITHMETIC_EXPR_IR_BUILDER_H_
 
 #include "base/fe_status.h"
 #include "codegen/cast_expr_ir_builder.h"
@@ -115,4 +115,4 @@ class ArithmeticIRBuilder {
 };
 }  // namespace codegen
 }  // namespace hybridse
-#endif  // SRC_CODEGEN_ARITHMETIC_EXPR_IR_BUILDER_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_ARITHMETIC_EXPR_IR_BUILDER_H_

--- a/hybridse/src/codegen/block_ir_builder.h
+++ b/hybridse/src/codegen/block_ir_builder.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_BLOCK_IR_BUILDER_H_
-#define SRC_CODEGEN_BLOCK_IR_BUILDER_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_BLOCK_IR_BUILDER_H_
+#define HYBRIDSE_SRC_CODEGEN_BLOCK_IR_BUILDER_H_
 
 #include <vector>
 #include "base/fe_status.h"
@@ -61,4 +61,4 @@ class BlockIRBuilder {
 
 }  // namespace codegen
 }  // namespace hybridse
-#endif  // SRC_CODEGEN_BLOCK_IR_BUILDER_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_BLOCK_IR_BUILDER_H_

--- a/hybridse/src/codegen/buf_ir_builder.h
+++ b/hybridse/src/codegen/buf_ir_builder.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_BUF_IR_BUILDER_H_
-#define SRC_CODEGEN_BUF_IR_BUILDER_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_BUF_IR_BUILDER_H_
+#define HYBRIDSE_SRC_CODEGEN_BUF_IR_BUILDER_H_
 
 #include <map>
 #include <string>
@@ -100,4 +100,4 @@ class BufNativeIRBuilder : public RowDecodeIRBuilder {
 
 }  // namespace codegen
 }  // namespace hybridse
-#endif  // SRC_CODEGEN_BUF_IR_BUILDER_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_BUF_IR_BUILDER_H_

--- a/hybridse/src/codegen/cast_expr_ir_builder.h
+++ b/hybridse/src/codegen/cast_expr_ir_builder.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_CAST_EXPR_IR_BUILDER_H_
-#define SRC_CODEGEN_CAST_EXPR_IR_BUILDER_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_CAST_EXPR_IR_BUILDER_H_
+#define HYBRIDSE_SRC_CODEGEN_CAST_EXPR_IR_BUILDER_H_
 #include "base/fe_status.h"
 #include "codegen/cond_select_ir_builder.h"
 #include "codegen/scope_var.h"
@@ -60,4 +60,4 @@ class CastExprIRBuilder {
 };
 }  // namespace codegen
 }  // namespace hybridse
-#endif  // SRC_CODEGEN_CAST_EXPR_IR_BUILDER_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_CAST_EXPR_IR_BUILDER_H_

--- a/hybridse/src/codegen/codegen_base_test.h
+++ b/hybridse/src/codegen/codegen_base_test.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_CODEGEN_BASE_TEST_H_
-#define SRC_CODEGEN_CODEGEN_BASE_TEST_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_CODEGEN_BASE_TEST_H_
+#define HYBRIDSE_SRC_CODEGEN_CODEGEN_BASE_TEST_H_
 
 #include <cstdint>
 #include <string>
@@ -107,4 +107,4 @@ bool BuildT2Buf(type::TableDef& table_def, int8_t** buf,  // NOLINT
 }  // namespace codegen
 }  // namespace hybridse
 
-#endif  // SRC_CODEGEN_CODEGEN_BASE_TEST_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_CODEGEN_BASE_TEST_H_

--- a/hybridse/src/codegen/cond_select_ir_builder.h
+++ b/hybridse/src/codegen/cond_select_ir_builder.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_COND_SELECT_IR_BUILDER_H_
-#define SRC_CODEGEN_COND_SELECT_IR_BUILDER_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_COND_SELECT_IR_BUILDER_H_
+#define HYBRIDSE_SRC_CODEGEN_COND_SELECT_IR_BUILDER_H_
 #include "base/fe_status.h"
 #include "codegen/native_value.h"
 namespace hybridse {
@@ -31,4 +31,4 @@ class CondSelectIRBuilder {
 }  // namespace codegen
 }  // namespace hybridse
 
-#endif  // SRC_CODEGEN_COND_SELECT_IR_BUILDER_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_COND_SELECT_IR_BUILDER_H_

--- a/hybridse/src/codegen/context.h
+++ b/hybridse/src/codegen/context.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_CONTEXT_H_
-#define SRC_CODEGEN_CONTEXT_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_CONTEXT_H_
+#define HYBRIDSE_SRC_CODEGEN_CONTEXT_H_
 
 #include <string>
 #include <unordered_map>
@@ -181,4 +181,4 @@ class CodeGenContext {
 
 }  // namespace codegen
 }  // namespace hybridse
-#endif  // SRC_CODEGEN_CONTEXT_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_CONTEXT_H_

--- a/hybridse/src/codegen/date_ir_builder.h
+++ b/hybridse/src/codegen/date_ir_builder.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_DATE_IR_BUILDER_H_
-#define SRC_CODEGEN_DATE_IR_BUILDER_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_DATE_IR_BUILDER_H_
+#define HYBRIDSE_SRC_CODEGEN_DATE_IR_BUILDER_H_
 #include "base/fe_status.h"
 #include "codegen/cast_expr_ir_builder.h"
 #include "codegen/null_ir_builder.h"
@@ -55,4 +55,4 @@ class DateIRBuilder : public StructTypeIRBuilder {
 };
 }  // namespace codegen
 }  // namespace hybridse
-#endif  // SRC_CODEGEN_DATE_IR_BUILDER_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_DATE_IR_BUILDER_H_

--- a/hybridse/src/codegen/expr_ir_builder.h
+++ b/hybridse/src/codegen/expr_ir_builder.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_EXPR_IR_BUILDER_H_
-#define SRC_CODEGEN_EXPR_IR_BUILDER_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_EXPR_IR_BUILDER_H_
+#define HYBRIDSE_SRC_CODEGEN_EXPR_IR_BUILDER_H_
 
 #include <map>
 #include <memory>
@@ -113,4 +113,4 @@ class ExprIRBuilder {
 };
 }  // namespace codegen
 }  // namespace hybridse
-#endif  // SRC_CODEGEN_EXPR_IR_BUILDER_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_EXPR_IR_BUILDER_H_

--- a/hybridse/src/codegen/fn_ir_builder.h
+++ b/hybridse/src/codegen/fn_ir_builder.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_FN_IR_BUILDER_H_
-#define SRC_CODEGEN_FN_IR_BUILDER_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_FN_IR_BUILDER_H_
+#define HYBRIDSE_SRC_CODEGEN_FN_IR_BUILDER_H_
 
 #include <vector>
 #include "base/fe_status.h"
@@ -55,4 +55,4 @@ class FnIRBuilder {
 
 }  // namespace codegen
 }  // namespace hybridse
-#endif  // SRC_CODEGEN_FN_IR_BUILDER_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_FN_IR_BUILDER_H_

--- a/hybridse/src/codegen/fn_let_ir_builder.h
+++ b/hybridse/src/codegen/fn_let_ir_builder.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_FN_LET_IR_BUILDER_H_
-#define SRC_CODEGEN_FN_LET_IR_BUILDER_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_FN_LET_IR_BUILDER_H_
+#define HYBRIDSE_SRC_CODEGEN_FN_LET_IR_BUILDER_H_
 #include <map>
 #include <string>
 #include <utility>
@@ -73,4 +73,4 @@ class RowFnLetIRBuilder {
 
 }  // namespace codegen
 }  // namespace hybridse
-#endif  // SRC_CODEGEN_FN_LET_IR_BUILDER_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_FN_LET_IR_BUILDER_H_

--- a/hybridse/src/codegen/fn_let_ir_builder_test.h
+++ b/hybridse/src/codegen/fn_let_ir_builder_test.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_FN_LET_IR_BUILDER_TEST_H_
-#define SRC_CODEGEN_FN_LET_IR_BUILDER_TEST_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_FN_LET_IR_BUILDER_TEST_H_
+#define HYBRIDSE_SRC_CODEGEN_FN_LET_IR_BUILDER_TEST_H_
 
 #include <memory>
 #include <string>
@@ -186,4 +186,4 @@ void CheckFnLetBuilder(::hybridse::node::NodeManager* manager, type::TableDef& t
 }  // namespace codegen
 }  // namespace hybridse
 
-#endif  // SRC_CODEGEN_FN_LET_IR_BUILDER_TEST_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_FN_LET_IR_BUILDER_TEST_H_

--- a/hybridse/src/codegen/ir_base_builder.h
+++ b/hybridse/src/codegen/ir_base_builder.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_IR_BASE_BUILDER_H_
-#define SRC_CODEGEN_IR_BASE_BUILDER_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_IR_BASE_BUILDER_H_
+#define HYBRIDSE_SRC_CODEGEN_IR_BASE_BUILDER_H_
 
 #include <string>
 #include <vector>
@@ -107,4 +107,4 @@ llvm::Value* CreateAllocaAtHead(llvm::IRBuilder<>* builder, llvm::Type* dtype,
 
 }  // namespace codegen
 }  // namespace hybridse
-#endif  // SRC_CODEGEN_IR_BASE_BUILDER_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_IR_BASE_BUILDER_H_

--- a/hybridse/src/codegen/ir_base_builder_test.h
+++ b/hybridse/src/codegen/ir_base_builder_test.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_IR_BASE_BUILDER_TEST_H_
-#define SRC_CODEGEN_IR_BASE_BUILDER_TEST_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_IR_BASE_BUILDER_TEST_H_
+#define HYBRIDSE_SRC_CODEGEN_IR_BASE_BUILDER_TEST_H_
 
 #include <memory>
 #include <string>
@@ -655,4 +655,4 @@ ModuleTestFunction<Ret, Args...> BuildExprFunction(
 
 }  // namespace codegen
 }  // namespace hybridse
-#endif  // SRC_CODEGEN_IR_BASE_BUILDER_TEST_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_IR_BASE_BUILDER_TEST_H_

--- a/hybridse/src/codegen/list_ir_builder.h
+++ b/hybridse/src/codegen/list_ir_builder.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_LIST_IR_BUILDER_H_
-#define SRC_CODEGEN_LIST_IR_BUILDER_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_LIST_IR_BUILDER_H_
+#define HYBRIDSE_SRC_CODEGEN_LIST_IR_BUILDER_H_
 
 #include <string>
 #include "base/fe_status.h"
@@ -56,4 +56,4 @@ class ListIRBuilder {
 
 }  // namespace codegen
 }  // namespace hybridse
-#endif  // SRC_CODEGEN_LIST_IR_BUILDER_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_LIST_IR_BUILDER_H_

--- a/hybridse/src/codegen/memery_ir_builder.h
+++ b/hybridse/src/codegen/memery_ir_builder.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_MEMERY_IR_BUILDER_H_
-#define SRC_CODEGEN_MEMERY_IR_BUILDER_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_MEMERY_IR_BUILDER_H_
+#define HYBRIDSE_SRC_CODEGEN_MEMERY_IR_BUILDER_H_
 #include <string>
 #include "base/fe_status.h"
 #include "codegen/scope_var.h"
@@ -44,4 +44,4 @@ class MemoryIRBuilder {
 
 }  // namespace codegen
 }  // namespace hybridse
-#endif  // SRC_CODEGEN_MEMERY_IR_BUILDER_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_MEMERY_IR_BUILDER_H_

--- a/hybridse/src/codegen/native_value.h
+++ b/hybridse/src/codegen/native_value.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_NATIVE_VALUE_H_
-#define SRC_CODEGEN_NATIVE_VALUE_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_NATIVE_VALUE_H_
+#define HYBRIDSE_SRC_CODEGEN_NATIVE_VALUE_H_
 
 #include <string>
 #include <vector>
@@ -97,4 +97,4 @@ class NativeValue {
 
 }  // namespace codegen
 }  // namespace hybridse
-#endif  // SRC_CODEGEN_NATIVE_VALUE_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_NATIVE_VALUE_H_

--- a/hybridse/src/codegen/null_ir_builder.h
+++ b/hybridse/src/codegen/null_ir_builder.h
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_NULL_IR_BUILDER_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_NULL_IR_BUILDER_H_
 
-#define SRC_CODEGEN_NULL_IR_BUILDER_H_
+#define HYBRIDSE_SRC_CODEGEN_NULL_IR_BUILDER_H_
 #include "base/fe_status.h"
 #include "codegen/native_value.h"
 namespace hybridse {
@@ -52,4 +52,4 @@ class NullIRBuilder {
 };
 }  // namespace codegen
 }  // namespace hybridse
-#endif  // SRC_CODEGEN_NULL_IR_BUILDER_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_NULL_IR_BUILDER_H_

--- a/hybridse/src/codegen/predicate_expr_ir_builder.h
+++ b/hybridse/src/codegen/predicate_expr_ir_builder.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_PREDICATE_EXPR_IR_BUILDER_H_
-#define SRC_CODEGEN_PREDICATE_EXPR_IR_BUILDER_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_PREDICATE_EXPR_IR_BUILDER_H_
+#define HYBRIDSE_SRC_CODEGEN_PREDICATE_EXPR_IR_BUILDER_H_
 
 #include "base/fe_status.h"
 #include "codegen/cast_expr_ir_builder.h"
@@ -97,4 +97,4 @@ class PredicateIRBuilder {
 };
 }  // namespace codegen
 }  // namespace hybridse
-#endif  // SRC_CODEGEN_PREDICATE_EXPR_IR_BUILDER_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_PREDICATE_EXPR_IR_BUILDER_H_

--- a/hybridse/src/codegen/row_ir_builder.h
+++ b/hybridse/src/codegen/row_ir_builder.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_ROW_IR_BUILDER_H_
-#define SRC_CODEGEN_ROW_IR_BUILDER_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_ROW_IR_BUILDER_H_
+#define HYBRIDSE_SRC_CODEGEN_ROW_IR_BUILDER_H_
 
 #include <string>
 #include "codegen/native_value.h"
@@ -57,4 +57,4 @@ class RowEncodeIRBuilder {
 
 }  // namespace codegen
 }  // namespace hybridse
-#endif  // SRC_CODEGEN_ROW_IR_BUILDER_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_ROW_IR_BUILDER_H_

--- a/hybridse/src/codegen/scope_var.h
+++ b/hybridse/src/codegen/scope_var.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_SCOPE_VAR_H_
-#define SRC_CODEGEN_SCOPE_VAR_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_SCOPE_VAR_H_
+#define HYBRIDSE_SRC_CODEGEN_SCOPE_VAR_H_
 
 #include <map>
 #include <string>
@@ -54,4 +54,4 @@ class ScopeVar {
 
 }  // namespace codegen
 }  // namespace hybridse
-#endif  // SRC_CODEGEN_SCOPE_VAR_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_SCOPE_VAR_H_

--- a/hybridse/src/codegen/string_ir_builder.h
+++ b/hybridse/src/codegen/string_ir_builder.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_STRING_IR_BUILDER_H_
-#define SRC_CODEGEN_STRING_IR_BUILDER_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_STRING_IR_BUILDER_H_
+#define HYBRIDSE_SRC_CODEGEN_STRING_IR_BUILDER_H_
 #include <string>
 #include <vector>
 #include "base/fe_status.h"
@@ -68,4 +68,4 @@ class StringIRBuilder : public StructTypeIRBuilder {
 };
 }  // namespace codegen
 }  // namespace hybridse
-#endif  // SRC_CODEGEN_STRING_IR_BUILDER_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_STRING_IR_BUILDER_H_

--- a/hybridse/src/codegen/struct_ir_builder.h
+++ b/hybridse/src/codegen/struct_ir_builder.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_STRUCT_IR_BUILDER_H_
-#define SRC_CODEGEN_STRUCT_IR_BUILDER_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_STRUCT_IR_BUILDER_H_
+#define HYBRIDSE_SRC_CODEGEN_STRUCT_IR_BUILDER_H_
 #include "base/fe_status.h"
 #include "codegen/cast_expr_ir_builder.h"
 #include "codegen/scope_var.h"
@@ -56,4 +56,4 @@ class StructTypeIRBuilder : public TypeIRBuilder {
 };
 }  // namespace codegen
 }  // namespace hybridse
-#endif  // SRC_CODEGEN_STRUCT_IR_BUILDER_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_STRUCT_IR_BUILDER_H_

--- a/hybridse/src/codegen/timestamp_ir_builder.h
+++ b/hybridse/src/codegen/timestamp_ir_builder.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_TIMESTAMP_IR_BUILDER_H_
-#define SRC_CODEGEN_TIMESTAMP_IR_BUILDER_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_TIMESTAMP_IR_BUILDER_H_
+#define HYBRIDSE_SRC_CODEGEN_TIMESTAMP_IR_BUILDER_H_
 #include "base/fe_status.h"
 #include "codegen/cast_expr_ir_builder.h"
 #include "codegen/scope_var.h"
@@ -59,4 +59,4 @@ class TimestampIRBuilder : public StructTypeIRBuilder {
 };
 }  // namespace codegen
 }  // namespace hybridse
-#endif  // SRC_CODEGEN_TIMESTAMP_IR_BUILDER_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_TIMESTAMP_IR_BUILDER_H_

--- a/hybridse/src/codegen/type_ir_builder.h
+++ b/hybridse/src/codegen/type_ir_builder.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_TYPE_IR_BUILDER_H_
-#define SRC_CODEGEN_TYPE_IR_BUILDER_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_TYPE_IR_BUILDER_H_
+#define HYBRIDSE_SRC_CODEGEN_TYPE_IR_BUILDER_H_
 
 #include <string>
 #include <vector>
@@ -158,4 +158,4 @@ inline const bool ConvertHybridSeType2LlvmType(const node::TypeNode* data_type,
 
 }  // namespace codegen
 }  // namespace hybridse
-#endif  // SRC_CODEGEN_TYPE_IR_BUILDER_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_TYPE_IR_BUILDER_H_

--- a/hybridse/src/codegen/udf_ir_builder.h
+++ b/hybridse/src/codegen/udf_ir_builder.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_UDF_IR_BUILDER_H_
-#define SRC_CODEGEN_UDF_IR_BUILDER_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_UDF_IR_BUILDER_H_
+#define HYBRIDSE_SRC_CODEGEN_UDF_IR_BUILDER_H_
 
 #include <map>
 #include <string>
@@ -107,4 +107,4 @@ class UdfIRBuilder {
 
 }  // namespace codegen
 }  // namespace hybridse
-#endif  // SRC_CODEGEN_UDF_IR_BUILDER_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_UDF_IR_BUILDER_H_

--- a/hybridse/src/codegen/variable_ir_builder.h
+++ b/hybridse/src/codegen/variable_ir_builder.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_VARIABLE_IR_BUILDER_H_
-#define SRC_CODEGEN_VARIABLE_IR_BUILDER_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_VARIABLE_IR_BUILDER_H_
+#define HYBRIDSE_SRC_CODEGEN_VARIABLE_IR_BUILDER_H_
 
 #include <string>
 #include "base/fe_status.h"
@@ -78,4 +78,4 @@ class VariableIRBuilder {
 };
 }  // namespace codegen
 }  // namespace hybridse
-#endif  // SRC_CODEGEN_VARIABLE_IR_BUILDER_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_VARIABLE_IR_BUILDER_H_

--- a/hybridse/src/codegen/window_ir_builder.h
+++ b/hybridse/src/codegen/window_ir_builder.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_CODEGEN_WINDOW_IR_BUILDER_H_
-#define SRC_CODEGEN_WINDOW_IR_BUILDER_H_
+#ifndef HYBRIDSE_SRC_CODEGEN_WINDOW_IR_BUILDER_H_
+#define HYBRIDSE_SRC_CODEGEN_WINDOW_IR_BUILDER_H_
 
 #include <map>
 #include <string>
@@ -80,4 +80,4 @@ class MemoryWindowDecodeIRBuilder : public WindowDecodeIRBuilder {
 
 }  // namespace codegen
 }  // namespace hybridse
-#endif  // SRC_CODEGEN_WINDOW_IR_BUILDER_H_
+#endif  // HYBRIDSE_SRC_CODEGEN_WINDOW_IR_BUILDER_H_

--- a/hybridse/src/llvm_ext/symbol_resolve.h
+++ b/hybridse/src/llvm_ext/symbol_resolve.h
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef SRC_LLVM_EXT_SYMBOL_RESOLVE_H_
-#define SRC_LLVM_EXT_SYMBOL_RESOLVE_H_
+#ifndef HYBRIDSE_SRC_LLVM_EXT_SYMBOL_RESOLVE_H_
+#define HYBRIDSE_SRC_LLVM_EXT_SYMBOL_RESOLVE_H_
 
 #include <map>
 #include <string>
@@ -56,4 +56,4 @@ class HybridSeSymbolResolver : public ::llvm::LegacyJITSymbolResolver {
 }  // namespace vm
 }  // namespace hybridse
 
-#endif  // SRC_LLVM_EXT_SYMBOL_RESOLVE_H_
+#endif  // HYBRIDSE_SRC_LLVM_EXT_SYMBOL_RESOLVE_H_

--- a/hybridse/src/passes/expression/default_passes.h
+++ b/hybridse/src/passes/expression/default_passes.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_PASSES_EXPRESSION_DEFAULT_PASSES_H_
-#define SRC_PASSES_EXPRESSION_DEFAULT_PASSES_H_
+#ifndef HYBRIDSE_SRC_PASSES_EXPRESSION_DEFAULT_PASSES_H_
+#define HYBRIDSE_SRC_PASSES_EXPRESSION_DEFAULT_PASSES_H_
 
 #include <memory>
 
@@ -35,4 +35,4 @@ void AddDefaultExprOptPasses(node::ExprAnalysisContext* ctx,
 
 }  // namespace passes
 }  // namespace hybridse
-#endif  // SRC_PASSES_EXPRESSION_DEFAULT_PASSES_H_
+#endif  // HYBRIDSE_SRC_PASSES_EXPRESSION_DEFAULT_PASSES_H_

--- a/hybridse/src/passes/expression/expr_pass_test.h
+++ b/hybridse/src/passes/expression/expr_pass_test.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_PASSES_EXPRESSION_EXPR_PASS_TEST_H_
-#define SRC_PASSES_EXPRESSION_EXPR_PASS_TEST_H_
+#ifndef HYBRIDSE_SRC_PASSES_EXPRESSION_EXPR_PASS_TEST_H_
+#define HYBRIDSE_SRC_PASSES_EXPRESSION_EXPR_PASS_TEST_H_
 
 #include <string>
 #include <vector>
@@ -97,4 +97,4 @@ class ExprPassTestBase : public ::testing::Test {
 
 }  // namespace passes
 }  // namespace hybridse
-#endif  // SRC_PASSES_EXPRESSION_EXPR_PASS_TEST_H_
+#endif  // HYBRIDSE_SRC_PASSES_EXPRESSION_EXPR_PASS_TEST_H_

--- a/hybridse/src/passes/expression/merge_aggregations.h
+++ b/hybridse/src/passes/expression/merge_aggregations.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_PASSES_EXPRESSION_MERGE_AGGREGATIONS_H_
-#define SRC_PASSES_EXPRESSION_MERGE_AGGREGATIONS_H_
+#ifndef HYBRIDSE_SRC_PASSES_EXPRESSION_MERGE_AGGREGATIONS_H_
+#define HYBRIDSE_SRC_PASSES_EXPRESSION_MERGE_AGGREGATIONS_H_
 
 #include <string>
 #include <unordered_map>
@@ -38,4 +38,4 @@ class MergeAggregations : public passes::ExprPass {
 
 }  // namespace passes
 }  // namespace hybridse
-#endif  // SRC_PASSES_EXPRESSION_MERGE_AGGREGATIONS_H_
+#endif  // HYBRIDSE_SRC_PASSES_EXPRESSION_MERGE_AGGREGATIONS_H_

--- a/hybridse/src/passes/expression/simplify.h
+++ b/hybridse/src/passes/expression/simplify.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_PASSES_EXPRESSION_SIMPLIFY_H_
-#define SRC_PASSES_EXPRESSION_SIMPLIFY_H_
+#ifndef HYBRIDSE_SRC_PASSES_EXPRESSION_SIMPLIFY_H_
+#define HYBRIDSE_SRC_PASSES_EXPRESSION_SIMPLIFY_H_
 
 #include <map>
 #include <string>
@@ -70,4 +70,4 @@ class ExprSimplifier : public ExprInplaceTransformUp {
 
 }  // namespace passes
 }  // namespace hybridse
-#endif  // SRC_PASSES_EXPRESSION_SIMPLIFY_H_
+#endif  // HYBRIDSE_SRC_PASSES_EXPRESSION_SIMPLIFY_H_

--- a/hybridse/src/passes/expression/window_iter_analysis.h
+++ b/hybridse/src/passes/expression/window_iter_analysis.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_PASSES_EXPRESSION_WINDOW_ITER_ANALYSIS_H_
-#define SRC_PASSES_EXPRESSION_WINDOW_ITER_ANALYSIS_H_
+#ifndef HYBRIDSE_SRC_PASSES_EXPRESSION_WINDOW_ITER_ANALYSIS_H_
+#define HYBRIDSE_SRC_PASSES_EXPRESSION_WINDOW_ITER_ANALYSIS_H_
 
 #include <string>
 #include <unordered_map>
@@ -87,4 +87,4 @@ class WindowIterAnalysis {
 
 }  // namespace passes
 }  // namespace hybridse
-#endif  // SRC_PASSES_EXPRESSION_WINDOW_ITER_ANALYSIS_H_
+#endif  // HYBRIDSE_SRC_PASSES_EXPRESSION_WINDOW_ITER_ANALYSIS_H_

--- a/hybridse/src/passes/lambdafy_projects.h
+++ b/hybridse/src/passes/lambdafy_projects.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_PASSES_LAMBDAFY_PROJECTS_H_
-#define SRC_PASSES_LAMBDAFY_PROJECTS_H_
+#ifndef HYBRIDSE_SRC_PASSES_LAMBDAFY_PROJECTS_H_
+#define HYBRIDSE_SRC_PASSES_LAMBDAFY_PROJECTS_H_
 
 #include <map>
 #include <string>
@@ -89,4 +89,4 @@ class LambdafyProjects {
 
 }  // namespace passes
 }  // namespace hybridse
-#endif  // SRC_PASSES_LAMBDAFY_PROJECTS_H_
+#endif  // HYBRIDSE_SRC_PASSES_LAMBDAFY_PROJECTS_H_

--- a/hybridse/src/passes/physical/batch_request_optimize.h
+++ b/hybridse/src/passes/physical/batch_request_optimize.h
@@ -25,8 +25,8 @@
 #include "passes/physical/physical_pass.h"
 #include "vm/physical_op.h"
 
-#ifndef SRC_PASSES_PHYSICAL_BATCH_REQUEST_OPTIMIZE_H_
-#define SRC_PASSES_PHYSICAL_BATCH_REQUEST_OPTIMIZE_H_
+#ifndef HYBRIDSE_SRC_PASSES_PHYSICAL_BATCH_REQUEST_OPTIMIZE_H_
+#define HYBRIDSE_SRC_PASSES_PHYSICAL_BATCH_REQUEST_OPTIMIZE_H_
 
 namespace hybridse {
 namespace passes {
@@ -151,4 +151,4 @@ class CommonColumnOptimize : public PhysicalPass {
 
 }  // namespace passes
 }  // namespace hybridse
-#endif  // SRC_PASSES_PHYSICAL_BATCH_REQUEST_OPTIMIZE_H_
+#endif  // HYBRIDSE_SRC_PASSES_PHYSICAL_BATCH_REQUEST_OPTIMIZE_H_

--- a/hybridse/src/passes/physical/cluster_optimized.h
+++ b/hybridse/src/passes/physical/cluster_optimized.h
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef SRC_PASSES_PHYSICAL_CLUSTER_OPTIMIZED_H_
-#define SRC_PASSES_PHYSICAL_CLUSTER_OPTIMIZED_H_
+#ifndef HYBRIDSE_SRC_PASSES_PHYSICAL_CLUSTER_OPTIMIZED_H_
+#define HYBRIDSE_SRC_PASSES_PHYSICAL_CLUSTER_OPTIMIZED_H_
 
 #include "passes/physical/transform_up_physical_pass.h"
 
@@ -36,4 +36,4 @@ class ClusterOptimized : public TransformUpPysicalPass {
 }  // namespace passes
 }  // namespace hybridse
 
-#endif  // SRC_PASSES_PHYSICAL_CLUSTER_OPTIMIZED_H_
+#endif  // HYBRIDSE_SRC_PASSES_PHYSICAL_CLUSTER_OPTIMIZED_H_

--- a/hybridse/src/passes/physical/condition_optimized.h
+++ b/hybridse/src/passes/physical/condition_optimized.h
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef SRC_PASSES_PHYSICAL_CONDITION_OPTIMIZED_H_
-#define SRC_PASSES_PHYSICAL_CONDITION_OPTIMIZED_H_
+#ifndef HYBRIDSE_SRC_PASSES_PHYSICAL_CONDITION_OPTIMIZED_H_
+#define HYBRIDSE_SRC_PASSES_PHYSICAL_CONDITION_OPTIMIZED_H_
 
 #include <utility>
 #include "passes/physical/transform_up_physical_pass.h"
@@ -64,4 +64,4 @@ class ConditionOptimized : public TransformUpPysicalPass {
 
 }  // namespace passes
 }  // namespace hybridse
-#endif  // SRC_PASSES_PHYSICAL_CONDITION_OPTIMIZED_H_
+#endif  // HYBRIDSE_SRC_PASSES_PHYSICAL_CONDITION_OPTIMIZED_H_

--- a/hybridse/src/passes/physical/group_and_sort_optimized.h
+++ b/hybridse/src/passes/physical/group_and_sort_optimized.h
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef SRC_PASSES_PHYSICAL_GROUP_AND_SORT_OPTIMIZED_H_
-#define SRC_PASSES_PHYSICAL_GROUP_AND_SORT_OPTIMIZED_H_
+#ifndef HYBRIDSE_SRC_PASSES_PHYSICAL_GROUP_AND_SORT_OPTIMIZED_H_
+#define HYBRIDSE_SRC_PASSES_PHYSICAL_GROUP_AND_SORT_OPTIMIZED_H_
 
 #include <memory>
 #include <string>
@@ -94,4 +94,4 @@ class GroupAndSortOptimized : public TransformUpPysicalPass {
 };
 }  // namespace passes
 }  // namespace hybridse
-#endif  // SRC_PASSES_PHYSICAL_GROUP_AND_SORT_OPTIMIZED_H_
+#endif  // HYBRIDSE_SRC_PASSES_PHYSICAL_GROUP_AND_SORT_OPTIMIZED_H_

--- a/hybridse/src/passes/physical/left_join_optimized.h
+++ b/hybridse/src/passes/physical/left_join_optimized.h
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef SRC_PASSES_PHYSICAL_LEFT_JOIN_OPTIMIZED_H_
-#define SRC_PASSES_PHYSICAL_LEFT_JOIN_OPTIMIZED_H_
+#ifndef HYBRIDSE_SRC_PASSES_PHYSICAL_LEFT_JOIN_OPTIMIZED_H_
+#define HYBRIDSE_SRC_PASSES_PHYSICAL_LEFT_JOIN_OPTIMIZED_H_
 
 #include <string>
 #include "passes/physical/transform_up_physical_pass.h"
@@ -38,4 +38,4 @@ class LeftJoinOptimized : public TransformUpPysicalPass {
 }  // namespace passes
 }  // namespace hybridse
 
-#endif  // SRC_PASSES_PHYSICAL_LEFT_JOIN_OPTIMIZED_H_
+#endif  // HYBRIDSE_SRC_PASSES_PHYSICAL_LEFT_JOIN_OPTIMIZED_H_

--- a/hybridse/src/passes/physical/limit_optimized.h
+++ b/hybridse/src/passes/physical/limit_optimized.h
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef SRC_PASSES_PHYSICAL_LIMIT_OPTIMIZED_H_
-#define SRC_PASSES_PHYSICAL_LIMIT_OPTIMIZED_H_
+#ifndef HYBRIDSE_SRC_PASSES_PHYSICAL_LIMIT_OPTIMIZED_H_
+#define HYBRIDSE_SRC_PASSES_PHYSICAL_LIMIT_OPTIMIZED_H_
 
 #include "passes/physical/transform_up_physical_pass.h"
 
@@ -35,4 +35,4 @@ class LimitOptimized : public TransformUpPysicalPass {
 }  // namespace passes
 }  // namespace hybridse
 
-#endif  // SRC_PASSES_PHYSICAL_LIMIT_OPTIMIZED_H_
+#endif  // HYBRIDSE_SRC_PASSES_PHYSICAL_LIMIT_OPTIMIZED_H_

--- a/hybridse/src/passes/physical/physical_pass.h
+++ b/hybridse/src/passes/physical/physical_pass.h
@@ -23,8 +23,8 @@
 #include "vm/physical_op.h"
 #include "vm/physical_plan_context.h"
 
-#ifndef SRC_PASSES_PHYSICAL_PHYSICAL_PASS_H_
-#define SRC_PASSES_PHYSICAL_PHYSICAL_PASS_H_
+#ifndef HYBRIDSE_SRC_PASSES_PHYSICAL_PHYSICAL_PASS_H_
+#define HYBRIDSE_SRC_PASSES_PHYSICAL_PHYSICAL_PASS_H_
 
 namespace hybridse {
 namespace passes {
@@ -40,4 +40,4 @@ class PhysicalPass : public PassBase<PhysicalOpNode, PhysicalPlanContext> {
 
 }  // namespace passes
 }  // namespace hybridse
-#endif  // SRC_PASSES_PHYSICAL_PHYSICAL_PASS_H_
+#endif  // HYBRIDSE_SRC_PASSES_PHYSICAL_PHYSICAL_PASS_H_

--- a/hybridse/src/passes/physical/simple_project_optimized.h
+++ b/hybridse/src/passes/physical/simple_project_optimized.h
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef SRC_PASSES_PHYSICAL_SIMPLE_PROJECT_OPTIMIZED_H_
-#define SRC_PASSES_PHYSICAL_SIMPLE_PROJECT_OPTIMIZED_H_
+#ifndef HYBRIDSE_SRC_PASSES_PHYSICAL_SIMPLE_PROJECT_OPTIMIZED_H_
+#define HYBRIDSE_SRC_PASSES_PHYSICAL_SIMPLE_PROJECT_OPTIMIZED_H_
 
 #include "passes/physical/transform_up_physical_pass.h"
 
@@ -34,4 +34,4 @@ class SimpleProjectOptimized : public TransformUpPysicalPass {
 }  // namespace passes
 }  // namespace hybridse
 
-#endif  // SRC_PASSES_PHYSICAL_SIMPLE_PROJECT_OPTIMIZED_H_
+#endif  // HYBRIDSE_SRC_PASSES_PHYSICAL_SIMPLE_PROJECT_OPTIMIZED_H_

--- a/hybridse/src/passes/physical/transform_up_physical_pass.h
+++ b/hybridse/src/passes/physical/transform_up_physical_pass.h
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef SRC_PASSES_PHYSICAL_TRANSFORM_UP_PHYSICAL_PASS_H_
-#define SRC_PASSES_PHYSICAL_TRANSFORM_UP_PHYSICAL_PASS_H_
+#ifndef HYBRIDSE_SRC_PASSES_PHYSICAL_TRANSFORM_UP_PHYSICAL_PASS_H_
+#define HYBRIDSE_SRC_PASSES_PHYSICAL_TRANSFORM_UP_PHYSICAL_PASS_H_
 
 #include <memory>
 #include <string>
@@ -114,4 +114,4 @@ class TransformUpPysicalPass : public PhysicalPass {
 }  // namespace passes
 }  // namespace hybridse
 
-#endif  // SRC_PASSES_PHYSICAL_TRANSFORM_UP_PHYSICAL_PASS_H_
+#endif  // HYBRIDSE_SRC_PASSES_PHYSICAL_TRANSFORM_UP_PHYSICAL_PASS_H_

--- a/hybridse/src/passes/physical/window_column_pruning.h
+++ b/hybridse/src/passes/physical/window_column_pruning.h
@@ -19,8 +19,8 @@
 #include "passes/physical/physical_pass.h"
 #include "vm/physical_op.h"
 
-#ifndef SRC_PASSES_PHYSICAL_WINDOW_COLUMN_PRUNING_H_
-#define SRC_PASSES_PHYSICAL_WINDOW_COLUMN_PRUNING_H_
+#ifndef HYBRIDSE_SRC_PASSES_PHYSICAL_WINDOW_COLUMN_PRUNING_H_
+#define HYBRIDSE_SRC_PASSES_PHYSICAL_WINDOW_COLUMN_PRUNING_H_
 
 namespace hybridse {
 namespace passes {
@@ -45,4 +45,4 @@ class WindowColumnPruning : public PhysicalPass {
 
 }  // namespace passes
 }  // namespace hybridse
-#endif  // SRC_PASSES_PHYSICAL_WINDOW_COLUMN_PRUNING_H_
+#endif  // HYBRIDSE_SRC_PASSES_PHYSICAL_WINDOW_COLUMN_PRUNING_H_

--- a/hybridse/src/passes/resolve_fn_and_attrs.h
+++ b/hybridse/src/passes/resolve_fn_and_attrs.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_PASSES_RESOLVE_FN_AND_ATTRS_H_
-#define SRC_PASSES_RESOLVE_FN_AND_ATTRS_H_
+#ifndef HYBRIDSE_SRC_PASSES_RESOLVE_FN_AND_ATTRS_H_
+#define HYBRIDSE_SRC_PASSES_RESOLVE_FN_AND_ATTRS_H_
 
 #include <string>
 #include <unordered_map>
@@ -70,4 +70,4 @@ class ResolveFnAndAttrs : public ExprPass {
 
 }  // namespace passes
 }  // namespace hybridse
-#endif  // SRC_PASSES_RESOLVE_FN_AND_ATTRS_H_
+#endif  // HYBRIDSE_SRC_PASSES_RESOLVE_FN_AND_ATTRS_H_

--- a/hybridse/src/passes/resolve_udf_def.h
+++ b/hybridse/src/passes/resolve_udf_def.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_PASSES_RESOLVE_UDF_DEF_H_
-#define SRC_PASSES_RESOLVE_UDF_DEF_H_
+#ifndef HYBRIDSE_SRC_PASSES_RESOLVE_UDF_DEF_H_
+#define HYBRIDSE_SRC_PASSES_RESOLVE_UDF_DEF_H_
 
 #include <string>
 #include <unordered_map>
@@ -97,4 +97,4 @@ class FnScopeInfoGuard {
 
 }  // namespace passes
 }  // namespace hybridse
-#endif  // SRC_PASSES_RESOLVE_UDF_DEF_H_
+#endif  // HYBRIDSE_SRC_PASSES_RESOLVE_UDF_DEF_H_

--- a/hybridse/src/plan/planner.h
+++ b/hybridse/src/plan/planner.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_PLAN_PLANNER_H_
-#define SRC_PLAN_PLANNER_H_
+#ifndef HYBRIDSE_SRC_PLAN_PLANNER_H_
+#define HYBRIDSE_SRC_PLAN_PLANNER_H_
 
 #include <map>
 #include <string>
@@ -96,4 +96,4 @@ class SimplePlanner : public Planner {
 }  // namespace plan
 }  // namespace hybridse
 
-#endif  // SRC_PLAN_PLANNER_H_
+#endif  // HYBRIDSE_SRC_PLAN_PLANNER_H_

--- a/hybridse/src/planv2/ast_node_converter.h
+++ b/hybridse/src/planv2/ast_node_converter.h
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef SRC_PLANV2_AST_NODE_CONVERTER_H_
-#define SRC_PLANV2_AST_NODE_CONVERTER_H_
+#ifndef HYBRIDSE_SRC_PLANV2_AST_NODE_CONVERTER_H_
+#define HYBRIDSE_SRC_PLANV2_AST_NODE_CONVERTER_H_
 #include <string>
 
 #include "node/node_manager.h"
@@ -104,4 +104,4 @@ base::Status ConvertCreateIndexStatement(const zetasql::ASTCreateIndexStatement*
                                          node::CreateIndexNode** output);
 }  // namespace plan
 }  // namespace hybridse
-#endif  // SRC_PLANV2_AST_NODE_CONVERTER_H_
+#endif  // HYBRIDSE_SRC_PLANV2_AST_NODE_CONVERTER_H_

--- a/hybridse/src/planv2/planner_v2.h
+++ b/hybridse/src/planv2/planner_v2.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_PLANV2_PLANNER_V2_H_
-#define SRC_PLANV2_PLANNER_V2_H_
+#ifndef HYBRIDSE_SRC_PLANV2_PLANNER_V2_H_
+#define HYBRIDSE_SRC_PLANV2_PLANNER_V2_H_
 
 #include <map>
 #include <string>
@@ -49,4 +49,4 @@ class SimplePlannerV2 : public SimplePlanner {
 }  // namespace plan
 }  // namespace hybridse
 
-#endif  // SRC_PLANV2_PLANNER_V2_H_
+#endif  // HYBRIDSE_SRC_PLANV2_PLANNER_V2_H_

--- a/hybridse/src/testing/engine_test_base.h
+++ b/hybridse/src/testing/engine_test_base.h
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef SRC_TESTING_ENGINE_TEST_BASE_H_
-#define SRC_TESTING_ENGINE_TEST_BASE_H_
+#ifndef HYBRIDSE_SRC_TESTING_ENGINE_TEST_BASE_H_
+#define HYBRIDSE_SRC_TESTING_ENGINE_TEST_BASE_H_
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -435,4 +435,4 @@ class BatchRequestEngineTestRunner : public EngineTestRunner {
 
 }  // namespace vm
 }  // namespace hybridse
-#endif  // SRC_TESTING_ENGINE_TEST_BASE_H_
+#endif  // HYBRIDSE_SRC_TESTING_ENGINE_TEST_BASE_H_

--- a/hybridse/src/testing/test_base.h
+++ b/hybridse/src/testing/test_base.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_TESTING_TEST_BASE_H_
-#define SRC_TESTING_TEST_BASE_H_
+#ifndef HYBRIDSE_SRC_TESTING_TEST_BASE_H_
+#define HYBRIDSE_SRC_TESTING_TEST_BASE_H_
 
 #include <memory>
 #include <sstream>
@@ -63,4 +63,4 @@ void PrintSchema(const Schema& schema);
 }  // namespace vm
 }  // namespace hybridse
 
-#endif  // SRC_TESTING_TEST_BASE_H_
+#endif  // HYBRIDSE_SRC_TESTING_TEST_BASE_H_

--- a/hybridse/src/udf/containers.h
+++ b/hybridse/src/udf/containers.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_UDF_CONTAINERS_H_
-#define SRC_UDF_CONTAINERS_H_
+#ifndef HYBRIDSE_SRC_UDF_CONTAINERS_H_
+#define HYBRIDSE_SRC_UDF_CONTAINERS_H_
 
 #include <algorithm>
 #include <functional>
@@ -305,4 +305,4 @@ class BoundedGroupByDict {
 }  // namespace udf
 }  // namespace hybridse
 
-#endif  // SRC_UDF_CONTAINERS_H_
+#endif  // HYBRIDSE_SRC_UDF_CONTAINERS_H_

--- a/hybridse/src/udf/default_udf_library.h
+++ b/hybridse/src/udf/default_udf_library.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_UDF_DEFAULT_UDF_LIBRARY_H_
-#define SRC_UDF_DEFAULT_UDF_LIBRARY_H_
+#ifndef HYBRIDSE_SRC_UDF_DEFAULT_UDF_LIBRARY_H_
+#define HYBRIDSE_SRC_UDF_DEFAULT_UDF_LIBRARY_H_
 #include "udf/udf_library.h"
 
 namespace hybridse {
@@ -51,4 +51,4 @@ class DefaultUdfLibrary : public UdfLibrary {
 }  // namespace udf
 }  // namespace hybridse
 
-#endif  // SRC_UDF_DEFAULT_UDF_LIBRARY_H_
+#endif  // HYBRIDSE_SRC_UDF_DEFAULT_UDF_LIBRARY_H_

--- a/hybridse/src/udf/literal_traits.h
+++ b/hybridse/src/udf/literal_traits.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_UDF_LITERAL_TRAITS_H_
-#define SRC_UDF_LITERAL_TRAITS_H_
+#ifndef HYBRIDSE_SRC_UDF_LITERAL_TRAITS_H_
+#define HYBRIDSE_SRC_UDF_LITERAL_TRAITS_H_
 
 #include <limits>
 #include <memory>
@@ -482,4 +482,4 @@ codec::Schema DataTypeTrait<LiteralTypedRow<LiteralArgTypes...>>::schema =
 }  // namespace udf
 }  // namespace hybridse
 
-#endif  // SRC_UDF_LITERAL_TRAITS_H_
+#endif  // HYBRIDSE_SRC_UDF_LITERAL_TRAITS_H_

--- a/hybridse/src/udf/udf.h
+++ b/hybridse/src/udf/udf.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_UDF_UDF_H_
-#define SRC_UDF_UDF_H_
+#ifndef HYBRIDSE_SRC_UDF_UDF_H_
+#define HYBRIDSE_SRC_UDF_UDF_H_
 #include <stdint.h>
 #include <string>
 #include <tuple>
@@ -281,4 +281,4 @@ void RegisterNativeUdfToModule();
 }  // namespace udf
 }  // namespace hybridse
 
-#endif  // SRC_UDF_UDF_H_
+#endif  // HYBRIDSE_SRC_UDF_UDF_H_

--- a/hybridse/src/udf/udf_library.h
+++ b/hybridse/src/udf/udf_library.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_UDF_UDF_LIBRARY_H_
-#define SRC_UDF_UDF_LIBRARY_H_
+#ifndef HYBRIDSE_SRC_UDF_UDF_LIBRARY_H_
+#define HYBRIDSE_SRC_UDF_UDF_LIBRARY_H_
 
 #include <memory>
 #include <string>
@@ -164,4 +164,4 @@ const std::string GetArgSignature(const std::vector<node::ExprNode*>& args);
 }  // namespace udf
 }  // namespace hybridse
 
-#endif  // SRC_UDF_UDF_LIBRARY_H_
+#endif  // HYBRIDSE_SRC_UDF_UDF_LIBRARY_H_

--- a/hybridse/src/udf/udf_registry.h
+++ b/hybridse/src/udf/udf_registry.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_UDF_UDF_REGISTRY_H_
-#define SRC_UDF_UDF_REGISTRY_H_
+#ifndef HYBRIDSE_SRC_UDF_UDF_REGISTRY_H_
+#define HYBRIDSE_SRC_UDF_UDF_REGISTRY_H_
 
 #include <memory>
 #include <sstream>
@@ -1874,4 +1874,4 @@ class UdafTemplateRegistryHelper : public UdfRegistryHelper<UdafRegistry> {
 }  // namespace udf
 }  // namespace hybridse
 
-#endif  // SRC_UDF_UDF_REGISTRY_H_
+#endif  // HYBRIDSE_SRC_UDF_UDF_REGISTRY_H_

--- a/hybridse/src/udf/udf_test.h
+++ b/hybridse/src/udf/udf_test.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_UDF_UDF_TEST_H_
-#define SRC_UDF_UDF_TEST_H_
+#ifndef HYBRIDSE_SRC_UDF_UDF_TEST_H_
+#define HYBRIDSE_SRC_UDF_UDF_TEST_H_
 
 #include <gtest/gtest.h>
 #include <memory>
@@ -217,4 +217,4 @@ codec::ListRef<bool> MakeBoolList(const std::initializer_list<int>& vec) {
 }  // namespace udf
 }  // namespace hybridse
 
-#endif  // SRC_UDF_UDF_TEST_H_
+#endif  // HYBRIDSE_SRC_UDF_UDF_TEST_H_

--- a/hybridse/src/version.h.in
+++ b/hybridse/src/version.h.in
@@ -14,14 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef HYBRIDSE_VERSION_H_
-#define HYBRIDSE_VERSION_H_
+#ifndef HYBRIDSE_HYBRIDSE_VERSION_H_
+#define HYBRIDSE_HYBRIDSE_VERSION_H_
 
 #define HYBRIDSE_VERSION_MAJOR @HYBRIDSE_VERSION_MAJOR@
 #define HYBRIDSE_VERSION_MEDIUM @HYBRIDSE_VERSION_MEDIUM@
 #define HYBRIDSE_VERSION_MINOR @HYBRIDSE_VERSION_MINOR@
 #define HYBRIDSE_VERSION_BUG @HYBRIDSE_VERSION_BUG@
 
-#endif /* !HYBRIDSE_VERSION_H_ */
+#endif /* !HYBRIDSE_HYBRIDSE_VERSION_H_ */
 
 /* vim: set expandtab ts=4 sw=4 sts=4 tw=100: */

--- a/hybridse/src/vm/catalog_wrapper.h
+++ b/hybridse/src/vm/catalog_wrapper.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_VM_CATALOG_WRAPPER_H_
-#define SRC_VM_CATALOG_WRAPPER_H_
+#ifndef HYBRIDSE_SRC_VM_CATALOG_WRAPPER_H_
+#define HYBRIDSE_SRC_VM_CATALOG_WRAPPER_H_
 #include <memory>
 #include <string>
 #include <utility>
@@ -482,4 +482,4 @@ class RowCombineWrapper : public RowHandler {
 }  // namespace vm
 }  // namespace hybridse
 
-#endif  // SRC_VM_CATALOG_WRAPPER_H_
+#endif  // HYBRIDSE_SRC_VM_CATALOG_WRAPPER_H_

--- a/hybridse/src/vm/core_api.h
+++ b/hybridse/src/vm/core_api.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_VM_CORE_API_H_
-#define SRC_VM_CORE_API_H_
+#ifndef HYBRIDSE_SRC_VM_CORE_API_H_
+#define HYBRIDSE_SRC_VM_CORE_API_H_
 
 #include <map>
 #include <memory>
@@ -173,4 +173,4 @@ class CoreAPI {
 
 }  // namespace vm
 }  // namespace hybridse
-#endif  // SRC_VM_CORE_API_H_
+#endif  // HYBRIDSE_SRC_VM_CORE_API_H_

--- a/hybridse/src/vm/jit.h
+++ b/hybridse/src/vm/jit.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_VM_JIT_H_
-#define SRC_VM_JIT_H_
+#ifndef HYBRIDSE_SRC_VM_JIT_H_
+#define HYBRIDSE_SRC_VM_JIT_H_
 
 #include <map>
 #include <memory>
@@ -139,4 +139,4 @@ class HybridSeMcJitWrapper : public HybridSeJitWrapper {
 
 }  // namespace vm
 }  // namespace hybridse
-#endif  // SRC_VM_JIT_H_
+#endif  // HYBRIDSE_SRC_VM_JIT_H_

--- a/hybridse/src/vm/jit_runtime.h
+++ b/hybridse/src/vm/jit_runtime.h
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef SRC_VM_JIT_RUNTIME_H_
-#define SRC_VM_JIT_RUNTIME_H_
+#ifndef HYBRIDSE_SRC_VM_JIT_RUNTIME_H_
+#define HYBRIDSE_SRC_VM_JIT_RUNTIME_H_
 
 #include <list>
 
@@ -65,4 +65,4 @@ class JitRuntime {
 
 }  // namespace vm
 }  // namespace hybridse
-#endif  // SRC_VM_JIT_RUNTIME_H_
+#endif  // HYBRIDSE_SRC_VM_JIT_RUNTIME_H_

--- a/hybridse/src/vm/jit_wrapper.h
+++ b/hybridse/src/vm/jit_wrapper.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_VM_JIT_WRAPPER_H_
-#define SRC_VM_JIT_WRAPPER_H_
+#ifndef HYBRIDSE_SRC_VM_JIT_WRAPPER_H_
+#define HYBRIDSE_SRC_VM_JIT_WRAPPER_H_
 
 #include <memory>
 #include <string>
@@ -62,4 +62,4 @@ void InitBuiltinJitSymbols(HybridSeJitWrapper* jit_ptr);
 
 }  // namespace vm
 }  // namespace hybridse
-#endif  // SRC_VM_JIT_WRAPPER_H_
+#endif  // HYBRIDSE_SRC_VM_JIT_WRAPPER_H_

--- a/hybridse/src/vm/local_tablet_handler.h
+++ b/hybridse/src/vm/local_tablet_handler.h
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef SRC_VM_LOCAL_TABLET_HANDLER_H_
-#define SRC_VM_LOCAL_TABLET_HANDLER_H_
+#ifndef HYBRIDSE_SRC_VM_LOCAL_TABLET_HANDLER_H_
+#define HYBRIDSE_SRC_VM_LOCAL_TABLET_HANDLER_H_
 #include <memory>
 #include <string>
 #include <vector>
@@ -121,4 +121,4 @@ class LocalTabletTableHandler : public MemTableHandler {
 };
 }  // namespace vm
 }  // namespace hybridse
-#endif  // SRC_VM_LOCAL_TABLET_HANDLER_H_
+#endif  // HYBRIDSE_SRC_VM_LOCAL_TABLET_HANDLER_H_

--- a/hybridse/src/vm/physical_plan_context.h
+++ b/hybridse/src/vm/physical_plan_context.h
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef SRC_VM_PHYSICAL_PLAN_CONTEXT_H_
-#define SRC_VM_PHYSICAL_PLAN_CONTEXT_H_
+#ifndef HYBRIDSE_SRC_VM_PHYSICAL_PLAN_CONTEXT_H_
+#define HYBRIDSE_SRC_VM_PHYSICAL_PLAN_CONTEXT_H_
 
 #include <map>
 #include <memory>
@@ -153,4 +153,4 @@ class PhysicalPlanContext {
 };
 }  // namespace vm
 }  // namespace hybridse
-#endif  // SRC_VM_PHYSICAL_PLAN_CONTEXT_H_
+#endif  // HYBRIDSE_SRC_VM_PHYSICAL_PLAN_CONTEXT_H_

--- a/hybridse/src/vm/runner.h
+++ b/hybridse/src/vm/runner.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_VM_RUNNER_H_
-#define SRC_VM_RUNNER_H_
+#ifndef HYBRIDSE_SRC_VM_RUNNER_H_
+#define HYBRIDSE_SRC_VM_RUNNER_H_
 
 #include <map>
 #include <memory>
@@ -1493,4 +1493,4 @@ class RunnerContext {
 };
 }  // namespace vm
 }  // namespace hybridse
-#endif  // SRC_VM_RUNNER_H_
+#endif  // HYBRIDSE_SRC_VM_RUNNER_H_

--- a/hybridse/src/vm/simple_catalog.h
+++ b/hybridse/src/vm/simple_catalog.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_VM_SIMPLE_CATALOG_H_
-#define SRC_VM_SIMPLE_CATALOG_H_
+#ifndef HYBRIDSE_SRC_VM_SIMPLE_CATALOG_H_
+#define HYBRIDSE_SRC_VM_SIMPLE_CATALOG_H_
 
 #include <map>
 #include <memory>
@@ -109,4 +109,4 @@ class SimpleCatalog : public Catalog {
 
 }  // namespace vm
 }  // namespace hybridse
-#endif  // SRC_VM_SIMPLE_CATALOG_H_
+#endif  // HYBRIDSE_SRC_VM_SIMPLE_CATALOG_H_

--- a/hybridse/src/vm/sql_compiler.h
+++ b/hybridse/src/vm/sql_compiler.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_VM_SQL_COMPILER_H_
-#define SRC_VM_SQL_COMPILER_H_
+#ifndef HYBRIDSE_SRC_VM_SQL_COMPILER_H_
+#define HYBRIDSE_SRC_VM_SQL_COMPILER_H_
 
 #include <memory>
 #include <set>
@@ -185,4 +185,4 @@ class SqlCompiler {
 
 }  // namespace vm
 }  // namespace hybridse
-#endif  // SRC_VM_SQL_COMPILER_H_
+#endif  // HYBRIDSE_SRC_VM_SQL_COMPILER_H_

--- a/hybridse/src/vm/transform.h
+++ b/hybridse/src/vm/transform.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_VM_TRANSFORM_H_
-#define SRC_VM_TRANSFORM_H_
+#ifndef HYBRIDSE_SRC_VM_TRANSFORM_H_
+#define HYBRIDSE_SRC_VM_TRANSFORM_H_
 
 #include <memory>
 #include <set>
@@ -340,4 +340,4 @@ Status ExtractProjectInfos(const node::PlanNodeList& projects,
                            ColumnProjects* output);
 }  // namespace vm
 }  // namespace hybridse
-#endif  // SRC_VM_TRANSFORM_H_
+#endif  // HYBRIDSE_SRC_VM_TRANSFORM_H_


### PR DESCRIPTION
**This PR try to solve the problem that cpplint reports header guards warning**

**The things this PR has done**

- [x] update header guard in `hybridse cpp file`(total 133 files changed), add HYBRIDSE_ prefix
- [x] rm -build/header_guard in workflow file: `style.yml` `CPPLINT.cfg`

**The reason to  do this PR**
hybridse source moved, cpplint reports header guards problem.
so we add -build/header_guard filter to cpplint temporarily

**The related issue**
#312 
[gitee awarded issue](https://gitee.com/paradigm4/OpenMLDB/issues/I48BYA) 