### PR TITLE
feat: support multiple databases for sql_cluster_router

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -11,7 +11,7 @@ on:
 
 env:
   GIT_SUBMODULE_STRATEGY: recursive
-  HYBRIDSE_SOURCE:
+  HYBRIDSE_SOURCE: local
 
 jobs:
   build_and_cpp_ut:

--- a/hybridse/include/sdk/base.h
+++ b/hybridse/include/sdk/base.h
@@ -140,6 +140,7 @@ class ProcedureInfo {
     virtual const hybridse::sdk::Schema& GetOutputSchema() const = 0;
     virtual const std::vector<std::string>& GetTables() const = 0;
     virtual const std::string& GetMainTable() const = 0;
+    virtual const std::string& GetMainDb() const = 0;
 };
 
 }  // namespace sdk

--- a/hybridse/include/vm/engine.h
+++ b/hybridse/include/vm/engine.h
@@ -287,13 +287,14 @@ class BatchRequestRunSession : public RunSession {
 
 /// An options class for controlling runtime interpreter behavior.
 struct ExplainOutput {
-    vm::Schema input_schema;    ///< The schema of request row for request-mode query
-    std::string request_name;   ///< The name of request for request-mode query
-    std::string logical_plan;   ///< Logical plan string
-    std::string physical_plan;  ///< Physical plan string
-    std::string ir;             ///< Codegen IR String
-    vm::Schema output_schema;   ///< The schema of query result
-    vm::Router router;          ///< The Router for request-mode query
+    vm::Schema input_schema;      ///< The schema of request row for request-mode query
+    std::string request_db_name;  ///< The name of request db for request-mode query
+    std::string request_name;     ///< The name of request for request-mode query
+    std::string logical_plan;     ///< Logical plan string
+    std::string physical_plan;    ///< Physical plan string
+    std::string ir;               ///< Codegen IR String
+    vm::Schema output_schema;     ///< The schema of query result
+    vm::Router router;            ///< The Router for request-mode query
 };
 
 
@@ -337,7 +338,7 @@ class Engine {
     /// The tables' names are returned in tables
     bool GetDependentTables(const std::string& sql, const std::string& db,
                             EngineMode engine_mode,
-                            std::set<std::string>* tables,
+                            std::set<std::pair<std::string, std::string>>* db_tables,
                             base::Status& status);  // NOLINT
 
     /// \brief Explain sql compiling result.
@@ -372,7 +373,7 @@ class Engine {
     void ClearCacheLocked(const std::string& db);
 
  private:
-    bool GetDependentTables(node::PlanNode* node, std::set<std::string>* tables,
+    bool GetDependentTables(node::PlanNode* node, std::set<std::pair<std::string, std::string>>* db_tables,
                             base::Status& status);  // NOLINT
     std::shared_ptr<CompileInfo> GetCacheLocked(const std::string& db,
                                                 const std::string& sql,

--- a/hybridse/include/vm/router.h
+++ b/hybridse/include/vm/router.h
@@ -25,6 +25,12 @@ namespace vm {
 
 class Router {
  public:
+    Router() : main_db_(), main_table_(), router_col_() {}
+    ~Router() {}
+    void SetMainDb(const std::string& main_db) {
+        main_db_ = main_db;
+    }
+    const std::string& GetMainDb() const { return main_db_; }
     void SetMainTable(const std::string& main_table) {
         main_table_ = main_table;
     }
@@ -39,6 +45,7 @@ class Router {
     bool IsWindowNode(const PhysicalOpNode* physical_node);
 
  private:
+    std::string main_db_;
     std::string main_table_;
     std::string router_col_;
 };

--- a/hybridse/include/vm/simple_catalog.h
+++ b/hybridse/include/vm/simple_catalog.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef HYBRIDSE_SRC_VM_SIMPLE_CATALOG_H_
-#define HYBRIDSE_SRC_VM_SIMPLE_CATALOG_H_
+#ifndef HYBRIDSE_INCLUDE_VM_SIMPLE_CATALOG_H_
+#define HYBRIDSE_INCLUDE_VM_SIMPLE_CATALOG_H_
 
 #include <map>
 #include <memory>
@@ -109,4 +109,4 @@ class SimpleCatalog : public Catalog {
 
 }  // namespace vm
 }  // namespace hybridse
-#endif  // HYBRIDSE_SRC_VM_SIMPLE_CATALOG_H_
+#endif  // HYBRIDSE_INCLUDE_VM_SIMPLE_CATALOG_H_

--- a/hybridse/src/vm/engine_compile_test.cc
+++ b/hybridse/src/vm/engine_compile_test.cc
@@ -298,20 +298,32 @@ TEST_F(EngineCompileTest, EngineCompileOnlyTest) {
 
 TEST_F(EngineCompileTest, EngineGetDependentTableTest) {
     {
-        std::vector<std::pair<std::string, std::set<std::string>>> pairs;
+        std::vector<std::pair<std::string, std::set<std::pair<std::string, std::string>>>> pairs;
         pairs.push_back(std::make_pair("SELECT col1, col2 from t1;",
-                                       std::set<std::string>({"t1"})));
-        pairs.push_back(
-            std::make_pair("SELECT t1.COL1, t1.COL2, t2.COL1, t2.COL2 FROM t1 "
-                           "last join t2 "
-                           "order by t2.col5 on t1.col1 = t2.col2;",
-                           std::set<std::string>({"t1", "t2"})));
+                                       std::set<std::pair<std::string, std::string>>({std::make_pair("", "t1")})));
+        pairs.push_back(std::make_pair(
+            "SELECT t1.COL1, t1.COL2, t2.COL1, t2.COL2 FROM t1 "
+            "last join t2 "
+            "order by t2.col5 on t1.col1 = t2.col2;",
+            std::set<std::pair<std::string, std::string>>({std::make_pair("", "t1"), std::make_pair("", "t2")})));
 
-        pairs.push_back(
-            std::make_pair("SELECT t1.COL1, t1.COL2, t2.COL1, t2.COL2 FROM t1 "
-                           "last join t2 "
-                           "order by t2.col5 on t1.col1 = t2.col2;",
-                           std::set<std::string>({"t1", "t2"})));
+        pairs.push_back(std::make_pair(
+            "SELECT t1.COL1, t1.COL2, db2.t2.COL1, db2.t2.COL2 FROM t1 "
+            "last join db2.t2 "
+            "order by db2.t2.col5 on t1.col1 = db2.t2.col2;",
+            std::set<std::pair<std::string, std::string>>({std::make_pair("", "t1"), std::make_pair("db2", "t2")})));
+
+        pairs.push_back(std::make_pair(
+            "SELECT db1.t1.COL1, db1.t1.COL2, db2.t2.COL1, db2.t2.COL2 FROM db1.t1 "
+            "last join db2.t2 "
+            "order by db2.t2.col5 on db1.t1.col1 = db2.t2.col2;",
+            std::set<std::pair<std::string, std::string>>({std::make_pair("db1", "t1"), std::make_pair("db2", "t2")})));
+
+        pairs.push_back(std::make_pair(
+            "SELECT t1.COL1, t1.COL2, t2.COL1, t2.COL2 FROM t1 "
+            "last join t2 "
+            "order by t2.col5 on t1.col1 = t2.col2;",
+            std::set<std::pair<std::string, std::string>>({std::make_pair("", "t1"), std::make_pair("", "t2")})));
         pairs.push_back(std::make_pair(
             "SELECT t1.col1 as id, t1.col2 as t1_col2, t1.col5 as t1_col5,\n"
             "      test_sum(t1.col1) OVER w1 as w1_col1_sum, sum(t1.col3) OVER "
@@ -324,7 +336,7 @@ TEST_F(EngineCompileTest, EngineGetDependentTableTest) {
             "t1.col5 = t2.col5\n"
             "      WINDOW w1 AS (PARTITION BY t1.col2 ORDER BY t1.col5 "
             "ROWS_RANGE BETWEEN 3 PRECEDING AND CURRENT ROW) limit 10;",
-            std::set<std::string>({"t1", "t2"})));
+            std::set<std::pair<std::string, std::string>>({std::make_pair("", "t1"), std::make_pair("", "t2")})));
 
         for (auto pair : pairs) {
             base::Status get_status;
@@ -334,10 +346,14 @@ TEST_F(EngineCompileTest, EngineGetDependentTableTest) {
             boost::to_lower(sqlstr);
             LOG(INFO) << sqlstr;
             std::cout << sqlstr << std::endl;
-            std::set<std::string> tables;
-            ASSERT_TRUE(engine.GetDependentTables(
-                sqlstr, "simple_db", kBatchMode, &tables, get_status));
-            ASSERT_EQ(tables, pair.second);
+            std::set<std::pair<std::string, std::string>> tables;
+            ASSERT_TRUE(engine.GetDependentTables(sqlstr, "simple_db", kBatchMode, &tables, get_status));
+            ASSERT_EQ(tables.size(), pair.second.size());
+            for (auto iter = tables.begin(), iter2 = pair.second.begin();
+                 iter != tables.end() && iter2 != pair.second.end(); iter++, iter2++) {
+                ASSERT_EQ(iter->first, iter2->first);
+                ASSERT_EQ(iter->second, iter2->second);
+            }
         }
 
         for (auto pair : pairs) {
@@ -348,18 +364,22 @@ TEST_F(EngineCompileTest, EngineGetDependentTableTest) {
             boost::to_lower(sqlstr);
             LOG(INFO) << sqlstr;
             std::cout << sqlstr << std::endl;
-            std::set<std::string> tables;
-            ASSERT_TRUE(engine.GetDependentTables(sqlstr, "db", kRequestMode,
-                                                  &tables, get_status));
-            ASSERT_EQ(tables, pair.second);
+            std::set<std::pair<std::string, std::string>> tables;
+            ASSERT_TRUE(engine.GetDependentTables(sqlstr, "db", kRequestMode, &tables, get_status));
+            ASSERT_EQ(tables.size(), pair.second.size());
+            for (auto iter = tables.begin(), iter2 = pair.second.begin();
+                 iter != tables.end() && iter2 != pair.second.end(); iter++, iter2++) {
+                ASSERT_EQ(iter->first, iter2->first);
+                ASSERT_EQ(iter->second, iter2->second);
+            }
         }
     }
 
     // const select
     {
-        std::vector<std::pair<std::string, std::set<std::string>>> pairs;
-        pairs.push_back(std::make_pair("SELECT substr(\"hello world\", 3, 6);",
-                                       std::set<std::string>()));
+        std::vector<std::pair<std::string, std::set<std::pair<std::string, std::string>>>> pairs;
+        pairs.push_back(
+            std::make_pair("SELECT substr(\"hello world\", 3, 6);", std::set<std::pair<std::string, std::string>>()));
         for (auto pair : pairs) {
             base::Status get_status;
             EngineOptions options;
@@ -368,10 +388,14 @@ TEST_F(EngineCompileTest, EngineGetDependentTableTest) {
             boost::to_lower(sqlstr);
             LOG(INFO) << sqlstr;
             std::cout << sqlstr << std::endl;
-            std::set<std::string> tables;
-            ASSERT_TRUE(engine.GetDependentTables(
-                sqlstr, "simple_db", kBatchMode, &tables, get_status));
-            ASSERT_EQ(tables, pair.second);
+            std::set<std::pair<std::string, std::string>> tables;
+            ASSERT_TRUE(engine.GetDependentTables(sqlstr, "simple_db", kBatchMode, &tables, get_status));
+            ASSERT_EQ(tables.size(), pair.second.size());
+            for (auto iter = tables.begin(), iter2 = pair.second.begin();
+                 iter != tables.end() && iter2 != pair.second.end(); iter++, iter2++) {
+                ASSERT_EQ(iter->first, iter2->first);
+                ASSERT_EQ(iter->second, iter2->second);
+            }
         }
     }
 }

--- a/hybridse/src/vm/sql_compiler.cc
+++ b/hybridse/src/vm/sql_compiler.cc
@@ -182,6 +182,7 @@ Status SqlCompiler::BuildRequestModePhysicalPlan(SqlContext* ctx, const ::hybrid
     CHECK_TRUE(codec::SchemaCodec::Encode(transformer.request_schema(), &ctx->encoded_request_schema), kPlanError,
                "Fail to encode request schema");
     ctx->request_name = transformer.request_name();
+    ctx->request_db_name = transformer.request_db_name();
     ctx->schema = *(*output)->GetOutputSchema();
     return Status::OK();
 }
@@ -204,6 +205,7 @@ Status SqlCompiler::BuildBatchRequestModePhysicalPlan(SqlContext* ctx, const ::h
                                           &ctx->encoded_request_schema),
                kPlanError, "Fail to encode request schema");
     ctx->request_name = transformer.request_name();
+    ctx->request_db_name = transformer.request_db_name();
 
     // set batch request output schema
     const auto& output_common_indices =

--- a/hybridse/src/vm/sql_compiler.h
+++ b/hybridse/src/vm/sql_compiler.h
@@ -59,6 +59,7 @@ struct SqlContext {
     std::shared_ptr<hybridse::vm::HybridSeJitWrapper> jit = nullptr;
     Schema schema;
     Schema request_schema;
+    std::string request_db_name;
     std::string request_name;
     Schema parameter_types;
     uint32_t row_size;

--- a/hybridse/src/vm/transform.cc
+++ b/hybridse/src/vm/transform.cc
@@ -1905,6 +1905,7 @@ Status RequestModeTransformer::TransformScanOp(const node::TablePlanNode* node,
         *output = provider;
         request_schema_ = *(*output)->GetOutputSchema();
         request_name_ = table->GetName();
+        request_db_name_ = table->GetDatabase();
         return Status::OK();
     } else {
         return BatchModeTransformer::TransformScanOp(node, output);

--- a/hybridse/src/vm/transform.h
+++ b/hybridse/src/vm/transform.h
@@ -261,6 +261,7 @@ class RequestModeTransformer : public BatchModeTransformer {
 
     const Schema& request_schema() const { return request_schema_; }
     const std::string& request_name() const { return request_name_; }
+    const std::string& request_db_name() const { return request_db_name_; }
     const BatchRequestInfo& batch_request_info() const {
         return batch_request_info_;
     }
@@ -282,7 +283,8 @@ class RequestModeTransformer : public BatchModeTransformer {
  private:
     bool enable_batch_request_opt_;
     vm::Schema request_schema_;
-    std::string request_name_;
+    std::string request_name_ = "";
+    std::string request_db_name_ = "";
     BatchRequestInfo batch_request_info_;
 };
 

--- a/src/base/ddl_parser.cc
+++ b/src/base/ddl_parser.cc
@@ -406,12 +406,14 @@ bool ResolveColumnToSourceColumnName(const hybridse::node::ColumnRefNode* col, c
     size_t source_column_id;
     const PhysicalOpNode* source;
     hybridse::base::Status status =
-        schemas_ctx->ResolveColumnID(col->GetRelationName(), col->GetColumnName(), &column_id, &path_idx,
+        schemas_ctx->ResolveColumnID(col->GetDBName(), col->GetRelationName(), col->GetColumnName(), &column_id,
+                                     &path_idx,
                                      &child_column_id, &source_column_id, &source);
 
     // try loose the relation
     if (!status.isOK() && !col->GetRelationName().empty()) {
-        status = schemas_ctx->ResolveColumnID("", col->GetColumnName(), &column_id, &path_idx, &child_column_id,
+        status = schemas_ctx->ResolveColumnID("", "", col->GetColumnName(), &column_id, &path_idx,
+                                              &child_column_id,
                                               &source_column_id, &source);
     }
 

--- a/src/catalog/base.h
+++ b/src/catalog/base.h
@@ -29,14 +29,15 @@ class ProcedureInfoImpl : public hybridse::sdk::ProcedureInfo {
  public:
     ProcedureInfoImpl(const std::string& db_name, const std::string& sp_name, const std::string& sql,
                       const ::hybridse::sdk::SchemaImpl& input_schema, const ::hybridse::sdk::SchemaImpl& output_schema,
-                      const std::vector<std::string>& tables, const std::string& main_table)
+                      const std::vector<std::string>& tables, const std::string& main_table, const std::string& main_db)
         : db_name_(db_name),
           sp_name_(sp_name),
           sql_(sql),
           input_schema_(input_schema),
           output_schema_(output_schema),
           tables_(tables),
-          main_table_(main_table) {}
+          main_table_(main_table),
+          main_db_(main_db){}
 
     ~ProcedureInfoImpl() {}
 
@@ -53,6 +54,7 @@ class ProcedureInfoImpl : public hybridse::sdk::ProcedureInfo {
     const std::vector<std::string>& GetTables() const override { return tables_; }
 
     const std::string& GetMainTable() const override { return main_table_; }
+    const std::string& GetMainDb() const override { return main_db_; }
 
  private:
     std::string db_name_;
@@ -62,6 +64,7 @@ class ProcedureInfoImpl : public hybridse::sdk::ProcedureInfo {
     ::hybridse::sdk::SchemaImpl output_schema_;
     std::vector<std::string> tables_;
     std::string main_table_;
+    std::string main_db_;
 };
 
 }  // namespace catalog

--- a/src/catalog/schema_adapter.h
+++ b/src/catalog/schema_adapter.h
@@ -419,7 +419,7 @@ class SchemaAdapter {
         std::shared_ptr<openmldb::catalog::ProcedureInfoImpl> sp_info_impl =
             std::make_shared<openmldb::catalog::ProcedureInfoImpl>(sp_info.db_name(), sp_info.sp_name(), sp_info.sql(),
                                                                    input_schema, output_schema, table_vec,
-                                                                   sp_info.main_table());
+                                                                   sp_info.main_table(), sp_info.main_db());
         return sp_info_impl;
     }
 };

--- a/src/proto/sql_procedure.proto
+++ b/src/proto/sql_procedure.proto
@@ -30,7 +30,9 @@ message ProcedureInfo {
     repeated openmldb.common.ColumnDesc input_schema = 4;
     repeated openmldb.common.ColumnDesc output_schema = 5;
     optional string main_table = 6;
-    repeated string tables = 7; // dependent tables
+    optional string main_db = 7;
+    repeated string tables = 8; // dependent tables
+    repeated string dbs = 9; // dependent dbs
 }
 
 message CreateProcedureRequest {

--- a/src/sdk/sql_cluster_router.h
+++ b/src/sdk/sql_cluster_router.h
@@ -178,11 +178,12 @@ class SQLClusterRouter : public SQLRouter {
         const std::string& db, const std::string& sp_name, int64_t timeout_ms,
         std::shared_ptr<SQLRequestRowBatch> row_batch, hybridse::sdk::Status* status);
 
+    std::shared_ptr<::openmldb::client::TabletClient> GetTabletClient(const std::string& db, const std::string& sql,
+                                                                      const ::hybridse::vm::EngineMode engine_mode,
+                                                                      const std::shared_ptr<SQLRequestRow>& row);
     std::shared_ptr<::openmldb::client::TabletClient> GetTabletClient(
-        const std::string& db, const std::string& sql, const std::shared_ptr<SQLRequestRow>& row);
-    std::shared_ptr<::openmldb::client::TabletClient> GetTabletClient(
-        const std::string& db, const std::string& sql, const std::shared_ptr<SQLRequestRow>& row,
-        const std::shared_ptr<SQLRequestRow>& parameter_row);
+        const std::string& db, const std::string& sql, const ::hybridse::vm::EngineMode engine_mode,
+        const std::shared_ptr<SQLRequestRow>& row, const std::shared_ptr<SQLRequestRow>& parameter_row);
 
  private:
     void GetTables(::hybridse::vm::PhysicalOpNode* node, std::set<std::string>* tables);

--- a/src/sdk/sql_cluster_test.cc
+++ b/src/sdk/sql_cluster_test.cc
@@ -143,7 +143,7 @@ TEST_F(SQLSDKQueryTest, GetTabletClient) {
         request_row->AppendInt64(3);
         ASSERT_TRUE(request_row->Build());
         auto sql_cluster_router = std::dynamic_pointer_cast<SQLClusterRouter>(router);
-        auto client = sql_cluster_router->GetTabletClient(db, sql, request_row);
+        auto client = sql_cluster_router->GetTabletClient(db, sql, hybridse::vm::kRequestMode, request_row);
         int pid = ::openmldb::base::hash64(pk) % 2;
         ASSERT_EQ(client->GetEndpoint(), tables[0].table_partition(pid).partition_meta(0).endpoint());
     }

--- a/src/sdk/sql_router.h
+++ b/src/sdk/sql_router.h
@@ -49,6 +49,7 @@ class ExplainInfo {
     virtual const std::string& GetPhysicalPlan() = 0;
     virtual const std::string& GetIR() = 0;
     virtual const std::string& GetRequestName() = 0;
+    virtual const std::string& GetRequestDbName() = 0;
 };
 
 class QueryFuture {

--- a/src/sdk/sql_sdk_test.h
+++ b/src/sdk/sql_sdk_test.h
@@ -132,20 +132,32 @@ class SQLSDKBatchRequestQueryTest : public SQLSDKQueryTest {
 
 void SQLSDKTest::CreateDB(hybridse::sqlcase::SqlCase& sql_case,  // NOLINT
                           std::shared_ptr<SQLRouter> router) {
+    std::unordered_set<std::string> input_dbs;
     if (sql_case.db().empty()) {
         sql_case.db_ = hybridse::sqlcase::SqlCase::GenRand("auto_db") + std::to_string((int64_t)time(NULL));
     }
-    DLOG(INFO) << "Create DB " << sql_case.db_ << " BEGIN";
+    input_dbs.insert(sql_case.db_);
+
+    for(int i = 0 ; i < sql_case.inputs_.size(); i++) {
+        if (!sql_case.inputs_[i].db_.empty()) {
+            input_dbs.insert(sql_case.inputs_[i].db_);
+        }
+    }
     hybridse::sdk::Status status;
     std::vector<std::string> dbs;
     ASSERT_TRUE(router->ShowDB(&dbs, &status));
 
     // create db if not exist
     std::set<std::string> db_set(dbs.begin(), dbs.end());
-    if (db_set.find(sql_case.db()) == db_set.cend()) {
-        ASSERT_TRUE(router->CreateDB(sql_case.db(), &status));
+    for(auto iter = input_dbs.begin(); iter != input_dbs.end(); iter++) {
+        auto db_name = *iter;
+        DLOG(INFO) << "Create DB " << db_name << " BEGIN";
+        if (db_set.find(db_name) == db_set.cend()) {
+            ASSERT_TRUE(router->CreateDB(db_name, &status));
+        }
+        DLOG(INFO) << "Create DB DONE!";
     }
-    DLOG(INFO) << "Create DB DONE!";
+
 }
 
 void SQLSDKTest::CreateTables(hybridse::sqlcase::SqlCase& sql_case,  // NOLINT
@@ -158,6 +170,7 @@ void SQLSDKTest::CreateTables(hybridse::sqlcase::SqlCase& sql_case,  // NOLINT
             sql_case.set_input_name(hybridse::sqlcase::SqlCase::GenRand("auto_t") + std::to_string((int64_t)time(NULL)),
                                     i);
         }
+        std::string input_db_name = sql_case.inputs_[i].db_.empty() ? sql_case.db() : sql_case.inputs_[i].db_;
         // create table
         std::string create;
         ASSERT_TRUE(sql_case.BuildCreateSqlFromInput(i, &create, partition_num));
@@ -165,7 +178,7 @@ void SQLSDKTest::CreateTables(hybridse::sqlcase::SqlCase& sql_case,  // NOLINT
         boost::replace_all(create, placeholder, sql_case.inputs()[i].name_);
         LOG(INFO) << create;
         if (!create.empty()) {
-            router->ExecuteDDL(sql_case.db(), create, &status);
+            router->ExecuteDDL(input_db_name, create, &status);
             ASSERT_TRUE(router->RefreshCatalog());
             ASSERT_TRUE(status.code == 0) << status.msg;
         }
@@ -184,10 +197,11 @@ void SQLSDKTest::DropTables(hybridse::sqlcase::SqlCase& sql_case,  // NOLINT
             continue;
         }
         // create table
+        std::string db_name = sql_case.inputs_[i].db_.empty() ? sql_case.db_ : sql_case.inputs_[i].db_;
         std::string drop = "drop table " + sql_case.inputs()[i].name_ + ";";
         LOG(INFO) << drop;
         if (!drop.empty()) {
-            router->ExecuteDDL(sql_case.db(), drop, &status);
+            router->ExecuteDDL(db_name, drop, &status);
             ASSERT_TRUE(router->RefreshCatalog());
         }
     }
@@ -295,6 +309,7 @@ void SQLSDKTest::InsertTables(hybridse::sqlcase::SqlCase& sql_case,  // NOLINT
             continue;
         }
 
+        std::string db_name = sql_case.inputs_[i].db_.empty() ? sql_case.db_ : sql_case.inputs_[i].db_;
         // insert into table
         std::vector<std::string> inserts;
         ASSERT_TRUE(sql_case.BuildInsertSqlListFromInput(i, &inserts));
@@ -308,7 +323,7 @@ void SQLSDKTest::InsertTables(hybridse::sqlcase::SqlCase& sql_case,  // NOLINT
             DLOG(INFO) << insert;
             if (!insert.empty()) {
                 for (int j = 0; j < sql_case.inputs()[i].repeat_; j++) {
-                    ASSERT_TRUE(router->ExecuteInsert(sql_case.db(), insert, &status)) << status.msg;
+                    ASSERT_TRUE(router->ExecuteInsert(db_name, insert, &status)) << status.msg;
                     ASSERT_TRUE(router->RefreshCatalog());
                 }
             }
@@ -531,7 +546,7 @@ void SQLSDKQueryTest::RequestExecuteSQL(hybridse::sqlcase::SqlCase& sql_case,  /
             results.push_back(rs);
             if (!has_batch_request) {
                 LOG(INFO) << "insert request: \n" << inserts[i];
-                bool ok = router->ExecuteInsert(sql_case.db(), inserts[i], &status);
+                bool ok = router->ExecuteInsert(insert_table.catalog(), inserts[i], &status);
                 ASSERT_TRUE(ok);
             }
         }
@@ -902,8 +917,10 @@ INSTANTIATE_TEST_SUITE_P(
     testing::ValuesIn(SQLSDKQueryTest::InitCases("/cases/function/select/test_sub_select.yaml")));
 INSTANTIATE_TEST_SUITE_P(SQLSDKTestWhere, SQLSDKQueryTest,
                          testing::ValuesIn(SQLSDKQueryTest::InitCases("/cases/function/select/test_where.yaml")));
-
-
+// Test Multiple Databases
+INSTANTIATE_TEST_SUITE_P(
+    SQLSDKTestMultipleDatabases, SQLSDKQueryTest,
+    testing::ValuesIn(SQLSDKQueryTest::InitCases("/cases/function/multiple_databases/test_multiple_databases.yaml")));
 // Test Window
 INSTANTIATE_TEST_SUITE_P(
     SQLSDKTestErrorWindow, SQLSDKQueryTest,


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- The commit message follows our guidelines
- Tests for the changes have been added (for bug fixes / features)
- Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)
#476 

* **What is the new behavior (if this is a feature change)?**
1. sql router support multiple databases. GetTablets base on table and db name
2. SpInfo add main_db field. GetTablet for procedure
3. GetDependentTables will ouput <db_name, table_name> pair sets.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
