### PR TITLE
ci: fix absl link, add sdk deploy on mac

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -246,6 +246,46 @@ jobs:
           MAVEN_TOKEN: ${{ secrets.OSSRH_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
+  java-sdk-deploy-mac:
+    runs-on: macos-latest
+    # TODO(hw): needs ut on mac
+    needs: [ "build_and_cpp_ut", "sql_sdk_test", "sql_cluster_test", "java-sdk", "python-sdk" ]
+    # java deploy is triggered with a push to main or a tag push
+    # a 'vX.Y.Z' tag push will deploy a release version to maven central,
+    # any other push will deploy a SNAPSHOT version.
+    # see more in 'steps/package_openmldb_javasdk.sh'
+    if: >
+      success() && github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '8'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_TOKEN
+          gpg-passphrase: GPG_PASSPHRASE # env variable for GPG private key passphrase
+
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v3
+        with:
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+
+      - name: upload to maven
+        run: |
+          bash steps/init_env.sh ${{ env.HYBRIDSE_SOURCE }}
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          VERSION=$(echo "$VERSION" | sed -e 's/^v//')
+          ./steps/package_openmldb_javasdk.sh "$VERSION"
+        env:
+          MAVEN_OPTS: -Duser.home=/github/home
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
   python-sdk-deploy:
     runs-on: ubuntu-latest
     needs: [ "build_and_cpp_ut", "sql_sdk_test", "sql_cluster_test", "java-sdk", "python-sdk" ]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,8 @@ set(SWIG_DIR ${CMAKE_PREFIX_PATH}/share/swig/4.0.1)
 find_package(SWIG REQUIRED)
 include(UseSWIG)
 find_package(absl REQUIRED)
+# modify absl::time_zone INTERFACE_LINK_LIBRARIES
+set_target_properties(absl::time_zone PROPERTIES INTERFACE_LINK_LIBRARIES "\$<\$<PLATFORM_ID:Darwin>:-framework CoreFoundation>")
 
 find_package(GTest 1.10 EXACT REQUIRED)
 

--- a/hybridse/CMakeLists.txt
+++ b/hybridse/CMakeLists.txt
@@ -160,6 +160,8 @@ link_directories(${CMAKE_PREFIX_PATH}/lib64)
 
 
 find_package(absl REQUIRED)
+# modify absl::time_zone INTERFACE_LINK_LIBRARIES
+set_target_properties(absl::time_zone PROPERTIES INTERFACE_LINK_LIBRARIES "\$<\$<PLATFORM_ID:Darwin>:-framework CoreFoundation>")
 
 find_package(GTest REQUIRED)
 
@@ -183,7 +185,8 @@ list(
         absl::strings_internal
         absl::synchronization
         absl::time
-        absl::status)
+        absl::status
+)
 
 list(APPEND ICU_LIBS icui18n icuio icuuc icudata)
 set(ZETASQL_LIBS

--- a/steps/package_openmldb_javasdk.sh
+++ b/steps/package_openmldb_javasdk.sh
@@ -31,12 +31,19 @@ if [ -n "$VERSION" ] ; then
     # tweak VERSION based on rules:
     #  - 0.2.2     -> 0.2.2
     #  - 0.2.2(.*) -> 0.2.2-SNAPSHOT
+
     # shellcheck disable=SC2001
     SUFFIX_VERSION=$(echo "$VERSION" | sed -e 's/^[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*//')
     BASE_VERSION=${VERSION%"$SUFFIX_VERSION"}
     if [ -n "$SUFFIX_VERSION" ]; then
-        VERSION="$BASE_VERSION-SNAPSHOT"
+      VERSION=${BASE_VERSION}
+      if [ -f openmldb-native/src/main/resources/libsql_jsdk.dylib ]; then
+        VERSION="${VERSION}-macos"
+      fi
+      VERSION="${VERSION}-SNAPSHOT"
     fi
+    echo "set version: ${VERSION}"
+
     mvn versions:set -DnewVersion="${VERSION}"
 fi
 mvn deploy -Dmaven.test.skip=true


### PR DESCRIPTION
A temporary solution to #454 `No rule to make target.../CoreFoundation.framework`.
And add the openmldb-jdbc deploy on mac.
