### PR TITLE
feat: support select into & set statement

### DIFF
--- a/cases/plan/cmd.yaml
+++ b/cases/plan/cmd.yaml
@@ -243,3 +243,82 @@ cases:
           +-table: t1
           +-options:
             +-charset: utf-8
+  - id: select_into_outfile_1
+    sql: SELECT col1 FROM t1 WHERE col1 > 10 INTO OUTFILE 'data.csv';
+    expect:
+      node_tree_str: |
+        +-node[kSelectIntoStmt]
+          +-out_file: data.csv
+          +-query:
+          |  +-node[kQuery]: kQuerySelect
+          |    +-distinct_opt: false
+          |    +-where_expr:
+          |    |  +-expr[binary]
+          |    |    +->[list]:
+          |    |      +-0:
+          |    |      |  +-expr[column ref]
+          |    |      |    +-relation_name: <nil>
+          |    |      |    +-column_name: col1
+          |    |      +-1:
+          |    |        +-expr[primary]
+          |    |          +-value: 10
+          |    |          +-type: int32
+          |    +-group_expr_list: null
+          |    +-having_expr: null
+          |    +-order_expr_list: null
+          |    +-limit: null
+          |    +-select_list[list]:
+          |    |  +-0:
+          |    |    +-node[kResTarget]
+          |    |      +-val:
+          |    |      |  +-expr[column ref]
+          |    |      |    +-relation_name: <nil>
+          |    |      |    +-column_name: col1
+          |    |      +-name: <nil>
+          |    +-tableref_list[list]:
+          |    |  +-0:
+          |    |    +-node[kTableRef]: kTable
+          |    |      +-table: t1
+          |    |      +-alias: <nil>
+          |    +-window_list: []
+          +-options: <nil>
+  - id: select_into_outfile_2
+    sql: SELECT col1 FROM t1 WHERE col1 <= 10 INTO OUTFILE 'data.csv' OPTIONS ( delimit = ',' );
+    expect:
+      node_tree_str: |
+        +-node[kSelectIntoStmt]
+          +-out_file: data.csv
+          +-query:
+          |  +-node[kQuery]: kQuerySelect
+          |    +-distinct_opt: false
+          |    +-where_expr:
+          |    |  +-expr[binary]
+          |    |    +-<=[list]:
+          |    |      +-0:
+          |    |      |  +-expr[column ref]
+          |    |      |    +-relation_name: <nil>
+          |    |      |    +-column_name: col1
+          |    |      +-1:
+          |    |        +-expr[primary]
+          |    |          +-value: 10
+          |    |          +-type: int32
+          |    +-group_expr_list: null
+          |    +-having_expr: null
+          |    +-order_expr_list: null
+          |    +-limit: null
+          |    +-select_list[list]:
+          |    |  +-0:
+          |    |    +-node[kResTarget]
+          |    |      +-val:
+          |    |      |  +-expr[column ref]
+          |    |      |    +-relation_name: <nil>
+          |    |      |    +-column_name: col1
+          |    |      +-name: <nil>
+          |    +-tableref_list[list]:
+          |    |  +-0:
+          |    |    +-node[kTableRef]: kTable
+          |    |      +-table: t1
+          |    |      +-alias: <nil>
+          |    +-window_list: []
+          +-options:
+            +-delimit: ,

--- a/cases/plan/cmd.yaml
+++ b/cases/plan/cmd.yaml
@@ -242,7 +242,10 @@ cases:
           +-db: db0
           +-table: t1
           +-options:
-            +-charset: utf-8
+            +-charset:
+              +-expr[primary]
+                +-value: utf-8
+                +-type: string
   - id: select_into_outfile_1
     sql: SELECT col1 FROM t1 WHERE col1 > 10 INTO OUTFILE 'data.csv';
     expect:
@@ -321,7 +324,10 @@ cases:
           |    |      +-alias: <nil>
           |    +-window_list: []
           +-options:
-            +-delimit: ,
+            +-delimit:
+              +-expr[primary]
+                +-value: ,
+                +-type: string
   - id: set_select_mode
     sql: SET SELECT_MODE = 'TRINO';
     expect:

--- a/cases/plan/cmd.yaml
+++ b/cases/plan/cmd.yaml
@@ -332,3 +332,8 @@ cases:
             +-expr[primary]
               +-value: TRINO
               +-type: string
+  - id: set_select_mode_2
+    desc: unsupport syntax
+    sql: SET SELECT_MODE = 1 + 2;
+    expect:
+      success: false

--- a/cases/plan/cmd.yaml
+++ b/cases/plan/cmd.yaml
@@ -322,3 +322,10 @@ cases:
           |    +-window_list: []
           +-options:
             +-delimit: ,
+  - id: set_select_mode
+    sql: SET SELECT_MODE = 'TRINO';
+    expect:
+      node_tree_str: |
+        +-node[CMD]
+          +-cmd_type: set select_mode
+          +-args: [TRINO]

--- a/cases/plan/cmd.yaml
+++ b/cases/plan/cmd.yaml
@@ -326,6 +326,9 @@ cases:
     sql: SET SELECT_MODE = 'TRINO';
     expect:
       node_tree_str: |
-        +-node[CMD]
-          +-cmd_type: set select_mode
-          +-args: [TRINO]
+        +-node[kSetStmt]
+          +-key: SELECT_MODE
+          +-value:
+            +-expr[primary]
+              +-value: TRINO
+              +-type: string

--- a/cases/plan/error_unsupport_sql.yaml
+++ b/cases/plan/error_unsupport_sql.yaml
@@ -72,3 +72,6 @@ cases:
   - id: in_predicate_fail
     desc: error with empty in list
     sql: select 'a' in () from t1;
+  - id: set_statement
+    desc: unsupported value type
+    sql: SET SELECT_MODE = 1 + 2;

--- a/hybridse/CHANGELOG.md
+++ b/hybridse/CHANGELOG.md
@@ -8,6 +8,15 @@
 
 ### SQL Syntax
 - Support IN predicate: [#423](https://github.com/4paradigm/OpenMLDB/pull/423)
+- DEPLOYMENT related statements: [#506](https://github.com/4paradigm/OpenMLDB/pull/506)
+  - `SHOW DEPLOYMENTS`: [#406](https://github.com/4paradigm/OpenMLDB/issues/460)
+  - `SHOW DEPLOYMENT foo`: [#406](https://github.com/4paradigm/OpenMLDB/issues/460)
+  - `DROP DEPLOYMENT foo`: [#406](https://github.com/4paradigm/OpenMLDB/issues/460)
+  - `DEPLOY foo <sql statement>`: [#447](https://github.com/4paradigm/OpenMLDB/issues/447)
+- Table Data Import/Export:
+  - `LOAD DATA INFILE <file name> INTO TABLE <table name>`: [#506](https://github.com/4paradigm/OpenMLDB/pull/506)
+  - `<query statement> INTO OUTFILE <file name>`: [#532](https://github.com/4paradigm/OpenMLDB/pull/532)
+- `SET SELECT_MODE`: [#532](https://github.com/4paradigm/OpenMLDB/pull/532)
 
 ### Bug Fix
 - Fix plan error triggered by optimize the same plan node repeatedly. [#437](https://github.com/4paradigm/OpenMLDB/issues/437)

--- a/hybridse/include/node/node_enum.h
+++ b/hybridse/include/node/node_enum.h
@@ -245,6 +245,7 @@ enum CmdType {
     kCmdShowDeployment,
     kCmdShowDeployments,
     kCmdDropDeployment,
+    kCmdSetSelectMode,
     kCmdUnknown = -1
 };
 enum ExplainType {

--- a/hybridse/include/node/node_enum.h
+++ b/hybridse/include/node/node_enum.h
@@ -88,6 +88,7 @@ enum SqlNodeType {
     kSelectIntoStmt,
     kLoadDataStmt,
     kDeployStmt,
+    kSetStmt,
     kUnknow = -1
 };
 
@@ -245,7 +246,6 @@ enum CmdType {
     kCmdShowDeployment,
     kCmdShowDeployments,
     kCmdDropDeployment,
-    kCmdSetSelectMode,
     kCmdUnknown = -1
 };
 enum ExplainType {
@@ -278,6 +278,7 @@ enum PlanType {
     kPlanTypeSelectInto,
     kPlanTypeLoadData,
     kPlanTypeDeploy,
+    kPlanTypeSet,
     kUnknowPlan = -1,
 };
 

--- a/hybridse/include/node/node_enum.h
+++ b/hybridse/include/node/node_enum.h
@@ -85,6 +85,7 @@ enum SqlNodeType {
     kCreateSpStmt,
     kInputParameter,
     kPartitionNum,
+    kSelectIntoStmt,
     kLoadDataStmt,
     kDeployStmt,
     kUnknow = -1
@@ -273,6 +274,7 @@ enum PlanType {
     kProjectNode,
     kPlanTypeCreateSp,
     kPlanTypeCreateIndex,
+    kPlanTypeSelectInto,
     kPlanTypeLoadData,
     kPlanTypeDeploy,
     kUnknowPlan = -1,

--- a/hybridse/include/node/node_manager.h
+++ b/hybridse/include/node/node_manager.h
@@ -265,6 +265,8 @@ class NodeManager {
                                        const std::string& out_file, const std::shared_ptr<OptionsMap> options);
     SelectIntoPlanNode* MakeSelectIntoPlanNode(const QueryNode* query, const std::string& query_str,
                                                const std::string& out_file, const std::shared_ptr<OptionsMap> options);
+    SetNode* MakeSetNode(const std::string& key, const ConstNode* value);
+    SetPlanNode* MakeSetPlanNode(const SetNode* set_node);
     // Make NodeList
     SqlNode *MakeExplainNode(const QueryNode *query,
                              node::ExplainType explain_type);

--- a/hybridse/include/node/node_manager.h
+++ b/hybridse/include/node/node_manager.h
@@ -261,6 +261,10 @@ class NodeManager {
                                    const std::shared_ptr<OptionsMap> options);
     LoadDataPlanNode* MakeLoadDataPlanNode(const std::string& file_name, const std::string &db,
                                            const std::string& table, const std::shared_ptr<OptionsMap> options);
+    SelectIntoNode* MakeSelectIntoNode(const QueryNode* query, const std::string& query_str,
+                                       const std::string& out_file, const std::shared_ptr<OptionsMap> options);
+    SelectIntoPlanNode* MakeSelectIntoPlanNode(const QueryNode* query, const std::string& query_str,
+                                               const std::string& out_file, const std::shared_ptr<OptionsMap> options);
     // Make NodeList
     SqlNode *MakeExplainNode(const QueryNode *query,
                              node::ExplainType explain_type);

--- a/hybridse/include/node/plan_node.h
+++ b/hybridse/include/node/plan_node.h
@@ -460,7 +460,7 @@ class DeployPlanNode : public LeafPlanNode {
     const bool if_not_exist_ = false;
 };
 
-class SelectIntoPlanNode final : public LeafPlanNode {
+class SelectIntoPlanNode : public LeafPlanNode {
  public:
     explicit SelectIntoPlanNode(const QueryNode* query, const std::string& query_str, const std::string& out,
                                 const std::shared_ptr<OptionsMap> options)
@@ -481,7 +481,7 @@ class SelectIntoPlanNode final : public LeafPlanNode {
     const std::shared_ptr<OptionsMap> options_;
 };
 
-class LoadDataPlanNode final : public LeafPlanNode {
+class LoadDataPlanNode : public LeafPlanNode {
  public:
     explicit LoadDataPlanNode(const std::string& f, const std::string& db, const std::string& table,
                           const std::shared_ptr<OptionsMap> op)

--- a/hybridse/include/node/plan_node.h
+++ b/hybridse/include/node/plan_node.h
@@ -502,6 +502,22 @@ class LoadDataPlanNode : public LeafPlanNode {
     const std::shared_ptr<OptionsMap> options_ = nullptr;
 };
 
+class SetPlanNode : public LeafPlanNode {
+ public:
+    explicit SetPlanNode(const std::string& key, const ConstNode* value)
+        : LeafPlanNode(kPlanTypeSet), key_(key), value_(value) {}
+    ~SetPlanNode() {}
+
+    const std::string& Key() const { return key_; }
+    const ConstNode* Value() const { return value_; }
+
+    void Print(std::ostream& output, const std::string& org_tab) const override;
+
+ private:
+    const std::string key_;
+    const ConstNode* value_;
+};
+
 class InsertPlanNode : public LeafPlanNode {
  public:
     explicit InsertPlanNode(const InsertStmt *insert_node) : LeafPlanNode(kPlanTypeInsert), insert_node_(insert_node) {}

--- a/hybridse/include/node/plan_node.h
+++ b/hybridse/include/node/plan_node.h
@@ -446,10 +446,10 @@ class DeployPlanNode : public LeafPlanNode {
         : LeafPlanNode(kPlanTypeDeploy), name_(name), stmt_(stmt), stmt_str_(stmt_str), if_not_exist_(if_not_exist) {}
     ~DeployPlanNode() {}
 
-    const std::string& name() const { return name_; }
-    const SqlNode* stmt() const { return stmt_; }
-    bool is_if_not_exists() const { return if_not_exist_; }
-    const std::string& stmt_str() const { return stmt_str_; }
+    const std::string& Name() const { return name_; }
+    const SqlNode* Stmt() const { return stmt_; }
+    bool IsIfNotExists() const { return if_not_exist_; }
+    const std::string& StmtStr() const { return stmt_str_; }
 
     void Print(std::ostream& output, const std::string& tab) const override;
 
@@ -460,15 +460,38 @@ class DeployPlanNode : public LeafPlanNode {
     const bool if_not_exist_ = false;
 };
 
-class LoadDataPlanNode : public LeafPlanNode {
+class SelectIntoPlanNode final : public LeafPlanNode {
+ public:
+    explicit SelectIntoPlanNode(const QueryNode* query, const std::string& query_str, const std::string& out,
+                                const std::shared_ptr<OptionsMap> options)
+        : LeafPlanNode(kPlanTypeSelectInto), query_(query), query_str_(query_str), out_file_(out), options_(options) {}
+    ~SelectIntoPlanNode() {}
+
+    const QueryNode* Query() const { return query_; }
+    const std::string& QueryStr() const { return query_str_; }
+    const std::string& OutFile() const { return out_file_; }
+    const std::shared_ptr<OptionsMap> Options() const { return options_; }
+
+    void Print(std::ostream& output, const std::string& tab) const override;
+
+ private:
+    const QueryNode* query_;
+    const std::string query_str_;
+    const std::string out_file_;
+    const std::shared_ptr<OptionsMap> options_;
+};
+
+class LoadDataPlanNode final : public LeafPlanNode {
  public:
     explicit LoadDataPlanNode(const std::string& f, const std::string& db, const std::string& table,
                           const std::shared_ptr<OptionsMap> op)
         : LeafPlanNode(kPlanTypeLoadData), file_(f), db_(db), table_(table), options_(op) {}
     ~LoadDataPlanNode() {}
 
-    const std::string& file() const { return file_; }
-    const std::shared_ptr<OptionsMap> options() const { return options_; }
+    const std::string& File() const { return file_; }
+    const std::string& Db() const { return db_; }
+    const std::string& Table() const { return table_; }
+    const std::shared_ptr<OptionsMap> Options() const { return options_; }
 
     void Print(std::ostream &output, const std::string &org_tab) const override;
 
@@ -476,7 +499,7 @@ class LoadDataPlanNode : public LeafPlanNode {
     const std::string file_;
     const std::string db_;
     const std::string table_;
-    std::shared_ptr<OptionsMap> options_ = nullptr;
+    const std::shared_ptr<OptionsMap> options_ = nullptr;
 };
 
 class InsertPlanNode : public LeafPlanNode {

--- a/hybridse/include/node/sql_node.h
+++ b/hybridse/include/node/sql_node.h
@@ -81,9 +81,12 @@ inline const std::string CmdTypeName(const CmdType &type) {
             return "show deployments";
         case kCmdDropDeployment:
             return "drop deployment";
-        default:
+        case kCmdSetSelectMode:
+            return "set select_mode";
+        case kCmdUnknown:
             return "unknown cmd type";
     }
+    return "undefined cmd type";
 }
 
 inline const std::string ExplainTypeName(const ExplainType &explain_type) {

--- a/hybridse/include/node/sql_node.h
+++ b/hybridse/include/node/sql_node.h
@@ -1978,7 +1978,28 @@ class CmdNode : public SqlNode {
     std::vector<std::string> args_;
 };
 
-class LoadDataNode : public SqlNode {
+class SelectIntoNode final : public SqlNode {
+ public:
+    explicit SelectIntoNode(const QueryNode* query, const std::string& query_str, const std::string& out,
+                            const std::shared_ptr<OptionsMap> options)
+        : SqlNode(kSelectIntoStmt, 0, 0), query_(query), query_str_(query_str), out_file_(out), options_(options) {}
+    ~SelectIntoNode() {}
+
+    const QueryNode* Query() const { return query_; }
+    const std::string& QueryStr() const { return query_str_; }
+    const std::string& OutFile() const { return out_file_; }
+    const std::shared_ptr<OptionsMap> Options() const { return options_; }
+
+    void Print(std::ostream& output, const std::string& org_tab) const override;
+
+ private:
+    const QueryNode* query_;
+    const std::string query_str_;
+    const std::string out_file_;
+    const std::shared_ptr<OptionsMap> options_;
+};
+
+class LoadDataNode final : public SqlNode {
  public:
     explicit LoadDataNode(const std::string& f, const std::string& db, const std::string& table,
                           const std::shared_ptr<OptionsMap> op)
@@ -1998,7 +2019,7 @@ class LoadDataNode : public SqlNode {
     const std::string table_;
     // TODO(aceforeverd): extend value to other type like number, list
     //    replace map with optimized class
-    std::shared_ptr<OptionsMap> options_ = nullptr;
+    const std::shared_ptr<OptionsMap> options_ = nullptr;
 };
 
 class CreateIndexNode : public SqlNode {
@@ -2022,7 +2043,7 @@ class ExplainNode : public SqlNode {
     const node::QueryNode *query_;
 };
 
-class DeployNode : public SqlNode {
+class DeployNode final : public SqlNode {
  public:
     explicit DeployNode(const std::string& name, const SqlNode* stmt, const std::string& stmt_str, bool if_not_exists)
         : SqlNode(kDeployStmt, 0, 0), name_(name), stmt_(stmt), stmt_str_(stmt_str), if_not_exists_(if_not_exists) {}

--- a/hybridse/include/node/sql_node.h
+++ b/hybridse/include/node/sql_node.h
@@ -81,8 +81,6 @@ inline const std::string CmdTypeName(const CmdType &type) {
             return "show deployments";
         case kCmdDropDeployment:
             return "drop deployment";
-        case kCmdSetSelectMode:
-            return "set select_mode";
         case kCmdUnknown:
             return "unknown cmd type";
     }
@@ -2023,6 +2021,21 @@ class LoadDataNode : public SqlNode {
     // TODO(aceforeverd): extend value to other type like number, list
     //    replace map with optimized class
     const std::shared_ptr<OptionsMap> options_ = nullptr;
+};
+
+class SetNode : public SqlNode {
+ public:
+     explicit SetNode(const std::string& key, const ConstNode* value) : SqlNode(kSetStmt, 0, 0), key_(key), value_(value) {}
+     ~SetNode() {}
+
+     const std::string& Key() const { return key_; }
+     const ConstNode* Value() const { return value_; }
+
+    void Print(std::ostream &output, const std::string &org_tab) const override;
+
+ private:
+    const std::string key_;
+    const ConstNode* value_;
 };
 
 class CreateIndexNode : public SqlNode {

--- a/hybridse/include/node/sql_node.h
+++ b/hybridse/include/node/sql_node.h
@@ -1981,7 +1981,7 @@ class CmdNode : public SqlNode {
     std::vector<std::string> args_;
 };
 
-class SelectIntoNode final : public SqlNode {
+class SelectIntoNode : public SqlNode {
  public:
     explicit SelectIntoNode(const QueryNode* query, const std::string& query_str, const std::string& out,
                             const std::shared_ptr<OptionsMap> options)
@@ -2002,7 +2002,7 @@ class SelectIntoNode final : public SqlNode {
     const std::shared_ptr<OptionsMap> options_;
 };
 
-class LoadDataNode final : public SqlNode {
+class LoadDataNode : public SqlNode {
  public:
     explicit LoadDataNode(const std::string& f, const std::string& db, const std::string& table,
                           const std::shared_ptr<OptionsMap> op)
@@ -2046,7 +2046,7 @@ class ExplainNode : public SqlNode {
     const node::QueryNode *query_;
 };
 
-class DeployNode final : public SqlNode {
+class DeployNode : public SqlNode {
  public:
     explicit DeployNode(const std::string& name, const SqlNode* stmt, const std::string& stmt_str, bool if_not_exists)
         : SqlNode(kDeployStmt, 0, 0), name_(name), stmt_(stmt), stmt_str_(stmt_str), if_not_exists_(if_not_exists) {}

--- a/hybridse/include/node/sql_node.h
+++ b/hybridse/include/node/sql_node.h
@@ -42,7 +42,9 @@ class LlvmUdfGenBase;
 namespace hybridse {
 namespace node {
 
-typedef std::unordered_map<std::string, std::string> OptionsMap;
+class ConstNode;
+
+typedef std::unordered_map<std::string, const ConstNode*> OptionsMap;
 
 // Global methods
 std::string NameOfSqlNodeType(const SqlNodeType &type);
@@ -2025,13 +2027,14 @@ class LoadDataNode : public SqlNode {
 
 class SetNode : public SqlNode {
  public:
-     explicit SetNode(const std::string& key, const ConstNode* value) : SqlNode(kSetStmt, 0, 0), key_(key), value_(value) {}
-     ~SetNode() {}
+    explicit SetNode(const std::string& key, const ConstNode* value)
+        : SqlNode(kSetStmt, 0, 0), key_(key), value_(value) {}
+    ~SetNode() {}
 
-     const std::string& Key() const { return key_; }
-     const ConstNode* Value() const { return value_; }
+    const std::string& Key() const { return key_; }
+    const ConstNode* Value() const { return value_; }
 
-    void Print(std::ostream &output, const std::string &org_tab) const override;
+    void Print(std::ostream& output, const std::string& org_tab) const override;
 
  private:
     const std::string key_;
@@ -2600,20 +2603,8 @@ void PrintValue(std::ostream &output, const std::string &org_tab, const std::str
 void PrintValue(std::ostream &output, const std::string &org_tab, const std::vector<std::string> &vec,
                 const std::string &item_name, bool last_child);
 
-template <typename K, typename V>
-inline void PrintValue(std::ostream &output, const std::string &org_tab, const std::unordered_map<K, V> &value,
-                const std::string &item_name, bool last_child) {
-    output << org_tab << SPACE_ST << item_name << ":";
-    if (value.empty()) {
-        output << " <nil>";
-        return;
-    }
-    auto new_tab = org_tab + INDENT + SPACE_ED;
-    for (auto it = value.cbegin(); it != value.cend(); ++it) {
-        output << "\n" << new_tab << SPACE_ST << it->first << ": "
-            << it->second;
-    }
-}
+void PrintValue(std::ostream &output, const std::string &org_tab, const OptionsMap &value,
+                const std::string &item_name, bool last_child);
 }  // namespace node
 }  // namespace hybridse
 #endif  // HYBRIDSE_INCLUDE_NODE_SQL_NODE_H_

--- a/hybridse/src/node/node_manager.cc
+++ b/hybridse/src/node/node_manager.cc
@@ -766,6 +766,18 @@ LoadDataPlanNode *NodeManager::MakeLoadDataPlanNode(const std::string &file_name
     return RegisterNode(node);
 }
 
+SelectIntoNode* NodeManager::MakeSelectIntoNode(const QueryNode* query, const std::string& query_str,
+                                   const std::string& out_file, const std::shared_ptr<OptionsMap> options) {
+    SelectIntoNode* node = new SelectIntoNode(query, query_str, out_file, options);
+    return RegisterNode(node);
+}
+
+SelectIntoPlanNode* NodeManager::MakeSelectIntoPlanNode(const QueryNode* query, const std::string& query_str,
+                                               const std::string& out_file, const std::shared_ptr<OptionsMap> options) {
+    SelectIntoPlanNode* node = new SelectIntoPlanNode(query, query_str, out_file, options);
+    return RegisterNode(node);
+}
+
 AllNode *NodeManager::MakeAllNode(const std::string &relation_name) { return MakeAllNode(relation_name, ""); }
 
 AllNode *NodeManager::MakeAllNode(const std::string &relation_name, const std::string &db_name) {

--- a/hybridse/src/node/node_manager.cc
+++ b/hybridse/src/node/node_manager.cc
@@ -778,6 +778,16 @@ SelectIntoPlanNode* NodeManager::MakeSelectIntoPlanNode(const QueryNode* query, 
     return RegisterNode(node);
 }
 
+SetNode* NodeManager::MakeSetNode(const std::string &key, const ConstNode *value) {
+    SetNode* node = new SetNode(key, value);
+    return RegisterNode(node);
+}
+
+SetPlanNode* NodeManager::MakeSetPlanNode(const SetNode *set_node) {
+    SetPlanNode* node = new SetPlanNode(set_node->Key(), set_node->Value());
+    return RegisterNode(node);
+}
+
 AllNode *NodeManager::MakeAllNode(const std::string &relation_name) { return MakeAllNode(relation_name, ""); }
 
 AllNode *NodeManager::MakeAllNode(const std::string &relation_name, const std::string &db_name) {

--- a/hybridse/src/node/plan_node.cc
+++ b/hybridse/src/node/plan_node.cc
@@ -217,6 +217,8 @@ std::string NameOfPlanNodeType(const PlanType &type) {
             return "kPlanTypeDeploy";
         case kPlanTypeLoadData:
             return "kPlanTypeLoadData";
+        case kPlanTypeSelectInto:
+            return "kPlanTypeSelectInto";
         case kPlanTypeCreateIndex:
             return "kPlanTypeCreateIndex";
         case kPlanTypeCreateSp:
@@ -678,11 +680,11 @@ void DeployPlanNode::Print(std::ostream &output, const std::string &tab) const {
     PlanNode::Print(output, tab);
     output << "\n";
     std::string new_tab = tab + INDENT;
-    PrintValue(output, new_tab, if_not_exist_ ? "true": "false", "if_not_exists", false);
+    PrintValue(output, new_tab, IsIfNotExists() ? "true": "false", "if_not_exists", false);
     output << "\n";
-    PrintValue(output, new_tab, name_, "name", false);
+    PrintValue(output, new_tab, Name(), "name", false);
     output << "\n";
-    PrintSqlNode(output, new_tab, stmt(), "stmt", true);
+    PrintSqlNode(output, new_tab, Stmt(), "stmt", true);
 }
 
 void LoadDataPlanNode::Print(std::ostream &output, const std::string &org_tab) const {
@@ -690,13 +692,24 @@ void LoadDataPlanNode::Print(std::ostream &output, const std::string &org_tab) c
 
     const std::string tab = org_tab + INDENT + SPACE_ED;
     output << "\n";
-    PrintValue(output, tab, file_, "file", false);
+    PrintValue(output, tab, File(), "file", false);
     output << "\n";
-    PrintValue(output, tab, db_, "db", false);
+    PrintValue(output, tab, Db(), "db", false);
     output << "\n";
-    PrintValue(output, tab, table_, "table", false);
+    PrintValue(output, tab, Table(), "table", false);
     output << "\n";
-    PrintValue<std::string, std::string>(output, tab, *options_.get(), "options", true);
+    PrintValue<std::string, std::string>(output, tab, *Options().get(), "options", true);
+}
+
+void SelectIntoPlanNode::Print(std::ostream &output, const std::string &tab) const {
+    PlanNode::Print(output, tab);
+    const std::string new_tab = tab + INDENT + SPACE_ED;
+    output << "\n";
+    PrintValue(output, new_tab, OutFile(), "out_file", false);
+    output << "\n";
+    PrintSqlNode(output, new_tab, Query(), "query", false);
+    output << "\n";
+    PrintValue<std::string, std::string>(output, new_tab, *Options().get(), "options", true);
 }
 }  // namespace node
 }  // namespace hybridse

--- a/hybridse/src/node/plan_node.cc
+++ b/hybridse/src/node/plan_node.cc
@@ -700,7 +700,7 @@ void LoadDataPlanNode::Print(std::ostream &output, const std::string &org_tab) c
     output << "\n";
     PrintValue(output, tab, Table(), "table", false);
     output << "\n";
-    PrintValue<std::string, std::string>(output, tab, *Options().get(), "options", true);
+    PrintValue(output, tab, *Options().get(), "options", true);
 }
 
 void SelectIntoPlanNode::Print(std::ostream &output, const std::string &tab) const {
@@ -711,7 +711,7 @@ void SelectIntoPlanNode::Print(std::ostream &output, const std::string &tab) con
     output << "\n";
     PrintSqlNode(output, new_tab, Query(), "query", false);
     output << "\n";
-    PrintValue<std::string, std::string>(output, new_tab, *Options().get(), "options", true);
+    PrintValue(output, new_tab, *Options().get(), "options", true);
 }
 
 void SetPlanNode::Print(std::ostream &output, const std::string &org_tab) const {

--- a/hybridse/src/node/plan_node.cc
+++ b/hybridse/src/node/plan_node.cc
@@ -223,6 +223,8 @@ std::string NameOfPlanNodeType(const PlanType &type) {
             return "kPlanTypeCreateIndex";
         case kPlanTypeCreateSp:
             return "kPlanTypeCreateSp";
+        case kPlanTypeSet:
+            return "kPlanTypeSet";
         case kUnknowPlan:
             return std::string("kUnknow");
     }
@@ -710,6 +712,15 @@ void SelectIntoPlanNode::Print(std::ostream &output, const std::string &tab) con
     PrintSqlNode(output, new_tab, Query(), "query", false);
     output << "\n";
     PrintValue<std::string, std::string>(output, new_tab, *Options().get(), "options", true);
+}
+
+void SetPlanNode::Print(std::ostream &output, const std::string &org_tab) const {
+    PlanNode::Print(output, org_tab);
+    const std::string tab = org_tab + INDENT + SPACE_ED;
+    output << "\n";
+    PrintValue(output, tab, Key(), "key", false);
+    output << "\n";
+    PrintSqlNode(output, tab, Value(), "value", true);
 }
 }  // namespace node
 }  // namespace hybridse

--- a/hybridse/src/node/sql_node.cc
+++ b/hybridse/src/node/sql_node.cc
@@ -170,6 +170,20 @@ void PrintValue(std::ostream &output, const std::string &org_tab, const std::vec
     output << org_tab << SPACE_ST << item_name << ": " << ss.str();
 }
 
+void PrintValue(std::ostream &output, const std::string &org_tab, const OptionsMap &value,
+                const std::string &item_name, bool last_child) {
+    output << org_tab << SPACE_ST << item_name << ":";
+    if (value.empty()) {
+        output << " <nil>";
+        return;
+    }
+    auto new_tab = org_tab + INDENT + SPACE_ED;
+    for (auto it = value.begin(); it != value.end(); ++it) {
+        output << "\n";
+        PrintSqlNode(output, new_tab, it->second, it->first, std::next(it) == value.end());
+    }
+}
+
 bool SqlNode::Equals(const SqlNode *that) const {
     if (this == that) {
         return true;
@@ -1329,7 +1343,7 @@ void SelectIntoNode::Print(std::ostream &output, const std::string &tab) const {
     output << "\n";
     PrintSqlNode(output, new_tab, Query(), "query", false);
     output << "\n";
-    PrintValue<std::string, std::string>(output, new_tab, *Options().get(), "options", true);
+    PrintValue(output, new_tab, *Options().get(), "options", true);
 }
 
 void LoadDataNode::Print(std::ostream &output, const std::string &org_tab) const {
@@ -1337,13 +1351,13 @@ void LoadDataNode::Print(std::ostream &output, const std::string &org_tab) const
 
     const std::string tab = org_tab + INDENT + SPACE_ED;
     output << "\n";
-    PrintValue(output, tab, file_, "file", false);
+    PrintValue(output, tab, File(), "file", false);
     output << "\n";
-    PrintValue(output, tab, db_, "db", false);
+    PrintValue(output, tab, Db(), "db", false);
     output << "\n";
-    PrintValue(output, tab, table_, "table", false);
+    PrintValue(output, tab, Table(), "table", false);
     output << "\n";
-    PrintValue<std::string, std::string>(output, tab, *options_.get(), "options", true);
+    PrintValue(output, tab, *Options().get(), "options", true);
 }
 
 void SetNode::Print(std::ostream &output, const std::string &org_tab) const {

--- a/hybridse/src/node/sql_node.cc
+++ b/hybridse/src/node/sql_node.cc
@@ -1047,6 +1047,9 @@ std::string NameOfSqlNodeType(const SqlNodeType &type) {
         case kLoadDataStmt:
             output = "kLoadDataStmt";
             break;
+        case kSetStmt:
+            output = "kSetStmt";
+            break;
         case kUnknow:
             output = "kUnknow";
             break;
@@ -1341,6 +1344,15 @@ void LoadDataNode::Print(std::ostream &output, const std::string &org_tab) const
     PrintValue(output, tab, table_, "table", false);
     output << "\n";
     PrintValue<std::string, std::string>(output, tab, *options_.get(), "options", true);
+}
+
+void SetNode::Print(std::ostream &output, const std::string &org_tab) const {
+    SqlNode::Print(output, org_tab);
+    const std::string tab = org_tab + INDENT + SPACE_ED;
+    output << "\n";
+    PrintValue(output, tab, Key(), "key", false);
+    output << "\n";
+    PrintSqlNode(output, tab, Value(), "value", true);
 }
 
 void InsertStmt::Print(std::ostream &output, const std::string &org_tab) const {

--- a/hybridse/src/node/sql_node.cc
+++ b/hybridse/src/node/sql_node.cc
@@ -1041,6 +1041,9 @@ std::string NameOfSqlNodeType(const SqlNodeType &type) {
         case kDeployStmt:
             output = "kDeployStmt";
             break;
+        case kSelectIntoStmt:
+            output = "kSelectIntoStmt";
+            break;
         case kLoadDataStmt:
             output = "kLoadDataStmt";
             break;
@@ -1313,6 +1316,17 @@ void DeployNode::Print(std::ostream& output, const std::string& org_tab) const {
     PrintValue(output, tab, name_, "name", false);
     output << "\n";
     PrintSqlNode(output, tab, stmt_, "stmt", true);
+}
+
+void SelectIntoNode::Print(std::ostream &output, const std::string &tab) const {
+    SqlNode::Print(output, tab);
+    const std::string new_tab = tab + INDENT + SPACE_ED;
+    output << "\n";
+    PrintValue(output, new_tab, OutFile(), "out_file", false);
+    output << "\n";
+    PrintSqlNode(output, new_tab, Query(), "query", false);
+    output << "\n";
+    PrintValue<std::string, std::string>(output, new_tab, *Options().get(), "options", true);
 }
 
 void LoadDataNode::Print(std::ostream &output, const std::string &org_tab) const {

--- a/hybridse/src/plan/planner.cc
+++ b/hybridse/src/plan/planner.cc
@@ -316,6 +316,12 @@ base::Status Planner::CreateSelectIntoPlanNode(const node::SelectIntoNode *root,
     return base::Status::OK();
 }
 
+base::Status Planner::CreateSetPlanNode(const node::SetNode *root, node::PlanNode **output) {
+    CHECK_TRUE(nullptr != root, common::kPlanError, "fail to create set plan with null node");
+    *output = node_manager_->MakeSetPlanNode(root);
+    return base::Status::OK();
+}
+
 base::Status Planner::CreateCreateTablePlan(const node::SqlNode *root, node::PlanNode **output) {
     CHECK_TRUE(nullptr != root, common::kPlanError, "fail to create table plan with null node")
     const node::CreateStmt *create_tree = static_cast<const node::CreateStmt *>(root);
@@ -477,6 +483,12 @@ base::Status SimplePlanner::CreatePlanTree(const NodePointVector &parser_trees, 
                 node::PlanNode *deploy_plan_node = nullptr;
                 CHECK_STATUS(CreateDeployPlanNode(dynamic_cast<node::DeployNode *>(parser_tree), &deploy_plan_node));
                 plan_trees.push_back(deploy_plan_node);
+                break;
+            }
+            case ::hybridse::node::kSetStmt: {
+                node::PlanNode *set_plan_node = nullptr;
+                CHECK_STATUS(CreateSetPlanNode(dynamic_cast<node::SetNode *>(parser_tree), &set_plan_node));
+                plan_trees.push_back(set_plan_node);
                 break;
             }
             default: {

--- a/hybridse/src/plan/planner.cc
+++ b/hybridse/src/plan/planner.cc
@@ -310,6 +310,12 @@ base::Status Planner::CreateLoadDataPlanNode(const node::LoadDataNode *root, nod
     return base::Status::OK();
 }
 
+base::Status Planner::CreateSelectIntoPlanNode(const node::SelectIntoNode *root, node::PlanNode **output) {
+    CHECK_TRUE(nullptr != root, common::kPlanError, "fail to create select into plan with null node");
+    *output = node_manager_->MakeSelectIntoPlanNode(root->Query(), root->QueryStr(), root->OutFile(), root->Options());
+    return base::Status::OK();
+}
+
 base::Status Planner::CreateCreateTablePlan(const node::SqlNode *root, node::PlanNode **output) {
     CHECK_TRUE(nullptr != root, common::kPlanError, "fail to create table plan with null node")
     const node::CreateStmt *create_tree = static_cast<const node::CreateStmt *>(root);
@@ -451,6 +457,13 @@ base::Status SimplePlanner::CreatePlanTree(const NodePointVector &parser_trees, 
                 node::PlanNode *create_index_plan = nullptr;
                 CHECK_STATUS(CreateCreateIndexPlan(parser_tree, &create_index_plan))
                 plan_trees.push_back(create_index_plan);
+                break;
+            }
+            case ::hybridse::node::kSelectIntoStmt: {
+                node::PlanNode *select_into_plan_node = nullptr;
+                CHECK_STATUS(CreateSelectIntoPlanNode(dynamic_cast<node::SelectIntoNode *>(parser_tree),
+                                                      &select_into_plan_node));
+                plan_trees.push_back(select_into_plan_node);
                 break;
             }
             case ::hybridse::node::kLoadDataStmt: {

--- a/hybridse/src/plan/planner.h
+++ b/hybridse/src/plan/planner.h
@@ -76,6 +76,7 @@ class Planner {
     base::Status CreateDeployPlanNode(const node::DeployNode *root, node::PlanNode **output);
     base::Status CreateLoadDataPlanNode(const node::LoadDataNode *root, node::PlanNode **output);
     base::Status CreateSelectIntoPlanNode(const node::SelectIntoNode *root, node::PlanNode **output);
+    base::Status CreateSetPlanNode(const node::SetNode *root, node::PlanNode **output);
     base::Status CreateCreateProcedurePlan(const node::SqlNode *root, const PlanNodeList &inner_plan_node_list,
                                            node::PlanNode **output);
     node::NodeManager *node_manager_;

--- a/hybridse/src/plan/planner.h
+++ b/hybridse/src/plan/planner.h
@@ -75,6 +75,7 @@ class Planner {
     base::Status CreateWindowPlanNode(const node::WindowDefNode *w_ptr, node::WindowPlanNode *plan_node);
     base::Status CreateDeployPlanNode(const node::DeployNode *root, node::PlanNode **output);
     base::Status CreateLoadDataPlanNode(const node::LoadDataNode *root, node::PlanNode **output);
+    base::Status CreateSelectIntoPlanNode(const node::SelectIntoNode *root, node::PlanNode **output);
     base::Status CreateCreateProcedurePlan(const node::SqlNode *root, const PlanNodeList &inner_plan_node_list,
                                            node::PlanNode **output);
     node::NodeManager *node_manager_;

--- a/hybridse/src/planv2/ast_node_converter.cc
+++ b/hybridse/src/planv2/ast_node_converter.cc
@@ -1597,7 +1597,7 @@ base::Status ConvertASTScript(const zetasql::ASTScript* script, node::NodeManage
     CHECK_TRUE(nullptr != script, common::kSqlAstError, "Fail to convert ASTScript, script is null")
     *output = node_manager->MakeNodeList();
     for (auto statement : script->statement_list()) {
-        CHECK_TRUE(nullptr != statement && statement->IsSqlStatement(), common::kSqlAstError, "not an SQL Statement")
+        CHECK_TRUE(nullptr != statement, common::kSqlAstError, "SQL Statement is null")
         node::SqlNode* stmt;
         CHECK_STATUS(ConvertStatement(statement, node_manager, &stmt));
         (*output)->PushBack(stmt);

--- a/hybridse/src/planv2/ast_node_converter.h
+++ b/hybridse/src/planv2/ast_node_converter.h
@@ -106,7 +106,7 @@ base::Status ConvertDropStatement(const zetasql::ASTDropStatement* root, node::N
                                   node::CmdNode** output);
 base::Status ConvertCreateIndexStatement(const zetasql::ASTCreateIndexStatement* root, node::NodeManager* node_manager,
                                          node::CreateIndexNode** output);
-base::Status ConvertAstOptionsListToMap(const zetasql::ASTOptionsList* options,
+base::Status ConvertAstOptionsListToMap(const zetasql::ASTOptionsList* options, node::NodeManager* node_manager,
                                         std::shared_ptr<node::OptionsMap> options_map);
 }  // namespace plan
 }  // namespace hybridse

--- a/hybridse/src/planv2/planner_v2_test.cc
+++ b/hybridse/src/planv2/planner_v2_test.cc
@@ -1593,8 +1593,9 @@ TEST_F(PlannerV2Test, DeployPlanNodeTest) {
   col1
 FROM
   t1
-)sql", deploy_stmt->stmt_str().c_str());
+)sql", deploy_stmt->StmtStr().c_str());
 }
+
 TEST_F(PlannerV2Test, LoadDataPlanNodeTest) {
     const std::string sql = "LOAD DATA INFILE 'hello.csv' INTO TABLE t1 OPTIONS (key = 'cat');";
     node::PlanNodeList plan_trees;
@@ -1608,6 +1609,49 @@ TEST_F(PlannerV2Test, LoadDataPlanNodeTest) {
   +-table: t1
   +-options:
     +-key: cat)sql", plan_trees.front()->GetTreeString().c_str());
+}
+
+TEST_F(PlannerV2Test, SelectIntoPlanNodeTest) {
+    const std::string sql = "SELECT c2 FROM t0 INTO OUTFILE 'm.txt' OPTIONS (key = 'cat');";
+    node::PlanNodeList plan_trees;
+    base::Status status;
+    NodeManager nm;
+    ASSERT_TRUE(plan::PlanAPI::CreatePlanTreeFromScript(sql, plan_trees, &nm, status));
+    ASSERT_EQ(1, plan_trees.size());
+    ASSERT_STREQ(R"sql(+-[kPlanTypeSelectInto]
+  +-out_file: m.txt
+  +-query:
+  |  +-node[kQuery]: kQuerySelect
+  |    +-distinct_opt: false
+  |    +-where_expr: null
+  |    +-group_expr_list: null
+  |    +-having_expr: null
+  |    +-order_expr_list: null
+  |    +-limit: null
+  |    +-select_list[list]:
+  |    |  +-0:
+  |    |    +-node[kResTarget]
+  |    |      +-val:
+  |    |      |  +-expr[column ref]
+  |    |      |    +-relation_name: <nil>
+  |    |      |    +-column_name: c2
+  |    |      +-name: <nil>
+  |    +-tableref_list[list]:
+  |    |  +-0:
+  |    |    +-node[kTableRef]: kTable
+  |    |      +-table: t0
+  |    |      +-alias: <nil>
+  |    +-window_list: []
+  +-options:
+    +-key: cat)sql", plan_trees.front()->GetTreeString().c_str());
+
+    const auto select_into = dynamic_cast<node::SelectIntoPlanNode*>(plan_trees.front());
+    ASSERT_TRUE(select_into != nullptr);
+    EXPECT_STREQ(R"sql(SELECT
+  c2
+FROM
+  t0
+)sql", select_into->QueryStr().c_str());
 }
 //
 // TEST_F(PlannerTest, CreateSpParseTest) {

--- a/hybridse/src/planv2/planner_v2_test.cc
+++ b/hybridse/src/planv2/planner_v2_test.cc
@@ -1608,7 +1608,10 @@ TEST_F(PlannerV2Test, LoadDataPlanNodeTest) {
   +-db: <nil>
   +-table: t1
   +-options:
-    +-key: cat)sql", plan_trees.front()->GetTreeString().c_str());
+    +-key:
+      +-expr[primary]
+        +-value: cat
+        +-type: string)sql", plan_trees.front()->GetTreeString().c_str());
 }
 
 TEST_F(PlannerV2Test, SelectIntoPlanNodeTest) {
@@ -1643,7 +1646,10 @@ TEST_F(PlannerV2Test, SelectIntoPlanNodeTest) {
   |    |      +-alias: <nil>
   |    +-window_list: []
   +-options:
-    +-key: cat)sql", plan_trees.front()->GetTreeString().c_str());
+    +-key:
+      +-expr[primary]
+        +-value: cat
+        +-type: string)sql", plan_trees.front()->GetTreeString().c_str());
 
     const auto select_into = dynamic_cast<node::SelectIntoPlanNode*>(plan_trees.front());
     ASSERT_TRUE(select_into != nullptr);

--- a/hybridse/src/planv2/planner_v2_test.cc
+++ b/hybridse/src/planv2/planner_v2_test.cc
@@ -1618,7 +1618,7 @@ TEST_F(PlannerV2Test, SelectIntoPlanNodeTest) {
     NodeManager nm;
     ASSERT_TRUE(plan::PlanAPI::CreatePlanTreeFromScript(sql, plan_trees, &nm, status));
     ASSERT_EQ(1, plan_trees.size());
-    ASSERT_STREQ(R"sql(+-[kPlanTypeSelectInto]
+    EXPECT_STREQ(R"sql(+-[kPlanTypeSelectInto]
   +-out_file: m.txt
   +-query:
   |  +-node[kQuery]: kQuerySelect
@@ -1652,6 +1652,21 @@ TEST_F(PlannerV2Test, SelectIntoPlanNodeTest) {
 FROM
   t0
 )sql", select_into->QueryStr().c_str());
+}
+
+TEST_F(PlannerV2Test, SetPlanNodeTest) {
+    const auto sql = "SET select_mode = 'TRINO'";
+    node::PlanNodeList plan_trees;
+    base::Status status;
+    NodeManager nm;
+    ASSERT_TRUE(plan::PlanAPI::CreatePlanTreeFromScript(sql, plan_trees, &nm, status));
+    ASSERT_EQ(1, plan_trees.size());
+    EXPECT_STREQ(R"sql(+-[kPlanTypeSet]
+  +-key: select_mode
+  +-value:
+    +-expr[primary]
+      +-value: TRINO
+      +-type: string)sql", plan_trees.front()->GetTreeString().c_str());
 }
 //
 // TEST_F(PlannerTest, CreateSpParseTest) {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- The commit message follows our guidelines
- Tests for the changes have been added (for bug fixes / features)
- Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

add new sql syntax
- #455 
- #445 

refactor:
- use `ConstNode` instead of `string` for value type in `select into outfile/load data infile` statement's Options list. So basic type like string, bool, int are supported

