### PR TITLE
feat: fix the base dir of yaml cases

### DIFF
--- a/src/test/base_test.cc
+++ b/src/test/base_test.cc
@@ -39,7 +39,7 @@ std::string SQLCaseTest::GetYAMLBaseDir() {
             yaml_base_dir.append("/");
         }
     } else {
-        yaml_base_dir = "/rtidb";
+        yaml_base_dir = "/openmldb";
     }
     DLOG(INFO) << "InitCases YMAL_CASE_BASE_DIR: " << yaml_base_dir;
     return yaml_base_dir;


### PR DESCRIPTION
Fix the base dir of yaml cases which should be `openmldb` instead of `rtidb`.