### PR TITLE
feat: set index if no index in create table stmt

### DIFF
--- a/cases/function/ddl/test_create.yaml
+++ b/cases/function/ddl/test_create.yaml
@@ -482,7 +482,7 @@ cases:
       create table {auto} (
       c1 string, c3 int, c4 bigint, c5 float, c6 double, c7 timestamp, c8 date);
     expect:
-      success: false
+      success: true
   -
     id: 44
     desc: bool-insert-1

--- a/src/nameserver/name_server_impl.cc
+++ b/src/nameserver/name_server_impl.cc
@@ -3976,15 +3976,15 @@ void NameServerImpl::CreateTable(RpcController* controller, const CreateTableReq
         return;
     }
 
-    // if no column_key, add one which key is the first column
+    // if no column_key, add one which key is the first column which is not float or double
     if (table_info->column_key_size() == 0) {
-        if (table_info->column_desc_size() == 0) {
-            response->set_code(::openmldb::base::ReturnCode::kInvalidParameter);
-            response->set_msg("can't be no column");
-            return;
+        for (const auto& column : table_info->column_desc()) {
+            if (column.data_type() != type::kFloat && column.data_type() != type::kDouble) {
+                auto add = table_info->add_column_key();
+                add->add_col_name(column.name());
+                break;
+            }
         }
-        auto add = table_info->add_column_key();
-        add->add_col_name(table_info->column_desc(0).name());
     }
 
     if (CheckTableMeta(*table_info) < 0) {

--- a/src/nameserver/name_server_impl.cc
+++ b/src/nameserver/name_server_impl.cc
@@ -3977,11 +3977,17 @@ void NameServerImpl::CreateTable(RpcController* controller, const CreateTableReq
     }
 
     // if no column_key, add one which key is the first column which is not float or double
+    // the logic should be the same as 'create table xx(xx,index(key=<auto_selected_col>)) xx;'
+    // Ref NsClient::TransformToTableDef
     if (table_info->column_key_size() == 0) {
         for (const auto& column : table_info->column_desc()) {
             if (column.data_type() != type::kFloat && column.data_type() != type::kDouble) {
                 auto add = table_info->add_column_key();
                 add->add_col_name(column.name());
+                // Ref hybridse::plan::PlanAPI::GenerateName
+                add->set_index_name("INDEX_0_" + std::to_string(::baidu::common::timer::now_time()));
+                // use the default ttl
+                add->mutable_ttl();
                 break;
             }
         }

--- a/src/nameserver/name_server_impl.h
+++ b/src/nameserver/name_server_impl.h
@@ -396,7 +396,7 @@ class NameServerImpl : public NameServer {
 
     void AddDataType(std::shared_ptr<TableInfo> table_info);
 
-    int CheckTableMeta(const TableInfo& table_info);
+    static int CheckTableMeta(const TableInfo& table_info);
 
     int FillColumnKey(TableInfo& table_info);  // NOLINT
 


### PR DESCRIPTION
Closes #462 

If no index in `create table`, set the first column(not float or double) as the index key.