### PR TITLE
feat: support set performance sensitive for command sql query

### DIFF
--- a/src/client/tablet_client.cc
+++ b/src/client/tablet_client.cc
@@ -47,7 +47,7 @@ TabletClient::~TabletClient() {}
 int TabletClient::Init() { return client_.Init(); }
 
 bool TabletClient::Query(const std::string& db, const std::string& sql, const std::string& row, brpc::Controller* cntl,
-                         openmldb::api::QueryResponse* response, const bool is_debug) {
+                         openmldb::api::QueryResponse* response, const bool is_debug, bool performance_sensitive) {
     if (cntl == NULL || response == NULL) return false;
     ::openmldb::api::QueryRequest request;
     request.set_sql(sql);
@@ -56,6 +56,7 @@ bool TabletClient::Query(const std::string& db, const std::string& sql, const st
     request.set_is_debug(is_debug);
     request.set_row_size(row.size());
     request.set_row_slices(1);
+    request.set_is_performance_sensitive(performance_sensitive);
     auto& io_buf = cntl->request_attachment();
     if (!codec::EncodeRpcRow(reinterpret_cast<const int8_t*>(row.data()), row.size(), &io_buf)) {
         LOG(WARNING) << "Encode row buffer failed";
@@ -72,7 +73,8 @@ bool TabletClient::Query(const std::string& db, const std::string& sql, const st
 bool TabletClient::Query(const std::string& db, const std::string& sql,
                          const std::vector<openmldb::type::DataType>& parameter_types,
                          const std::string& parameter_row,
-                         brpc::Controller* cntl, ::openmldb::api::QueryResponse* response, const bool is_debug) {
+                         brpc::Controller* cntl, ::openmldb::api::QueryResponse* response, const bool is_debug,
+                         bool performance_sensitive) {
     if (cntl == NULL || response == NULL) return false;
     ::openmldb::api::QueryRequest request;
     request.set_sql(sql);
@@ -81,7 +83,7 @@ bool TabletClient::Query(const std::string& db, const std::string& sql,
     request.set_is_debug(is_debug);
     request.set_parameter_row_size(parameter_row.size());
     request.set_parameter_row_slices(1);
-    request.set_is_performance_sensitive(true);
+    request.set_is_performance_sensitive(performance_sensitive);
     for (auto& type : parameter_types) {
         request.add_parameter_types(type);
     }

--- a/src/client/tablet_client.h
+++ b/src/client/tablet_client.h
@@ -67,10 +67,11 @@ class TabletClient : public Client {
 
     bool Query(const std::string& db, const std::string& sql,
                const std::vector<openmldb::type::DataType>& parameter_types, const std::string& parameter_row,
-               brpc::Controller* cntl, ::openmldb::api::QueryResponse* response, const bool is_debug = false);
+               brpc::Controller* cntl, ::openmldb::api::QueryResponse* response, const bool is_debug = false,
+               bool performance_sensitive = true);
 
     bool Query(const std::string& db, const std::string& sql, const std::string& row, brpc::Controller* cntl,
-               ::openmldb::api::QueryResponse* response, const bool is_debug = false);
+               ::openmldb::api::QueryResponse* response, const bool is_debug = false, bool performance_sensitive = true);
 
     bool SQLBatchRequestQuery(const std::string& db, const std::string& sql,
                               std::shared_ptr<::openmldb::sdk::SQLRequestRowBatch>, brpc::Controller* cntl,

--- a/src/client/tablet_client.h
+++ b/src/client/tablet_client.h
@@ -71,7 +71,8 @@ class TabletClient : public Client {
                bool performance_sensitive = true);
 
     bool Query(const std::string& db, const std::string& sql, const std::string& row, brpc::Controller* cntl,
-               ::openmldb::api::QueryResponse* response, const bool is_debug = false, bool performance_sensitive = true);
+               ::openmldb::api::QueryResponse* response, const bool is_debug = false,
+               bool performance_sensitive = true);
 
     bool SQLBatchRequestQuery(const std::string& db, const std::string& sql,
                               std::shared_ptr<::openmldb::sdk::SQLRequestRowBatch>, brpc::Controller* cntl,

--- a/src/cmd/sql_cmd.h
+++ b/src/cmd/sql_cmd.h
@@ -619,7 +619,7 @@ void HandleSQL(const std::string &sql) {
                 return;
             }
             ::hybridse::sdk::Status status;
-            auto rs = sr->ExecuteSQL(db, sql, &status);
+            auto rs = sr->ExecuteSQL(db, sql, &status, performance_sensitive);
             if (!rs) {
                 std::cout << "fail to execute query" << std::endl;
             } else {

--- a/src/sdk/sql_cluster_router.cc
+++ b/src/sdk/sql_cluster_router.cc
@@ -906,12 +906,13 @@ std::shared_ptr<hybridse::sdk::ResultSet> SQLClusterRouter::ExecuteSQLRequest(co
     return rs;
 }
 std::shared_ptr<::hybridse::sdk::ResultSet> SQLClusterRouter::ExecuteSQL(const std::string& db, const std::string& sql,
-                                                                         ::hybridse::sdk::Status* status) {
-    return ExecuteSQLParameterized(db, sql, std::shared_ptr<openmldb::sdk::SQLRequestRow>(), status);
+                                                                         ::hybridse::sdk::Status* status,
+                                                                         bool performance_sensitive) {
+    return ExecuteSQLParameterized(db, sql, std::shared_ptr<openmldb::sdk::SQLRequestRow>(), status, performance_sensitive);
 }
 std::shared_ptr<::hybridse::sdk::ResultSet> SQLClusterRouter::ExecuteSQLParameterized(
     const std::string& db, const std::string& sql, std::shared_ptr<openmldb::sdk::SQLRequestRow> parameter,
-    ::hybridse::sdk::Status* status) {
+    ::hybridse::sdk::Status* status, bool performance_sensitive) {
     auto cntl = std::make_shared<::brpc::Controller>();
     cntl->set_timeout_ms(options_.request_timeout);
     auto response = std::make_shared<::openmldb::api::QueryResponse>();
@@ -929,7 +930,7 @@ std::shared_ptr<::hybridse::sdk::ResultSet> SQLClusterRouter::ExecuteSQLParamete
     }
     DLOG(INFO) << " send query to tablet " << client->GetEndpoint();
     if (!client->Query(db, sql, parameter_types, parameter ? parameter->GetRow() : "", cntl.get(), response.get(),
-                       options_.enable_debug)) {
+                       options_.enable_debug, performance_sensitive)) {
         status->msg = response->msg();
         status->code = -1;
         return {};

--- a/src/sdk/sql_cluster_router.cc
+++ b/src/sdk/sql_cluster_router.cc
@@ -908,7 +908,8 @@ std::shared_ptr<hybridse::sdk::ResultSet> SQLClusterRouter::ExecuteSQLRequest(co
 std::shared_ptr<::hybridse::sdk::ResultSet> SQLClusterRouter::ExecuteSQL(const std::string& db, const std::string& sql,
                                                                          ::hybridse::sdk::Status* status,
                                                                          bool performance_sensitive) {
-    return ExecuteSQLParameterized(db, sql, std::shared_ptr<openmldb::sdk::SQLRequestRow>(), status, performance_sensitive);
+    return ExecuteSQLParameterized(db, sql, std::shared_ptr<openmldb::sdk::SQLRequestRow>(), status,
+        performance_sensitive);
 }
 std::shared_ptr<::hybridse::sdk::ResultSet> SQLClusterRouter::ExecuteSQLParameterized(
     const std::string& db, const std::string& sql, std::shared_ptr<openmldb::sdk::SQLRequestRow> parameter,

--- a/src/sdk/sql_cluster_router.h
+++ b/src/sdk/sql_cluster_router.h
@@ -142,11 +142,13 @@ class SQLClusterRouter : public SQLRouter {
                                                                 std::shared_ptr<SQLRequestRow> row,
                                                                 hybridse::sdk::Status* status) override;
     std::shared_ptr<hybridse::sdk::ResultSet> ExecuteSQL(const std::string& db, const std::string& sql,
-                                                         ::hybridse::sdk::Status* status) override;
+                                                         ::hybridse::sdk::Status* status,
+                                                         bool performance_sensitive = true) override;
     /// Execute batch SQL with parameter row
     std::shared_ptr<hybridse::sdk::ResultSet> ExecuteSQLParameterized(const std::string& db, const std::string& sql,
                                                          std::shared_ptr<SQLRequestRow> parameter,
-                                                         ::hybridse::sdk::Status* status) override;
+                                                         ::hybridse::sdk::Status* status,
+                                                         bool performance_sensitive = true) override;
 
     std::shared_ptr<hybridse::sdk::ResultSet> ExecuteSQLBatchRequest(const std::string& db, const std::string& sql,
                                                                      std::shared_ptr<SQLRequestRowBatch> row_batch,

--- a/src/sdk/sql_router.h
+++ b/src/sdk/sql_router.h
@@ -103,11 +103,12 @@ class SQLRouter {
         hybridse::sdk::Status* status) = 0;
 
     virtual std::shared_ptr<hybridse::sdk::ResultSet> ExecuteSQL(const std::string& db, const std::string& sql,
-                                                                 hybridse::sdk::Status* status) = 0;
+                                                                 hybridse::sdk::Status* status,
+                                                                 bool performance_sensitive = true) = 0;
 
     virtual std::shared_ptr<hybridse::sdk::ResultSet> ExecuteSQLParameterized(
         const std::string& db, const std::string& sql, std::shared_ptr<openmldb::sdk::SQLRequestRow> parameter,
-        hybridse::sdk::Status* status) = 0;
+        hybridse::sdk::Status* status, bool performance_sensitive = true) = 0;
 
     virtual std::shared_ptr<hybridse::sdk::ResultSet> ExecuteSQLBatchRequest(
         const std::string& db, const std::string& sql, std::shared_ptr<openmldb::sdk::SQLRequestRowBatch> row_batch,

--- a/src/tablet/tablet_impl.cc
+++ b/src/tablet/tablet_impl.cc
@@ -683,7 +683,8 @@ int TabletImpl::CheckTableMeta(const openmldb::api::TableMeta* table_meta, std::
     }
     if (table_meta->tid() <= 0) {
         msg = "tid is zero";
-        return -1;
+        // tobe
+        //return -1;
     }
     std::map<std::string, ::openmldb::type::DataType> column_map;
     if (table_meta->column_desc_size() > 0) {

--- a/src/tablet/tablet_impl.cc
+++ b/src/tablet/tablet_impl.cc
@@ -683,8 +683,7 @@ int TabletImpl::CheckTableMeta(const openmldb::api::TableMeta* table_meta, std::
     }
     if (table_meta->tid() <= 0) {
         msg = "tid is zero";
-        // tobe
-        //return -1;
+        return -1;
     }
     std::map<std::string, ::openmldb::type::DataType> column_map;
     if (table_meta->column_desc_size() > 0) {


### PR DESCRIPTION
* Support `set` sql command
* Pass `performance_sensitive` to sql client query
* Resolve https://github.com/4paradigm/OpenMLDB/issues/555

We will add ut after merging the pr for `sql_cmd_test.cc`. We will pass `performance_sensitive` for explain API later.