### PR TITLE
feat: support plan explain

### DIFF
--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/ConcatJoinPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/ConcatJoinPlan.scala
@@ -29,14 +29,14 @@ object ConcatJoinPlan {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 
-  def gen(ctx: PlanContext, node: PhysicalJoinNode, left: SparkInstance, right: SparkInstance): SparkInstance = {
+  def gen(ctx: PlanContext, physicalNode: PhysicalJoinNode, left: SparkInstance, right: SparkInstance): SparkInstance = {
     // Check join type
-    val joinType = node.join().join_type()
+    val joinType = physicalNode.join().join_type()
     if (joinType != JoinType.kJoinTypeConcat) {
       throw new HybridSeException(s"Concat join type $joinType not supported")
     }
 
-    val indexName = ctx.getIndexInfo(node.GetNodeId()).indexColumnName
+    val indexName = ctx.getIndexInfo(physicalNode.GetNodeId()).indexColumnName
 
     // Note that this is exception to use "getDfWithIndex" instead of "getSparkDfConsideringIndex"
     // because ConcatJoin has not index flag but request input dataframe with index
@@ -60,7 +60,7 @@ object ConcatJoinPlan {
       case _ => throw new HybridSeException("Unsupported concat join join type: " + joinType)
     }
 
-    val nodeIndexType = ctx.getIndexInfo(node.GetNodeId()).nodeIndexType
+    val nodeIndexType = ctx.getIndexInfo(physicalNode.GetNodeId()).nodeIndexType
 
     // Drop the index column, this will drop two columns with the same index name
     val outputDf = nodeIndexType match {
@@ -75,7 +75,7 @@ object ConcatJoinPlan {
       case _ => throw new HybridSeException("Handle unsupported concat join node index type: %s".format(nodeIndexType))
     }
 
-    SparkInstance.createConsideringIndex(ctx, node.GetNodeId(), outputDf)
+    SparkInstance.createConsideringIndex(ctx, physicalNode.GetNodeId(), outputDf, physicalNode)
   }
 
 }

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/ConcatJoinPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/ConcatJoinPlan.scala
@@ -29,7 +29,8 @@ object ConcatJoinPlan {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 
-  def gen(ctx: PlanContext, physicalNode: PhysicalJoinNode, left: SparkInstance, right: SparkInstance): SparkInstance = {
+  def gen(ctx: PlanContext, physicalNode: PhysicalJoinNode, left: SparkInstance,
+          right: SparkInstance): SparkInstance = {
     // Check join type
     val joinType = physicalNode.join().join_type()
     if (joinType != JoinType.kJoinTypeConcat) {

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/DataProviderPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/DataProviderPlan.scala
@@ -17,22 +17,22 @@
 package com._4paradigm.openmldb.batch.nodes
 
 import com._4paradigm.hybridse.sdk.HybridSeException
-import com._4paradigm.hybridse.vm.PhysicalDataProviderNode
+import com._4paradigm.hybridse.vm.{PhysicalDataProviderNode, PhysicalOpNode}
 import com._4paradigm.openmldb.batch.{PlanContext, SparkInstance}
 
 
 object DataProviderPlan {
 
-  def gen(ctx: PlanContext, node: PhysicalDataProviderNode, inputs: Seq[SparkInstance]): SparkInstance = {
-    val tableName = node.GetName()
+  def gen(ctx: PlanContext, physicalNode: PhysicalDataProviderNode, physicalOpNode: PhysicalOpNode): SparkInstance = {
+    val tableName = physicalNode.GetName()
     val df = ctx.getDataFrame(tableName).getOrElse {
       throw new HybridSeException(s"Input table $tableName not found")
     }
 
     // If limit has been set
-    val outputDf = if (node.GetLimitCnt() > 0) df.limit(node.GetLimitCnt()) else df
+    val outputDf = if (physicalNode.GetLimitCnt() > 0) df.limit(physicalNode.GetLimitCnt()) else df
 
-    SparkInstance.createConsideringIndex(ctx, node.GetNodeId(), outputDf)
+    SparkInstance.createConsideringIndex(ctx, physicalNode.GetNodeId(), outputDf, physicalOpNode)
   }
 
 }

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/FilterPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/FilterPlan.scala
@@ -41,8 +41,10 @@ object FilterPlan {
 
       val keyNum = leftKeys.GetChildNum
       for (i <- 0 until keyNum) {
-        val leftColumn = SparkColumnUtil.resolveExprNodeToColumn(leftKeys.GetChild(i), physicalNode.GetProducer(0), inputDf)
-        val rightColumn = SparkColumnUtil.resolveExprNodeToColumn(rightKeys.GetChild(i), physicalNode.GetProducer(0), inputDf)
+        val leftColumn = SparkColumnUtil
+          .resolveExprNodeToColumn(leftKeys.GetChild(i), physicalNode.GetProducer(0), inputDf)
+        val rightColumn = SparkColumnUtil
+          .resolveExprNodeToColumn(rightKeys.GetChild(i), physicalNode.GetProducer(0), inputDf)
         // TODO: Add tests to check null equality in Spark and HybridSE core
         outputDf = outputDf.where(leftColumn === rightColumn)
       }

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/JoinPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/JoinPlan.scala
@@ -90,8 +90,10 @@ object JoinPlan {
 
       val keyNum = leftKeys.GetChildNum
       for (i <- 0 until keyNum) {
-        val leftColumn = SparkColumnUtil.resolveExprNodeToColumn(leftKeys.GetChild(i), physicalNode.GetProducer(0), leftDf)
-        val rightColumn = SparkColumnUtil.resolveExprNodeToColumn(rightKeys.GetChild(i), physicalNode.GetProducer(1), rightDf)
+        val leftColumn = SparkColumnUtil.
+          resolveExprNodeToColumn(leftKeys.GetChild(i), physicalNode.GetProducer(0), leftDf)
+        val rightColumn = SparkColumnUtil.
+          resolveExprNodeToColumn(rightKeys.GetChild(i), physicalNode.GetProducer(1), rightDf)
         joinConditions += (leftColumn === rightColumn)
       }
     }

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/LimitPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/LimitPlan.scala
@@ -16,16 +16,17 @@
 
 package com._4paradigm.openmldb.batch.nodes
 
-import com._4paradigm.hybridse.vm.PhysicalLimitNode
+import com._4paradigm.hybridse.vm.{PhysicalLimitNode, PhysicalOpNode}
 import com._4paradigm.openmldb.batch.{PlanContext, SparkInstance}
 
 
 object LimitPlan {
 
-  def gen(ctx: PlanContext, node: PhysicalLimitNode, input: SparkInstance): SparkInstance = {
-    val outputDf = input.getDfConsideringIndex(ctx, node.GetNodeId()).limit(node.GetLimitCnt())
+  def gen(ctx: PlanContext, physicalNode: PhysicalLimitNode,
+          input: SparkInstance, physicalOpNode: PhysicalOpNode): SparkInstance = {
+    val outputDf = input.getDfConsideringIndex(ctx, physicalNode.GetNodeId()).limit(physicalNode.GetLimitCnt())
 
-    SparkInstance.createConsideringIndex(ctx, node.GetNodeId(), outputDf)
+    SparkInstance.createConsideringIndex(ctx, physicalNode.GetNodeId(), outputDf, physicalOpNode)
   }
 
 }

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/RenamePlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/RenamePlan.scala
@@ -16,17 +16,18 @@
 
 package com._4paradigm.openmldb.batch.nodes
 
-import com._4paradigm.hybridse.vm.PhysicalRenameNode
+import com._4paradigm.hybridse.vm.{PhysicalOpNode, PhysicalRenameNode}
 import com._4paradigm.openmldb.batch.{PlanContext, SparkInstance}
 
 
 object RenamePlan {
 
-  def gen(ctx: PlanContext, node: PhysicalRenameNode, input: SparkInstance): SparkInstance = {
+  def gen(ctx: PlanContext, physicalNode: PhysicalRenameNode,
+          input: SparkInstance, physicalOpNode: PhysicalOpNode): SparkInstance = {
     // Return the same dataframe for child node
-    val outputDf = input.getDfConsideringIndex(ctx, node.GetNodeId())
+    val outputDf = input.getDfConsideringIndex(ctx, physicalNode.GetNodeId())
 
-    SparkInstance.createConsideringIndex(ctx, node.GetNodeId(), outputDf)
+    SparkInstance.createConsideringIndex(ctx, physicalNode.GetNodeId(), outputDf, physicalOpNode)
   }
 
 }

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/SortByPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/SortByPlan.scala
@@ -16,16 +16,17 @@
 
 package com._4paradigm.openmldb.batch.nodes
 
-import com._4paradigm.hybridse.vm.PhysicalSortNode
+import com._4paradigm.hybridse.vm.{PhysicalOpNode, PhysicalSortNode}
 import com._4paradigm.openmldb.batch.utils.PhysicalNodeUtil
 import com._4paradigm.openmldb.batch.{PlanContext, SparkInstance}
 
 object SortByPlan {
-  def gen(ctx: PlanContext, node: PhysicalSortNode, input: SparkInstance): SparkInstance = {
+  def gen(ctx: PlanContext, physicalNode: PhysicalSortNode,
+          input: SparkInstance, physicalOpNode: PhysicalOpNode): SparkInstance = {
 
-    val dfWithIndex = input.getDfConsideringIndex(ctx, node.GetNodeId())
-    val outputDf = dfWithIndex.sort(PhysicalNodeUtil.getOrderbyColumns(node, dfWithIndex): _*)
+    val dfWithIndex = input.getDfConsideringIndex(ctx, physicalNode.GetNodeId())
+    val outputDf = dfWithIndex.sort(PhysicalNodeUtil.getOrderbyColumns(physicalNode, dfWithIndex): _*)
 
-    SparkInstance.createConsideringIndex(ctx, node.GetNodeId(), outputDf)
+    SparkInstance.createConsideringIndex(ctx, physicalNode.GetNodeId(), outputDf, physicalOpNode)
   }
 }

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/WindowAggPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/WindowAggPlan.scala
@@ -16,10 +16,9 @@
 
 package com._4paradigm.openmldb.batch.nodes
 
-import com._4paradigm.hybridse.vm.PhysicalWindowAggrerationNode
-import com._4paradigm.openmldb.batch.utils.{
-  AutoDestructibleIterator, HybridseUtil, PhysicalNodeUtil, SkewDataFrameUtils, SparkUtil
-}
+import com._4paradigm.hybridse.vm.{PhysicalOpNode, PhysicalWindowAggrerationNode}
+import com._4paradigm.openmldb.batch.utils.{AutoDestructibleIterator, HybridseUtil,
+  PhysicalNodeUtil, SkewDataFrameUtils, SparkUtil}
 import com._4paradigm.openmldb.batch.window.WindowAggPlanUtil.WindowAggConfig
 import com._4paradigm.openmldb.batch.window.{WindowAggPlanUtil, WindowComputer}
 import com._4paradigm.openmldb.batch.{OpenmldbBatchConfig, PlanContext, SparkInstance}
@@ -48,7 +47,8 @@ object WindowAggPlan {
   private val logger = LoggerFactory.getLogger(this.getClass)
 
   /** The entrance function to generate Spark dataframe from window agg physical node. */
-  def gen(ctx: PlanContext, physicalNode: PhysicalWindowAggrerationNode, inputTable: SparkInstance): SparkInstance = {
+  def gen(ctx: PlanContext, physicalNode: PhysicalWindowAggrerationNode,
+          inputTable: SparkInstance, physicalOpNode: PhysicalOpNode): SparkInstance = {
     // Check if we should support window with union or not
     val isWindowWithUnion = physicalNode.window_unions().GetSize().toInt > 0
     // Check if we should keep the index column
@@ -120,7 +120,7 @@ object WindowAggPlan {
       ctx.getSparkSession.createDataFrame(outputRdd, outputSchema)
     }
 
-    SparkInstance.createConsideringIndex(ctx, physicalNode.GetNodeId(), outputDf)
+    SparkInstance.createConsideringIndex(ctx, physicalNode.GetNodeId(), outputDf, physicalOpNode)
   }
 
 


### PR DESCRIPTION
- Now, we can't use explain to print code plan in openMLDB-batch. Such as `planner.plan(sql, Map("t" -> table)).explain()`
- In order to support explain, modify 'SparkInstance'
- Issue: https://github.com/4paradigm/OpenMLDB/issues/488
