### PR TITLE
feat: add a config for print the physical plan

### DIFF
--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/OpenmldbBatchConfig.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/OpenmldbBatchConfig.scala
@@ -104,6 +104,9 @@ class OpenmldbBatchConfig extends Serializable {
   @ConfigOption(name="openmldb.physical.plan.graphviz.path", doc="The path of physical plan graphviz image")
   var physicalPlanGraphvizPath = ""
 
+  @ConfigOption(name="openmldb.physical.plan.print", doc="Print the sql physical plan")
+  var printPhysicalPlan = false
+
   @ConfigOption(name="openmldb.enable.native.last.join", doc="Enable native last join or not")
   var enableNativeLastJoin = true
 

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/SparkPlanner.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/SparkPlanner.scala
@@ -78,7 +78,10 @@ class SparkPlanner(session: SparkSession, config: OpenmldbBatchConfig, dbName: S
 
       val root = engine.getPlan
       logger.info("Get HybridSE physical plan: ")
-      root.Print()
+
+      if (config.printPhysicalPlan) {
+        root.Print()
+      }
 
       if (!config.physicalPlanGraphvizPath.equals("")) {
         logger.info("Draw the physical plan and save to " + config.physicalPlanGraphvizPath)


### PR DESCRIPTION
- We don't need to print physical plan each time when we execute plan.
- Now, if we want to get the physical plan, we should `set("openmldb.physical.plan.print", true)`.
