### PR TITLE
ci: fix version set and maven opt on macos

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -241,6 +241,7 @@ jobs:
           VERSION=$(echo "$VERSION" | sed -e 's/^v//')
           ./steps/package_openmldb_javasdk.sh "$VERSION"
         env:
+          # do not set user.home on macos
           MAVEN_OPTS: -Duser.home=/github/home
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_TOKEN: ${{ secrets.OSSRH_TOKEN }}
@@ -281,7 +282,6 @@ jobs:
           VERSION=$(echo "$VERSION" | sed -e 's/^v//')
           ./steps/package_openmldb_javasdk.sh "$VERSION"
         env:
-          MAVEN_OPTS: -Duser.home=/github/home
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_TOKEN: ${{ secrets.OSSRH_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/steps/package_openmldb_javasdk.sh
+++ b/steps/package_openmldb_javasdk.sh
@@ -27,14 +27,15 @@ test -f build/src/sdk/libsql_jsdk.dylib && cp build/src/sdk/libsql_jsdk.dylib  j
 test -f build/src/sdk/libsql_jsdk.so && cp build/src/sdk/libsql_jsdk.so  java/openmldb-native/src/main/resources/
 
 pushd java/
-if [ -n "$VERSION" ] ; then
+BASE_PATTERN="^[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*"
+if [[ $VERSION =~ $BASE_PATTERN ]]; then
     # tweak VERSION based on rules:
     #  - 0.2.2     -> 0.2.2
     #  - 0.2.2(.*) -> 0.2.2-SNAPSHOT
 
     # shellcheck disable=SC2001
-    SUFFIX_VERSION=$(echo "$VERSION" | sed -e 's/^[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*//')
-    BASE_VERSION=${VERSION%"$SUFFIX_VERSION"}
+    SUFFIX_VERSION=$(echo "$VERSION" | sed -e "s/${BASE_PATTERN}//")
+    BASE_VERSION=${VERSION%"$SUFFIX_VERSION"}0
     if [ -n "$SUFFIX_VERSION" ]; then
       VERSION=${BASE_VERSION}
       if [ -f openmldb-native/src/main/resources/libsql_jsdk.dylib ]; then
@@ -45,6 +46,8 @@ if [ -n "$VERSION" ] ; then
     echo "set version: ${VERSION}"
 
     mvn versions:set -DnewVersion="${VERSION}"
+else
+    echo "use version in pom files"
 fi
 mvn deploy -Dmaven.test.skip=true
 popd


### PR DESCRIPTION
Closes #519 
Only tags will reset the version.
Do not add MAVEN OPT user.home on macos.