### PR TITLE
fix: show deployments of db returns empty, not error

### DIFF
--- a/src/cmd/sql_cmd.h
+++ b/src/cmd/sql_cmd.h
@@ -536,9 +536,9 @@ void PrintProcedureSchema(const std::string& head, const ::hybridse::sdk::Schema
             stream << "Empty set" << std::endl;
             return;
         }
+        stream << head << std::endl;
 
         ::hybridse::base::TextTable t('-', ' ', ' ');
-
         t.add("#");
         t.add("Field");
         t.add("Type");
@@ -1281,7 +1281,7 @@ void HandleSQL(const std::string& sql) {
             if (status.OK()) {
                 sr->RefreshCatalog();
                 std::cout << "SUCCEED: Create successfully" << std::endl;
-            }  else {
+            } else {
                 std::cout << "ERROR: " << status.msg << std::endl;
             }
             return;

--- a/src/cmd/sql_cmd.h
+++ b/src/cmd/sql_cmd.h
@@ -536,7 +536,7 @@ void PrintProcedureSchema(const std::string& head, const ::hybridse::sdk::Schema
             stream << "Empty set" << std::endl;
             return;
         }
-        stream << head << std::endl;
+        stream << "# " << head << std::endl;
 
         ::hybridse::base::TextTable t('-', ' ', ' ');
         t.add("#");

--- a/src/cmd/sql_cmd.h
+++ b/src/cmd/sql_cmd.h
@@ -560,9 +560,12 @@ void PrintProcedureSchema(const std::string& head, const ::hybridse::sdk::Schema
 }
 
 void PrintProcedureInfo(const hybridse::sdk::ProcedureInfo& sp_info) {
-    std::vector<std::vector<std::string>> vec;
-    vec.push_back({sp_info.GetDbName(), sp_info.GetSpName()});
-    PrintItemTable(std::cout, {"DB", "SP"}, vec);
+    std::vector<std::string> vec{sp_info.GetDbName(), sp_info.GetSpName()};
+    std::string type_name = "SP";
+    if (sp_info.GetType() == hybridse::sdk::kReqDeployment) {
+        type_name = "Deployment";
+    }
+    PrintItemTable(std::cout, {"DB", type_name}, {vec}, true);
     std::vector<std::string> items{sp_info.GetSql()};
     PrintItemTable(std::cout, {"SQL"}, {items}, true);
     PrintProcedureSchema("Input Schema", sp_info.GetInputSchema(), std::cout);

--- a/src/nameserver/name_server_impl.cc
+++ b/src/nameserver/name_server_impl.cc
@@ -10159,9 +10159,7 @@ void NameServerImpl::ShowProcedure(RpcController* controller, const api::ShowPro
         }
         // only find one db
         if (db_sp_info_map_.find(db_name) == db_sp_info_map_.end()) {
-            response->set_code(::openmldb::base::ReturnCode::kDatabaseNotFound);
-            response->set_msg("database not found");
-            PDLOG(WARNING, "database[%s] not found", db_name);
+            // db_sp_info_map_ has no entry of db, just means no sp in db, return empty sp info array.
             return;
         }
         auto& sp_map = db_sp_info_map_[db_name];


### PR DESCRIPTION
Show deployments of db shouldn't return error, cause the 'sp info map' will delete the db if no sp in it. 