### PR TITLE
style: enforece cpp style convention in hybridse

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -11,7 +11,7 @@ on:
 
 env:
   GIT_SUBMODULE_STRATEGY: recursive
-  HYBRIDSE_SOURCE:
+  HYBRIDSE_SOURCE: local
 
 jobs:
   build_and_cpp_ut:

--- a/hybridse/examples/toydb/src/bm/engine_bm_case.cc
+++ b/hybridse/examples/toydb/src/bm/engine_bm_case.cc
@@ -109,7 +109,7 @@ static void EngineRequestMode(const std::string sql, MODE mode,
     auto catalog = vm::BuildOnePkTableStorage(size);
     vm::EngineOptions options;
     if (hybridse::sqlcase::SqlCase::IsCluster()) {
-        options.set_cluster_optimized(true);
+        options.SetClusterOptimized(true);
     }
     Engine engine(catalog, options);
     RequestRunSession session;
@@ -827,18 +827,18 @@ void EngineBenchmarkOnCase(hybridse::sqlcase::SqlCase& sql_case,  // NOLINT
 
     vm::EngineOptions engine_options;
     if (engine_mode == vm::kBatchRequestMode) {
-        engine_options.set_batch_request_optimized(
+        engine_options.SetBatchRequestOptimized(
             sql_case.batch_request_optimized_);
     }
     if (hybridse::sqlcase::SqlCase::IsCluster()) {
-        engine_options.set_cluster_optimized(true);
+        engine_options.SetClusterOptimized(true);
     } else {
-        engine_options.set_cluster_optimized(false);
+        engine_options.SetClusterOptimized(false);
     }
     if (hybridse::sqlcase::SqlCase::IsDisableExprOpt()) {
-        engine_options.set_enable_expr_optimize(false);
+        engine_options.SetEnableExprOptimize(false);
     } else {
-        engine_options.set_enable_expr_optimize(true);
+        engine_options.SetEnableExprOptimize(true);
     }
     std::unique_ptr<vm::EngineTestRunner> engine_runner;
     if (engine_mode == vm::kBatchMode) {

--- a/hybridse/examples/toydb/src/cmd/toydb_run_engine.cc
+++ b/hybridse/examples/toydb/src/cmd/toydb_run_engine.cc
@@ -71,18 +71,18 @@ int RunSingle(const std::string& yaml_path) {
         return ENGINE_TEST_RET_INVALID_CASE;
     }
     EngineOptions options;
-    options.set_cluster_optimized(FLAGS_cluster_mode == "cluster");
-    options.set_batch_request_optimized(FLAGS_enable_batch_request_opt);
-    options.set_performance_sensitive(FLAGS_performance_sensitive);
-    options.set_enable_expr_optimize(FLAGS_enable_expr_opt);
-    options.set_enable_batch_window_parallelization(
+    options.SetClusterOptimized(FLAGS_cluster_mode == "cluster");
+    options.SetBatchRequestOptimized(FLAGS_enable_batch_request_opt);
+    options.SetPerformanceSensitive(FLAGS_performance_sensitive);
+    options.SetEnableExprOptimize(FLAGS_enable_expr_opt);
+    options.SetEnableBatchWindowParallelization(
         FLAGS_enable_batch_window_parallelization);
 
     JitOptions& jit_options = options.jit_options();
-    jit_options.set_enable_mcjit(FLAGS_enable_mcjit);
-    jit_options.set_enable_vtune(FLAGS_enable_vtune);
-    jit_options.set_enable_gdb(FLAGS_enable_gdb);
-    jit_options.set_enable_perf(FLAGS_enable_perf);
+    jit_options.SetEnableMCJIT(FLAGS_enable_mcjit);
+    jit_options.SetEnableVTune(FLAGS_enable_vtune);
+    jit_options.SetEnableGDB(FLAGS_enable_gdb);
+    jit_options.SetEnablePerf(FLAGS_enable_perf);
 
     for (auto& sql_case : cases) {
         if (FLAGS_case_id >= 0 &&

--- a/hybridse/examples/toydb/src/testing/toydb_engine_test.cc
+++ b/hybridse/examples/toydb/src/testing/toydb_engine_test.cc
@@ -61,7 +61,7 @@ TEST_P(EngineTest, TestBatchRequestEngineForLastRow) {
 TEST_P(EngineTest, TestClusterRequestEngine) {
     ParamType sql_case = GetParam();
     EngineOptions options;
-    options.set_cluster_optimized(true);
+    options.SetClusterOptimized(true);
     LOG(INFO) << "ID: " << sql_case.id() << ", DESC: " << sql_case.desc();
     if (!boost::contains(sql_case.mode(), "request-unsupport") &&
         !boost::contains(sql_case.mode(), "rtidb-unsupport") &&
@@ -74,7 +74,7 @@ TEST_P(EngineTest, TestClusterRequestEngine) {
 TEST_P(EngineTest, TestClusterBatchRequestEngine) {
     ParamType sql_case = GetParam();
     EngineOptions options;
-    options.set_cluster_optimized(true);
+    options.SetClusterOptimized(true);
     LOG(INFO) << "ID: " << sql_case.id() << ", DESC: " << sql_case.desc();
     if (!boost::contains(sql_case.mode(), "request-unsupport") &&
         !boost::contains(sql_case.mode(), "rtidb-unsupport") &&
@@ -90,7 +90,7 @@ TEST_P(BatchRequestEngineTest, TestBatchRequestEngine) {
     ParamType sql_case = GetParam();
     LOG(INFO) << "ID: " << sql_case.id() << ", DESC: " << sql_case.desc();
     EngineOptions options;
-    options.set_cluster_optimized(false);
+    options.SetClusterOptimized(false);
     if (!boost::contains(sql_case.mode(), "batch-request-unsupport")) {
         EngineCheck(sql_case, options, kBatchRequestMode);
     } else {
@@ -101,7 +101,7 @@ TEST_P(BatchRequestEngineTest, TestClusterBatchRequestEngine) {
     ParamType sql_case = GetParam();
     LOG(INFO) << "ID: " << sql_case.id() << ", DESC: " << sql_case.desc();
     EngineOptions options;
-    options.set_cluster_optimized(true);
+    options.SetClusterOptimized(true);
     if (!boost::contains(sql_case.mode(), "batch-request-unsupport") &&
         !boost::contains(sql_case.mode(), "cluster-unsupport")) {
         EngineCheck(sql_case, options, kBatchRequestMode);

--- a/hybridse/examples/toydb/src/testing/toydb_engine_test_base.cc
+++ b/hybridse/examples/toydb/src/testing/toydb_engine_test_base.cc
@@ -86,7 +86,7 @@ bool InitToydbEngineCatalog(
             return false;
         }
         name_table_map[table_def.name()] = table;
-        if (engine_options.is_cluster_optimzied()) {
+        if (engine_options.IsClusterOptimzied()) {
             // add table with local tablet
             if (!AddTable(catalog, table_def, table, engine.get())) {
                 return false;

--- a/hybridse/include/vm/engine.h
+++ b/hybridse/include/vm/engine.h
@@ -47,81 +47,81 @@ class EngineOptions {
     EngineOptions();
 
     /// Set `true` to enable storing ir results into SqlContext, default `false`.
-    inline void set_keep_ir(bool flag) { this->keep_ir_ = flag; }
+    inline void SetKeepIR(bool flag) { this->keep_ir_ = flag; }
     /// Return if support to store ir results into SqlContext.
-    inline bool is_keep_ir() const { return this->keep_ir_; }
+    inline bool IsKeepIR() const { return this->keep_ir_; }
 
     /// Set `true` if only support to compile SQL, default `false`
     ///
     /// If set `true`, the engine won't generate runner plan as well.
-    inline void set_compile_only(bool flag) { this->compile_only_ = flag; }
+    inline void SetCompileOnly(bool flag) { this->compile_only_ = flag; }
     /// Return if only support to compile physical plan.
-    inline bool is_compile_only() const { return compile_only_; }
+    inline bool IsCompileOnly() const { return compile_only_; }
 
 
     /// Set `true` if the engine only generate physical plan, default `false`.
     ///
     /// If set `true`, the engine won't build llvm jit.
-    inline void set_plan_only(bool flag) { plan_only_ = flag; }
+    inline void SetPlanOnly(bool flag) { plan_only_ = flag; }
     /// Return `true` if the engine only generate physical plan.
-    inline bool is_plan_only() const { return plan_only_; }
+    inline bool IsPlanOnly() const { return plan_only_; }
 
     /// Set `true` if the engine is performance sensitive, default `true`.
     ///
     /// Normally, the engine can support more abilities under performance un-sensitive mode.
-    inline void set_performance_sensitive(bool flag) {
+    inline void SetPerformanceSensitive(bool flag) {
         performance_sensitive_ = flag;
     }
     /// Return `true` if the engine is performance sensitive.
-    inline bool is_performance_sensitive() const {
+    inline bool IsPerformanceSensitive() const {
         return performance_sensitive_;
     }
 
     /// Set `true` to enable cluster optimization, default `false`
-    inline EngineOptions* set_cluster_optimized(bool flag) {
+    inline EngineOptions* SetClusterOptimized(bool flag) {
         cluster_optimized_ = flag;
         return this;
     }
     /// Return if the engine support cluster optimization.
-    inline bool is_cluster_optimzied() const { return cluster_optimized_; }
+    inline bool IsClusterOptimzied() const { return cluster_optimized_; }
 
     /// Set `true` to enable batch request optimization, default `true`.
-    inline EngineOptions* set_batch_request_optimized(bool flag) {
+    inline EngineOptions* SetBatchRequestOptimized(bool flag) {
         batch_request_optimized_ = flag;
         return this;
     }
     /// Return if the engine support batch request optimization.
-    inline bool is_batch_request_optimized() const { return batch_request_optimized_; }
+    inline bool IsBatchRequestOptimized() const { return batch_request_optimized_; }
 
     /// Set `true` to enable expression optimization, default `true`.
-    inline EngineOptions* set_enable_expr_optimize(bool flag) {
+    inline EngineOptions* SetEnableExprOptimize(bool flag) {
         enable_expr_optimize_ = flag;
         return this;
     }
     /// Return if the engine support expression optimization
-    inline bool is_enable_expr_optimize() const { return enable_expr_optimize_; }
+    inline bool IsEnableExprOptimize() const { return enable_expr_optimize_; }
 
     /// Set `true` to enable batch window parallelization, default `false`.
-    inline EngineOptions* set_enable_batch_window_parallelization(bool flag) {
+    inline EngineOptions* SetEnableBatchWindowParallelization(bool flag) {
         enable_batch_window_parallelization_ = flag;
         return this;
     }
     /// Return if the engine support batch window parallelization.
-    inline bool is_enable_batch_window_parallelization() const {
+    inline bool IsEnableBatchWindowParallelization() const {
         return enable_batch_window_parallelization_;
     }
 
     /// Set the maximum number of cache entries, default is `50`.
-    inline void set_max_sql_cache_size(uint32_t size) {
+    inline void SetMaxSQLCacheSize(uint32_t size) {
         max_sql_cache_size_ = size;
     }
     /// Return the maximum number of entries we can hold for compiling cache.
-    inline uint32_t max_sql_cache_size() const { return max_sql_cache_size_; }
+    inline uint32_t GetMaxSQLCacheSize() const { return max_sql_cache_size_; }
 
     /// Set `true` to enable spark unsafe row format, default `false`.
-    EngineOptions* set_enable_spark_unsaferow_format(bool flag);
+    EngineOptions* SetEnableSparkUnsaferowFormat(bool flag);
     /// Return if the engine can support can support spark unsafe row format.
-    inline bool is_enable_spark_unsaferow_format() const {
+    inline bool IsEnableSparkUnsaferowFormat() const {
         return enable_spark_unsaferow_format_;
     }
 

--- a/hybridse/include/vm/engine_context.h
+++ b/hybridse/include/vm/engine_context.h
@@ -82,17 +82,17 @@ class CompileInfoCache {
 
 class JitOptions {
  public:
-    bool is_enable_mcjit() const { return enable_mcjit_; }
-    void set_enable_mcjit(bool flag) { enable_mcjit_ = flag; }
+    bool IsEnableMCJIT() const { return enable_mcjit_; }
+    void SetEnableMCJIT(bool flag) { enable_mcjit_ = flag; }
 
-    bool is_enable_vtune() const { return enable_vtune_; }
-    void set_enable_vtune(bool flag) { enable_vtune_ = flag; }
+    bool IsEnableVTune() const { return enable_vtune_; }
+    void SetEnableVTune(bool flag) { enable_vtune_ = flag; }
 
-    bool is_enable_gdb() const { return enable_gdb_; }
-    void set_enable_gdb(bool flag) { enable_gdb_ = flag; }
+    bool IsEnableGDB() const { return enable_gdb_; }
+    void SetEnableGDB(bool flag) { enable_gdb_ = flag; }
 
-    bool is_enable_perf() const { return enable_perf_; }
-    void set_enable_perf(bool flag) { enable_perf_ = flag; }
+    bool IsEnablePerf() const { return enable_perf_; }
+    void SetEnablePerf(bool flag) { enable_perf_ = flag; }
 
  private:
     bool enable_mcjit_ = false;

--- a/hybridse/java/hybridse-sdk/src/main/java/com/_4paradigm/hybridse/sdk/JitManager.java
+++ b/hybridse/java/hybridse-sdk/src/main/java/com/_4paradigm/hybridse/sdk/JitManager.java
@@ -70,22 +70,22 @@ public class JitManager {
             String enableMcJit = prop.getProperty("fesql.jit.enable_mcjit");
             if (enableMcJit != null && enableMcJit.toLowerCase().equals("true")) {
                 logger.info("Try enable llvm legacy mcjit support");
-                options.set_enable_mcjit(true);
+                options.SetEnableMCJIT(true);
             }
             String enableVtune = prop.getProperty("fesql.jit.enable_vtune");
             if (enableVtune != null && enableVtune.toLowerCase().equals("true")) {
                 logger.info("Try enable intel jit events support");
-                options.set_enable_vtune(true);
+                options.SetEnableVTune(true);
             }
             String enablePerf = prop.getProperty("fesql.jit.enable_perf");
             if (enablePerf != null && enablePerf.toLowerCase().equals("true")) {
                 logger.info("Try enable perf jit events support");
-                options.set_enable_perf(true);
+                options.SetEnablePerf(true);
             }
             String enableGdb = prop.getProperty("fesql.jit.enable_gdb");
             if (enableGdb != null && enableGdb.toLowerCase().equals("true")) {
                 logger.info("Try enable gdb jit events support");
-                options.set_enable_gdb(true);
+                options.SetEnableGDB(true);
             }
         } catch (IOException ex) {
             logger.debug("Can not find jit.properties", ex);

--- a/hybridse/java/hybridse-sdk/src/main/java/com/_4paradigm/hybridse/sdk/RequestEngine.java
+++ b/hybridse/java/hybridse-sdk/src/main/java/com/_4paradigm/hybridse/sdk/RequestEngine.java
@@ -51,9 +51,9 @@ public class RequestEngine implements AutoCloseable {
      */
     public RequestEngine(String sql, TypeOuterClass.Database database) throws UnsupportedHybridSeException {
         options = new EngineOptions();
-        options.set_keep_ir(true);
-        options.set_compile_only(true);
-        options.set_performance_sensitive(false);
+        options.SetKeepIR(true);
+        options.SetCompileOnly(true);
+        options.SetPerformanceSensitive(false);
         catalog = new SimpleCatalog();
         session = new RequestRunSession();
         catalog.AddDatabase(database);

--- a/hybridse/java/hybridse-sdk/src/main/java/com/_4paradigm/hybridse/sdk/SqlEngine.java
+++ b/hybridse/java/hybridse-sdk/src/main/java/com/_4paradigm/hybridse/sdk/SqlEngine.java
@@ -99,9 +99,9 @@ public class SqlEngine implements AutoCloseable {
      */
     public static EngineOptions createDefaultEngineOptions() {
         EngineOptions engineOptions = new EngineOptions();
-        engineOptions.set_keep_ir(true);
-        engineOptions.set_compile_only(true);
-        engineOptions.set_performance_sensitive(false);
+        engineOptions.SetKeepIR(true);
+        engineOptions.SetCompileOnly(true);
+        engineOptions.SetPerformanceSensitive(false);
         return engineOptions;
     }
 

--- a/hybridse/java/hybridse-sdk/src/test/java/com/_4paradigm/hybridse/sdk/SqlEngineTest.java
+++ b/hybridse/java/hybridse-sdk/src/test/java/com/_4paradigm/hybridse/sdk/SqlEngineTest.java
@@ -149,7 +149,7 @@ public class SqlEngineTest {
         }
         try {
             EngineOptions options = createDefaultEngineOptions();
-            options.set_enable_batch_window_parallelization(true);
+            options.SetEnableBatchWindowParallelization(true);
             SqlEngine engine = new SqlEngine(sql, db.build(), options);
             Assert.assertNotNull(engine.getPlan());
         } catch (UnsupportedHybridSeException e) {
@@ -231,7 +231,7 @@ public class SqlEngineTest {
         }
         try {
             EngineOptions options = createDefaultEngineOptions();
-            options.set_enable_batch_window_parallelization(true);
+            options.SetEnableBatchWindowParallelization(true);
             SqlEngine engine = new SqlEngine(sql, Lists.newArrayList(db.build(), db2.build()),
                     options, defaultDbName);
             Assert.assertNotNull(engine.getPlan());
@@ -324,7 +324,7 @@ public class SqlEngineTest {
         }
         try {
             EngineOptions options = createDefaultEngineOptions();
-            options.set_enable_batch_window_parallelization(true);
+            options.SetEnableBatchWindowParallelization(true);
             SqlEngine engine = new SqlEngine(sql,
                     Lists.newArrayList(db.build(), db2.build()), options, defaultDbName);
             Assert.assertNull(engine.getPlan());

--- a/hybridse/src/passes/physical/batch_request_optimize_test.cc
+++ b/hybridse/src/passes/physical/batch_request_optimize_test.cc
@@ -148,7 +148,7 @@ void CheckOptimizePlan(const SqlCase& sql_case_org,
     auto catalog = std::make_shared<SimpleCatalog>();
     InitSimpleCataLogFromSqlCase(sql_case, catalog);
     EngineOptions options;
-    options.set_compile_only(true);
+    options.SetCompileOnly(true);
     auto engine = std::make_shared<vm::Engine>(catalog, options);
     std::string sql_str = sql_case.sql_str();
     for (int j = 0; j < sql_case.CountInputs(); ++j) {

--- a/hybridse/src/testing/engine_test_base.cc
+++ b/hybridse/src/testing/engine_test_base.cc
@@ -433,9 +433,9 @@ void EngineTestRunner::RunCheck() {
     if (!sql_case_.batch_plan().empty() && engine_mode == kBatchMode) {
         ASSERT_EQ(oss.str(), sql_case_.batch_plan());
     } else if (!sql_case_.cluster_request_plan().empty() && engine_mode == kRequestMode &&
-               options_.is_cluster_optimzied()) {
+               options_.IsClusterOptimzied()) {
         ASSERT_EQ(oss.str(), sql_case_.cluster_request_plan());
-    } else if (!sql_case_.request_plan().empty() && engine_mode == kRequestMode && !options_.is_cluster_optimzied()) {
+    } else if (!sql_case_.request_plan().empty() && engine_mode == kRequestMode && !options_.IsClusterOptimzied()) {
         ASSERT_EQ(oss.str(), sql_case_.request_plan());
     }
     status = PrepareData();

--- a/hybridse/src/testing/engine_test_base.h
+++ b/hybridse/src/testing/engine_test_base.h
@@ -359,7 +359,7 @@ class BatchRequestEngineTestRunner : public EngineTestRunner {
         size_t request_schema_size = static_cast<size_t>(request_schema.size());
         if (common_column_indices.empty() ||
             common_column_indices.size() == request_schema_size ||
-            !options_.is_batch_request_optimized()) {
+            !options_.IsBatchRequestOptimized()) {
             request_rows_ = original_request_data;
         } else {
             std::vector<size_t> non_common_column_indices;

--- a/hybridse/src/vm/engine_compile_test.cc
+++ b/hybridse/src/vm/engine_compile_test.cc
@@ -58,8 +58,8 @@ TEST_F(EngineCompileTest, EngineLRUCacheTest) {
 
     // Simple Engine
     EngineOptions options;
-    options.set_compile_only(true);
-    options.set_max_sql_cache_size(1);
+    options.SetCompileOnly(true);
+    options.SetMaxSQLCacheSize(1);
     Engine engine(catalog, options);
 
     std::string sql = "select col1, col2 from t1;";
@@ -104,8 +104,8 @@ TEST_F(EngineCompileTest, EngineWithParameterizedLRUCacheTest) {
 
     // Simple Engine
     EngineOptions options;
-    options.set_compile_only(true);
-    options.set_max_sql_cache_size(1);
+    options.SetCompileOnly(true);
+    options.SetMaxSQLCacheSize(1);
     Engine engine(catalog, options);
 
     hybridse::codec::Schema parameter_schema;
@@ -189,7 +189,7 @@ TEST_F(EngineCompileTest, EngineEmptyDefaultDBLRUCacheTest) {
     }
 
     EngineOptions options;
-    options.set_performance_sensitive(false);
+    options.SetPerformanceSensitive(false);
     Engine engine(catalog, options);
     std::string sql =
         "select db1.t1.col1, db1.t1.col2,db2.t2.col3,db2.t2.col4 from db1.t1 last join db2.t2 ORDER BY db2.t2.col5 "
@@ -259,8 +259,8 @@ TEST_F(EngineCompileTest, EngineCompileOnlyTest) {
             "SELECT t1.COL1, t1.COL2, t2.COL1, t2.COL2 FROM t1 last join t2 "
             "order by t2.col5 on t1.col1 = t2.col2;"};
         EngineOptions options;
-        options.set_compile_only(true);
-        options.set_performance_sensitive(false);
+        options.SetCompileOnly(true);
+        options.SetPerformanceSensitive(false);
         Engine engine(catalog, options);
         base::Status get_status;
         for (auto sqlstr : sql_str_list) {
@@ -282,7 +282,7 @@ TEST_F(EngineCompileTest, EngineCompileOnlyTest) {
             "on "
             "t1.col1 = t2.col2;"};
         EngineOptions options;
-        options.set_performance_sensitive(false);
+        options.SetPerformanceSensitive(false);
         Engine engine(catalog, options);
         base::Status get_status;
         for (auto sqlstr : sql_str_list) {
@@ -406,8 +406,8 @@ TEST_F(EngineCompileTest, RouterTest) {
             "window w1 as (partition by col2 \n"
             "order by col5 rows between 3 preceding and current row);";
         EngineOptions options;
-        options.set_compile_only(true);
-        options.set_performance_sensitive(false);
+        options.SetCompileOnly(true);
+        options.SetPerformanceSensitive(false);
         Engine engine(catalog, options);
         ExplainOutput explain_output;
         codec::Schema empty_parameter_schema;
@@ -451,8 +451,8 @@ TEST_F(EngineCompileTest, ExplainBatchRequestTest) {
         "window w1 as (partition by col2 \n"
         "order by col5 rows between 3 preceding and current row);";
     EngineOptions options;
-    options.set_compile_only(true);
-    options.set_performance_sensitive(false);
+    options.SetCompileOnly(true);
+    options.SetPerformanceSensitive(false);
     Engine engine(catalog, options);
     ExplainOutput explain_output;
     base::Status status;
@@ -509,7 +509,7 @@ TEST_F(EngineCompileTest, EngineCompileWithoutDefaultDBTest) {
             "select db1.t1.col1, db1.t1.col2,db2.t2.col3,db2.t2.col4 from db1.t1 last join db2.t2 ORDER BY db2.t2.col5 "
             "on db1.t1.col1=db2.t2.col1;"};
         EngineOptions options;
-        options.set_performance_sensitive(false);
+        options.SetPerformanceSensitive(false);
         Engine engine(catalog, options);
         base::Status get_status;
         for (auto sqlstr : sql_str_list) {

--- a/hybridse/src/vm/jit.cc
+++ b/hybridse/src/vm/jit.cc
@@ -253,7 +253,7 @@ bool HybridSeMcJitWrapper::AddModule(
     } else {
         execution_engine_->addModule(std::move(module));
     }
-    if (jit_options_.is_enable_vtune()) {
+    if (jit_options_.IsEnableVTune()) {
         auto listener = ::llvm::JITEventListener::createIntelJITEventListener();
         if (listener == nullptr) {
             LOG(WARNING) << "Intel jit events is not enabled";
@@ -261,7 +261,7 @@ bool HybridSeMcJitWrapper::AddModule(
             execution_engine_->RegisterJITEventListener(listener);
         }
     }
-    if (jit_options_.is_enable_gdb()) {
+    if (jit_options_.IsEnableGDB()) {
         auto listener =
             ::llvm::JITEventListener::createGDBRegistrationListener();
         if (listener == nullptr) {
@@ -276,7 +276,7 @@ bool HybridSeMcJitWrapper::AddModule(
 #endif
         }
     }
-    if (jit_options_.is_enable_perf()) {
+    if (jit_options_.IsEnablePerf()) {
         auto listener = ::llvm::JITEventListener::createPerfJITEventListener();
         if (listener == nullptr) {
             LOG(WARNING) << "Perf jit events is not enabled";

--- a/hybridse/src/vm/jit_wrapper.cc
+++ b/hybridse/src/vm/jit_wrapper.cc
@@ -70,7 +70,7 @@ HybridSeJitWrapper* HybridSeJitWrapper::Create() {
 }
 
 HybridSeJitWrapper* HybridSeJitWrapper::Create(const JitOptions& jit_options) {
-    if (jit_options.is_enable_mcjit()) {
+    if (jit_options.IsEnableMCJIT()) {
 #ifdef LLVM_EXT_ENABLE
         LOG(INFO) << "Create McJit engine";
         return new HybridSeMcJitWrapper(jit_options);
@@ -79,8 +79,8 @@ HybridSeJitWrapper* HybridSeJitWrapper::Create(const JitOptions& jit_options) {
         return new HybridSeLlvmJitWrapper();
 #endif
     } else {
-        if (jit_options.is_enable_vtune() || jit_options.is_enable_perf() ||
-            jit_options.is_enable_gdb()) {
+        if (jit_options.IsEnableVTune() || jit_options.IsEnablePerf() ||
+            jit_options.IsEnableGDB()) {
             LOG(WARNING) << "LLJIT do not support jit events";
         }
         return new HybridSeLlvmJitWrapper();

--- a/hybridse/src/vm/jit_wrapper_test.cc
+++ b/hybridse/src/vm/jit_wrapper_test.cc
@@ -101,26 +101,26 @@ void simple_test(const EngineOptions &options) {
 
 TEST_F(JitWrapperTest, test) {
     EngineOptions options;
-    options.set_keep_ir(true);
+    options.SetKeepIR(true);
     simple_test(options);
 }
 
 #ifdef LLVM_EXT_ENABLE
 TEST_F(JitWrapperTest, test_mcjit) {
     EngineOptions options;
-    options.set_keep_ir(true);
-    options.jit_options().set_enable_mcjit(true);
-    options.jit_options().set_enable_gdb(true);
-    options.jit_options().set_enable_perf(true);
-    options.jit_options().set_enable_vtune(true);
+    options.SetKeepIR(true);
+    options.jit_options().SetEnableMCJIT(true);
+    options.jit_options().SetEnableGDB(true);
+    options.jit_options().SetEnablePerf(true);
+    options.jit_options().SetEnableVTune(true);
     simple_test(options);
 }
 #endif
 
 TEST_F(JitWrapperTest, test_window) {
     EngineOptions options;
-    options.set_keep_ir(true);
-    options.set_performance_sensitive(false);
+    options.SetKeepIR(true);
+    options.SetPerformanceSensitive(false);
     auto catalog = GetTestCatalog();
     auto compile_info = Compile(
         "select col_1, sum(col_2) over w, "

--- a/hybridse/src/vm/schemas_context_test.cc
+++ b/hybridse/src/vm/schemas_context_test.cc
@@ -173,7 +173,7 @@ PhysicalOpNode* GetTestSqlPlan(SqlCase& sql_case,  // NOLINT
     std::map<size_t, std::string> idx_to_table_dict;
     auto catalog = std::make_shared<SimpleCatalog>();
     EngineOptions options;
-    options.set_plan_only(true);
+    options.SetPlanOnly(true);
     auto engine = std::make_shared<vm::Engine>(catalog, options);
     InitSimpleCataLogFromSqlCase(sql_case, catalog);
 

--- a/src/base/ddl_parser.h
+++ b/src/base/ddl_parser.h
@@ -237,9 +237,9 @@ class DDLParser {
         // TODO(hw): engine is input, do not create in here
         ::hybridse::vm::Engine::InitializeGlobalLLVM();
         ::hybridse::vm::EngineOptions options;
-        options.set_keep_ir(true);
-        options.set_compile_only(true);
-        options.set_performance_sensitive(false);
+        options.SetKeepIR(true);
+        options.SetCompileOnly(true);
+        options.SetPerformanceSensitive(false);
         auto engine = std::make_shared<hybridse::vm::Engine>(catalog, options);
 
         ::hybridse::base::Status status;

--- a/src/catalog/sdk_catalog_test.cc
+++ b/src/catalog/sdk_catalog_test.cc
@@ -61,7 +61,7 @@ TEST_F(SDKCatalogTest, sdk_smoke_test) {
     Procedures procedures;
     ASSERT_TRUE(catalog->Init(tables, procedures));
     ::hybridse::vm::EngineOptions options;
-    options.set_compile_only(true);
+    options.SetCompileOnly(true);
     ::hybridse::vm::Engine engine(catalog, options);
     std::string sql = "select col1, col2 + 1 from t1;";
     ::hybridse::vm::BatchRunSession session;
@@ -81,7 +81,7 @@ TEST_F(SDKCatalogTest, sdk_window_smoke_test) {
     Procedures procedures;
     ASSERT_TRUE(catalog->Init(tables, procedures));
     ::hybridse::vm::EngineOptions options;
-    options.set_compile_only(true);
+    options.SetCompileOnly(true);
     ::hybridse::vm::Engine engine(catalog, options);
     std::string sql =
         "select sum(col2) over w1, t1.col1, t1.col2 from t1 window w1 "
@@ -106,7 +106,7 @@ TEST_F(SDKCatalogTest, sdk_lastjoin_smoke_test) {
     Procedures procedures;
     ASSERT_TRUE(catalog->Init(tables, procedures));
     ::hybridse::vm::EngineOptions options;
-    options.set_compile_only(true);
+    options.SetCompileOnly(true);
     ::hybridse::vm::Engine engine(catalog, options);
     std::string sql =
         "select t1.col1 as c1, t1.col2 as c2 , t2.col1 as c3, t2.col2 as c4 "

--- a/src/sdk/db_sdk.cc
+++ b/src/sdk/db_sdk.cc
@@ -74,8 +74,8 @@ bool ClusterSDK::Init() {
               << ",session timeout " << options_.session_timeout << " and session id " << zk_client_->GetSessionTerm();
 
     ::hybridse::vm::EngineOptions eopt;
-    eopt.set_compile_only(true);
-    eopt.set_plan_only(true);
+    eopt.SetCompileOnly(true);
+    eopt.SetPlanOnly(true);
     engine_ = new ::hybridse::vm::Engine(catalog_, eopt);
 
     ok = BuildCatalog();
@@ -406,8 +406,8 @@ std::vector<std::shared_ptr<hybridse::sdk::ProcedureInfo>> DBSDK::GetProcedureIn
 
 bool StandAloneSDK::Init() {
     ::hybridse::vm::EngineOptions opt;
-    opt.set_compile_only(true);
-    opt.set_plan_only(true);
+    opt.SetCompileOnly(true);
+    opt.SetPlanOnly(true);
     engine_ = new ::hybridse::vm::Engine(catalog_, opt);
     return PeriodicRefresh();
 }

--- a/src/tablet/tablet_impl.cc
+++ b/src/tablet/tablet_impl.cc
@@ -149,7 +149,7 @@ bool TabletImpl::Init(const std::string& real_endpoint) {
 bool TabletImpl::Init(const std::string& zk_cluster, const std::string& zk_path, const std::string& endpoint,
                       const std::string& real_endpoint) {
     ::hybridse::vm::EngineOptions options;
-    options.set_cluster_optimized(FLAGS_enable_distsql);
+    options.SetClusterOptimized(FLAGS_enable_distsql);
     engine_ = std::unique_ptr<::hybridse::vm::Engine>(new ::hybridse::vm::Engine(catalog_, options));
     catalog_->SetLocalTablet(
         std::shared_ptr<::hybridse::vm::Tablet>(new ::hybridse::vm::LocalTablet(engine_.get(), sp_cache_)));


### PR DESCRIPTION
This PR try to solve the problem that some api don't follow google cpp style.

**background**
cpp code should follow our style guide: https://github.com/4paradigm/rfcs/blob/main/style-guide/code-convention.md

The thing this PR has done:

- [x] Change the api of EngineOptions and JitOptions' methods to follow google cpp style name, just leave the corresponding part in openmldb-batch unchanged

 
The related issues
[gitee related issue](https://gitee.com/paradigm4/OpenMLDB/issues/I48BZZ)
[286](https://github.com/4paradigm/OpenMLDB/issues/286)

