### PR TITLE
fix: memory problems reported by sanitizer

### DIFF
--- a/hybridse/CMakeLists.txt
+++ b/hybridse/CMakeLists.txt
@@ -51,6 +51,7 @@ option(PYSDK_ENABLE "Enable pysdk" ON)
 option(JAVASDK_ENABLE "Enable javasdk" ON)
 option(EXAMPLES_ENABLE "Enable examples" ON)
 option(LLVM_EXT_ENABLE "Enable llvm ext sources" OFF)
+option(SANITIZER_ENABLE "Enable AddressSanitizer in Debug mode" OFF)
 
 if (NOT DEFINED CMAKE_PREFIX_PATH)
     set(CMAKE_PREFIX_PATH ${CMAKE_SOURCE_DIR}/thirdparty)
@@ -65,6 +66,12 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+if (SANITIZER_ENABLE)
+    set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+    set (CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+    message(STATUS "Enabled AddressSanitizer")
+endif()
 
 set(SWIG_DIR ${CMAKE_PREFIX_PATH}/share/swig/4.0.1)
 # llvm dependency

--- a/hybridse/examples/toydb/src/storage/table_iterator_test.cc
+++ b/hybridse/examples/toydb/src/storage/table_iterator_test.cc
@@ -50,7 +50,7 @@ class TableIteratorTest : public ::testing::Test {
     ~TableIteratorTest() {}
 };
 
-TEST_F(TableIteratorTest, empty_window_table) {
+TEST_F(TableIteratorTest, EmptyWindowTable) {
     type::TableDef table_def;
     BuildTableSchema(table_def);
     std::shared_ptr<Table> table(new Table(1, 1, table_def));
@@ -59,7 +59,7 @@ TEST_F(TableIteratorTest, empty_window_table) {
     ASSERT_FALSE(it.Valid());
 }
 
-TEST_F(TableIteratorTest, empty_full_table) {
+TEST_F(TableIteratorTest, EmptyFullTable) {
     type::TableDef table_def;
     BuildTableSchema(table_def);
     std::shared_ptr<Table> table(new Table(1, 1, table_def));
@@ -68,7 +68,7 @@ TEST_F(TableIteratorTest, empty_full_table) {
     ASSERT_FALSE(it.Valid());
 }
 
-TEST_F(TableIteratorTest, it_full_table) {
+TEST_F(TableIteratorTest, ItFullTable) {
     type::TableDef table_def;
     BuildTableSchema(table_def);
     std::shared_ptr<Table> table(new Table(1, 1, table_def));
@@ -104,7 +104,7 @@ TEST_F(TableIteratorTest, it_full_table) {
     ASSERT_FALSE(it.Valid());
 }
 
-TEST_F(TableIteratorTest, it_window_table) {
+TEST_F(TableIteratorTest, ItWindowTable) {
     type::TableDef table_def;
     BuildTableSchema(table_def);
     std::shared_ptr<Table> table(new Table(1, 1, table_def));
@@ -129,7 +129,8 @@ TEST_F(TableIteratorTest, it_window_table) {
     ASSERT_TRUE(it.Valid());
     {
         auto key = it.GetKey();
-        Row key_expect("key1");
+        const std::string key1 = "key1";
+        Row key_expect(key1);
         ASSERT_EQ(0, key.compare(key_expect));
         auto wit = it.GetValue();
         wit->SeekToFirst();
@@ -142,7 +143,8 @@ TEST_F(TableIteratorTest, it_window_table) {
     it.Next();
     {
         auto key = it.GetKey();
-        Row key_expect("key2");
+        const std::string key2 = "key2";
+        Row key_expect(key2);
         ASSERT_EQ(0, key.compare(key_expect));
         auto wit = it.GetValue();
         wit->SeekToFirst();

--- a/hybridse/include/base/fe_slice.h
+++ b/hybridse/include/base/fe_slice.h
@@ -115,10 +115,11 @@ inline int Slice::compare(const Slice &b) const {
     const size_t min_len = (size_ < b.size_) ? size_ : b.size_;
     int r = memcmp(data_, b.data_, min_len);
     if (r == 0) {
-        if (size_ < b.size_)
+        if (size_ < b.size_) {
             r = -1;
-        else if (size_ > b.size_)
+        } else if (size_ > b.size_) {
             r = +1;
+        }
     }
     return r;
 }

--- a/hybridse/include/base/mem_pool.h
+++ b/hybridse/include/base/mem_pool.h
@@ -39,7 +39,7 @@ class MemoryChunk {
                    << reinterpret_cast<void*>(this) << ")" << std::endl;
         delete[] mem_;
     }
-    inline size_t available_size() { return chuck_size_ - allocated_size_; }
+    inline size_t available_size() const { return chuck_size_ - allocated_size_; }
     char* Alloc(size_t request_size) {
         if (request_size > available_size()) {
             return nullptr;
@@ -48,15 +48,14 @@ class MemoryChunk {
         allocated_size_ += request_size;
         return addr;
     }
-    inline void free() { allocated_size_ = 0; }
     inline MemoryChunk* next() { return next_; }
     enum { DEFAULT_CHUCK_SIZE = 4096 };
 
  private:
     MemoryChunk* next_;
-    size_t chuck_size_;
+    const size_t chuck_size_;
     size_t allocated_size_;
-    char* mem_;
+    char* const mem_;
 };
 class ByteMemoryPool {
  public:

--- a/hybridse/include/codec/row.h
+++ b/hybridse/include/codec/row.h
@@ -38,9 +38,9 @@ class Row {
     Row();
     explicit Row(const std::string &str);
     Row(const Row &s);
-    Row(size_t major_slices, const Row &major, size_t secondary_slices,
+    explicit Row(size_t major_slices, const Row &major, size_t secondary_slices,
         const Row &secondary);
-    Row(const hybridse::base::RefCountedSlice &s, size_t secondary_slices,
+    explicit Row(const hybridse::base::RefCountedSlice &s, size_t secondary_slices,
         const Row &secondary);
 
     explicit Row(const hybridse::base::RefCountedSlice &s);

--- a/hybridse/include/codec/type_codec.h
+++ b/hybridse/include/codec/type_codec.h
@@ -27,30 +27,38 @@
 
 namespace hybridse {
 namespace codec {
+
 static const uint32_t SEED = 0xe17a1465;
+
 struct StringRef {
     StringRef() : size_(0), data_(nullptr) {}
     explicit StringRef(const char* str)
         : size_(nullptr == str ? 0 : strlen(str)), data_(str) {}
+    explicit StringRef(uint32_t size, const char* data) : size_(size), data_(data) {}
+
     explicit StringRef(const std::string& str)
         : size_(str.size()), data_(str.data()) {}
-    StringRef(uint32_t size, const char* data) : size_(size), data_(data) {}
+
     ~StringRef() {}
+
     const inline bool IsNull() const { return nullptr == data_; }
     const std::string ToString() const {
         return size_ == 0 ? "" : std::string(data_, size_);
     }
+
     static int compare(const StringRef& a, const StringRef& b) {
         const size_t min_len = (a.size_ < b.size_) ? a.size_ : b.size_;
         int r = memcmp(a.data_, b.data_, min_len);
         if (r == 0) {
-            if (a.size_ < b.size_)
+            if (a.size_ < b.size_) {
                 r = -1;
-            else if (a.size_ > b.size_)
+            } else if (a.size_ > b.size_) {
                 r = +1;
+            }
         }
         return r;
     }
+
     uint32_t size_;
     const char* data_;
 };

--- a/hybridse/src/base/mem_pool_test.cc
+++ b/hybridse/src/base/mem_pool_test.cc
@@ -37,11 +37,13 @@ TEST_F(MemPoolTest, ByteMemoryPoolTest) {
 
     {
         ByteMemoryPool mem_pool;
+        const char src1[] = "helloworld";
         char* s1 = mem_pool.Alloc(10);
-        memcpy(s1, "helloworld", 10);
+        memcpy(s1, src1, strlen(src1));
 
+        const char src2[] = "hybridse";
         char* s2 = mem_pool.Alloc(5);
-        memcpy(s2, "hybridse", 10);
+        memcpy(s2, src2, strlen(src2));
 
         char* s3 = mem_pool.Alloc(15);
         memcpy(s3, s1, 10);

--- a/hybridse/src/codegen/cast_expr_ir_builder_test.cc
+++ b/hybridse/src/codegen/cast_expr_ir_builder_test.cc
@@ -479,7 +479,7 @@ void CastExprCheck(CASTTYPE exp_value, std::string src_type_str,
                 return;
             }
             ExprCheck<CASTTYPE, udf::Nullable<codec::StringRef>>(
-                cast_func, exp_value, codec::StringRef(src_value_str));
+                cast_func, exp_value, codec::StringRef(src_value_str.size(), src_value_str.data()));
             break;
         }
         default: {
@@ -597,7 +597,7 @@ void CastExprCheck(std::string cast_type_str, std::string cast_value_str,
                     nullptr, src_type_str, src_value_str);
             } else {
                 CastExprCheck<codec::StringRef>(
-                    codec::StringRef(cast_value_str), src_type_str,
+                    codec::StringRef(cast_value_str.size(), cast_value_str.data()), src_type_str,
                     src_value_str);
             }
             break;

--- a/hybridse/src/codegen/udf_ir_builder_test.cc
+++ b/hybridse/src/codegen/udf_ir_builder_test.cc
@@ -560,16 +560,16 @@ TEST_F(UdfIRBuilderTest, substring_pos_udf_test) {
 TEST_F(UdfIRBuilderTest, concat_str_udf_test) {
     //    concat("12345") == "12345"
     CheckUdf<StringRef, StringRef>("concat", StringRef("12345"),
-                                   StringRef(std::string("12345")));
+                                   StringRef("12345"));
 
     // concat("12345", "67890") == "1234567890"
     CheckUdf<StringRef, StringRef, StringRef>("concat", StringRef("1234567890"),
-                                              StringRef(std::string("12345")),
+                                              StringRef("12345"),
                                               StringRef("67890"));
 
     // concat("123", "4567890", "abcde") == "1234567890abcde"
     CheckUdf<StringRef, StringRef, StringRef, StringRef>(
-        "concat", StringRef("1234567890abcde"), StringRef(std::string("123")),
+        "concat", StringRef("1234567890abcde"), StringRef("123"),
         StringRef("4567890"), StringRef("abcde"));
 
     // concat("1", "23", "456", "7890", "abc", "de") == "1234567890abcde"

--- a/hybridse/src/planv2/ast_node_converter.cc
+++ b/hybridse/src/planv2/ast_node_converter.cc
@@ -1676,7 +1676,6 @@ base::Status ASTIntervalLIteralToNum(const zetasql::ASTExpression* ast_expr, int
                         ": invalid interval unit")
     }
     bool is_null = false;
-    const int size = interval_literal->image().size();
     codec::StringRef str_ref(interval_literal->image().size() - 1, interval_literal->image().data());
     udf::v1::string_to_bigint(&str_ref, val, &is_null);
 

--- a/hybridse/src/udf/default_udf_library.cc
+++ b/hybridse/src/udf/default_udf_library.cc
@@ -1722,7 +1722,7 @@ void DefaultUdfLibrary::InitDateUdf() {
 }
 
 void DefaultUdfLibrary::Init() {
-    udf::RegisterNativeUdfToModule();
+    udf::RegisterNativeUdfToModule(this->node_manager());
     InitUtilityUdf();
     InitDateUdf();
     InitTypeUdf();

--- a/hybridse/src/udf/udf.cc
+++ b/hybridse/src/udf/udf.cc
@@ -879,42 +879,41 @@ bool RegisterMethod(const std::string &fn_name, hybridse::node::TypeNode *ret,
     return true;
 }
 
-void RegisterNativeUdfToModule() {
-    node::NodeManager nm;
+void RegisterNativeUdfToModule(hybridse::node::NodeManager* nm) {
     base::Status status;
 
-    auto bool_ty = nm.MakeTypeNode(node::kBool);
-    auto i32_ty = nm.MakeTypeNode(node::kInt32);
-    auto i64_ty = nm.MakeTypeNode(node::kInt64);
-    auto i16_ty = nm.MakeTypeNode(node::kInt16);
-    auto float_ty = nm.MakeTypeNode(node::kFloat);
-    auto double_ty = nm.MakeTypeNode(node::kDouble);
-    auto time_ty = nm.MakeTypeNode(node::kTimestamp);
-    auto date_ty = nm.MakeTypeNode(node::kDate);
-    auto string_ty = nm.MakeTypeNode(node::kVarchar);
-    auto row_ty = nm.MakeTypeNode(node::kRow);
+    auto bool_ty = nm->MakeTypeNode(node::kBool);
+    auto i32_ty = nm->MakeTypeNode(node::kInt32);
+    auto i64_ty = nm->MakeTypeNode(node::kInt64);
+    auto i16_ty = nm->MakeTypeNode(node::kInt16);
+    auto float_ty = nm->MakeTypeNode(node::kFloat);
+    auto double_ty = nm->MakeTypeNode(node::kDouble);
+    auto time_ty = nm->MakeTypeNode(node::kTimestamp);
+    auto date_ty = nm->MakeTypeNode(node::kDate);
+    auto string_ty = nm->MakeTypeNode(node::kVarchar);
+    auto row_ty = nm->MakeTypeNode(node::kRow);
 
-    auto list_i32_ty = nm.MakeTypeNode(node::kList, i32_ty);
-    auto list_i64_ty = nm.MakeTypeNode(node::kList, i64_ty);
-    auto list_i16_ty = nm.MakeTypeNode(node::kList, i16_ty);
-    auto list_bool_ty = nm.MakeTypeNode(node::kList, bool_ty);
-    auto list_float_ty = nm.MakeTypeNode(node::kList, float_ty);
-    auto list_double_ty = nm.MakeTypeNode(node::kList, double_ty);
-    auto list_time_ty = nm.MakeTypeNode(node::kList, time_ty);
-    auto list_date_ty = nm.MakeTypeNode(node::kList, date_ty);
-    auto list_string_ty = nm.MakeTypeNode(node::kList, string_ty);
-    auto list_row_ty = nm.MakeTypeNode(node::kList, row_ty);
+    auto list_i32_ty = nm->MakeTypeNode(node::kList, i32_ty);
+    auto list_i64_ty = nm->MakeTypeNode(node::kList, i64_ty);
+    auto list_i16_ty = nm->MakeTypeNode(node::kList, i16_ty);
+    auto list_bool_ty = nm->MakeTypeNode(node::kList, bool_ty);
+    auto list_float_ty = nm->MakeTypeNode(node::kList, float_ty);
+    auto list_double_ty = nm->MakeTypeNode(node::kList, double_ty);
+    auto list_time_ty = nm->MakeTypeNode(node::kList, time_ty);
+    auto list_date_ty = nm->MakeTypeNode(node::kList, date_ty);
+    auto list_string_ty = nm->MakeTypeNode(node::kList, string_ty);
+    auto list_row_ty = nm->MakeTypeNode(node::kList, row_ty);
 
-    auto iter_i32_ty = nm.MakeTypeNode(node::kIterator, i32_ty);
-    auto iter_i64_ty = nm.MakeTypeNode(node::kIterator, i64_ty);
-    auto iter_i16_ty = nm.MakeTypeNode(node::kIterator, i16_ty);
-    auto iter_bool_ty = nm.MakeTypeNode(node::kIterator, bool_ty);
-    auto iter_float_ty = nm.MakeTypeNode(node::kIterator, float_ty);
-    auto iter_double_ty = nm.MakeTypeNode(node::kIterator, double_ty);
-    auto iter_time_ty = nm.MakeTypeNode(node::kIterator, time_ty);
-    auto iter_date_ty = nm.MakeTypeNode(node::kIterator, date_ty);
-    auto iter_string_ty = nm.MakeTypeNode(node::kIterator, string_ty);
-    auto iter_row_ty = nm.MakeTypeNode(node::kIterator, row_ty);
+    auto iter_i32_ty = nm->MakeTypeNode(node::kIterator, i32_ty);
+    auto iter_i64_ty = nm->MakeTypeNode(node::kIterator, i64_ty);
+    auto iter_i16_ty = nm->MakeTypeNode(node::kIterator, i16_ty);
+    auto iter_bool_ty = nm->MakeTypeNode(node::kIterator, bool_ty);
+    auto iter_float_ty = nm->MakeTypeNode(node::kIterator, float_ty);
+    auto iter_double_ty = nm->MakeTypeNode(node::kIterator, double_ty);
+    auto iter_time_ty = nm->MakeTypeNode(node::kIterator, time_ty);
+    auto iter_date_ty = nm->MakeTypeNode(node::kIterator, date_ty);
+    auto iter_string_ty = nm->MakeTypeNode(node::kIterator, string_ty);
+    auto iter_row_ty = nm->MakeTypeNode(node::kIterator, row_ty);
 
     RegisterMethod("iterator", bool_ty, {list_i16_ty, iter_i16_ty},
                    reinterpret_cast<void *>(v1::iterator_list<int16_t>));

--- a/hybridse/src/udf/udf.h
+++ b/hybridse/src/udf/udf.h
@@ -22,6 +22,7 @@
 #include "boost/lexical_cast.hpp"
 #include "codec/list_iterator_codec.h"
 #include "codec/type_codec.h"
+#include "node/node_manager.h"
 #include "proto/fe_type.pb.h"
 
 namespace hybridse {
@@ -277,7 +278,7 @@ uint32_t to_string_len(const V &v);
 
 }  // namespace v1
 
-void RegisterNativeUdfToModule();
+void RegisterNativeUdfToModule(hybridse::node::NodeManager* nm);
 }  // namespace udf
 }  // namespace hybridse
 

--- a/hybridse/src/vm/transform.cc
+++ b/hybridse/src/vm/transform.cc
@@ -1533,7 +1533,7 @@ Status BatchModeTransformer::GenFnDef(const node::FuncDefPlanNode* fn_plan) {
     ::hybridse::codegen::FnIRBuilder builder(module_);
     ::llvm::Function* fn = nullptr;
     Status status;
-    bool ok = builder.Build(fn_plan->fn_def_, &fn, status);
+    builder.Build(fn_plan->fn_def_, &fn, status);
     CHECK_STATUS(status)
 
     type::Type column_type;


### PR DESCRIPTION
Add Sanitizer build option to hybridse
- with `-DSANITIZER_ENABLE=ON` to enable address sanitizer. Note: only available if `CMAKE_BUILD_TYPE` is `Debug`

*Note: if runs on macos, sanitizer may fail still, see #581*

Fix
- #565 
- #567 
- #561 

***Note: `StringRef` might broken with a bad usage, there is discussion on #560 . But remains TODO because `std::string_view` has the same problem.***