### PR TITLE
refactor: define performance_sensitive in sql_cluster

### DIFF
--- a/src/cmd/sql_cmd.h
+++ b/src/cmd/sql_cmd.h
@@ -74,7 +74,6 @@ const std::string VERSION = std::to_string(OPENMLDB_VERSION_MAJOR) + "." +  // N
 std::string db = "";  // NOLINT
 ::openmldb::sdk::DBSDK* cs = nullptr;
 ::openmldb::sdk::SQLClusterRouter* sr = nullptr;
-bool performance_sensitive = true;
 
 // TODO(zekai): refactor status and error code
 class FileOptionsParser {
@@ -1068,7 +1067,8 @@ void SetVariable(const std::string& key, const hybridse::node::ConstNode* value)
     boost::to_lower(lower_key);
     if (lower_key == "performance_sensitive") {
         if (value->GetDataType() == hybridse::node::kBool) {
-            performance_sensitive = value->GetBool();
+            bool performance_sensitive = value->GetBool();
+            sr->SetPerformanceSensitive(performance_sensitive);
             printf("SUCCEED: Success to set %s as %s\n", key.c_str(), performance_sensitive ? "true" : "false");
         } else {
             printf("ERROR: The type of %s should be bool\n", key.c_str());
@@ -1295,7 +1295,7 @@ void HandleSQL(const std::string& sql) {
             std::string mu_script = sql;
             mu_script.replace(0u, 7u, empty);
             ::hybridse::sdk::Status status;
-            auto info = sr->Explain(db, mu_script, &status, performance_sensitive);
+            auto info = sr->Explain(db, mu_script, &status);
             if (!info) {
                 std::cout << "ERROR: Failed to get explain info" << std::endl;
                 return;
@@ -1369,7 +1369,7 @@ void HandleSQL(const std::string& sql) {
         case hybridse::node::kPlanTypeFuncDef:
         case hybridse::node::kPlanTypeQuery: {
             ::hybridse::sdk::Status status;
-            auto rs = sr->ExecuteSQL(db, sql, &status, performance_sensitive);
+            auto rs = sr->ExecuteSQL(db, sql, &status);
             if (!rs) {
                 std::cout << "ERROR: " << status.msg << std::endl;
             } else {
@@ -1383,7 +1383,7 @@ void HandleSQL(const std::string& sql) {
             const std::string& file_path = select_into_plan_node->OutFile();
             const std::shared_ptr<hybridse::node::OptionsMap> options_map = select_into_plan_node->Options();
             ::hybridse::sdk::Status status;
-            auto rs = sr->ExecuteSQL(db, query_sql, &status, performance_sensitive);
+            auto rs = sr->ExecuteSQL(db, query_sql, &status);
             if (!rs) {
                 std::cout << "ERROR: Failed to execute query" << std::endl;
             } else {

--- a/src/sdk/sql_cluster_router.cc
+++ b/src/sdk/sql_cluster_router.cc
@@ -212,8 +212,7 @@ std::shared_ptr<SQLRequestRow> SQLClusterRouter::GetRequestRow(const std::string
     ::hybridse::vm::ExplainOutput explain;
     ::hybridse::base::Status vm_status;
 
-    bool ok = cluster_sdk_->GetEngine()->Explain(sql, db, ::hybridse::vm::kRequestMode,
-                                                 &explain, &vm_status);
+    bool ok = cluster_sdk_->GetEngine()->Explain(sql, db, ::hybridse::vm::kRequestMode, &explain, &vm_status);
     if (!ok) {
         status->code = -1;
         status->msg = vm_status.msg;
@@ -547,15 +546,14 @@ DefaultValueMap SQLClusterRouter::GetDefaultMap(std::shared_ptr<::openmldb::name
         if (!column_map.empty()) {
             i = column_map.at(idx);
         }
-        if (hybridse::node::kExprPrimary != row->children_.at(i)->GetExprType()
-            && hybridse::node::kExprParameter != row->children_.at(i)->GetExprType()) {
+        if (hybridse::node::kExprPrimary != row->children_.at(i)->GetExprType() &&
+            hybridse::node::kExprParameter != row->children_.at(i)->GetExprType()) {
             LOG(WARNING) << "insert value isn't const value or placeholder";
             return {};
         }
 
         if (hybridse::node::kExprPrimary == row->children_.at(i)->GetExprType()) {
-            ::hybridse::node::ConstNode* primary =
-                dynamic_cast<::hybridse::node::ConstNode*>(row->children_.at(i));
+            ::hybridse::node::ConstNode* primary = dynamic_cast<::hybridse::node::ConstNode*>(row->children_.at(i));
             std::shared_ptr<::hybridse::node::ConstNode> val;
             if (primary->IsNull()) {
                 if (column.not_null()) {
@@ -734,15 +732,19 @@ bool SQLClusterRouter::DropDB(const std::string& db, hybridse::sdk::Status* stat
     }
     return true;
 }
+
+void SQLClusterRouter::SetPerformanceSensitive(const bool performance_sensitive) {
+    performance_sensitive_ = performance_sensitive;
+}
+
 std::shared_ptr<::openmldb::client::TabletClient> SQLClusterRouter::GetTabletClient(
     const std::string& db, const std::string& sql, const ::hybridse::vm::EngineMode engine_mode,
     const std::shared_ptr<SQLRequestRow>& row) {
     return GetTabletClient(db, sql, engine_mode, row, std::shared_ptr<openmldb::sdk::SQLRequestRow>());
 }
 std::shared_ptr<::openmldb::client::TabletClient> SQLClusterRouter::GetTabletClient(
-    const std::string& db, const std::string& sql, const ::hybridse::vm::EngineMode engine_mode, const
-                                                       std::shared_ptr<SQLRequestRow>& row,
-    const std::shared_ptr<openmldb::sdk::SQLRequestRow>& parameter) {
+    const std::string& db, const std::string& sql, const ::hybridse::vm::EngineMode engine_mode,
+    const std::shared_ptr<SQLRequestRow>& row, const std::shared_ptr<openmldb::sdk::SQLRequestRow>& parameter) {
     ::hybridse::codec::Schema parameter_schema_raw;
     if (parameter) {
         for (int i = 0; i < parameter->GetSchema()->GetColumnCnt(); i++) {
@@ -765,8 +767,7 @@ std::shared_ptr<::openmldb::client::TabletClient> SQLClusterRouter::GetTabletCli
     if (!cache) {
         ::hybridse::vm::ExplainOutput explain;
         ::hybridse::base::Status vm_status;
-        if (cluster_sdk_->GetEngine()->Explain(sql, db, engine_mode, parameter_schema_raw, &explain,
-                                               &vm_status)) {
+        if (cluster_sdk_->GetEngine()->Explain(sql, db, engine_mode, parameter_schema_raw, &explain, &vm_status)) {
             std::shared_ptr<::hybridse::sdk::SchemaImpl> schema;
             if (explain.input_schema.size() > 0) {
                 schema = std::make_shared<::hybridse::sdk::SchemaImpl>(explain.input_schema);
@@ -781,8 +782,7 @@ std::shared_ptr<::openmldb::client::TabletClient> SQLClusterRouter::GetTabletCli
                 }
             }
             if (schema) {
-                cache = std::make_shared<SQLCache>(
-                    schema, parameter_schema, explain.router);
+                cache = std::make_shared<SQLCache>(schema, parameter_schema, explain.router);
                 SetCache(db, sql, cache);
             }
         }
@@ -905,14 +905,12 @@ std::shared_ptr<hybridse::sdk::ResultSet> SQLClusterRouter::ExecuteSQLRequest(co
     return rs;
 }
 std::shared_ptr<::hybridse::sdk::ResultSet> SQLClusterRouter::ExecuteSQL(const std::string& db, const std::string& sql,
-                                                                         ::hybridse::sdk::Status* status,
-                                                                         bool performance_sensitive) {
-    return ExecuteSQLParameterized(db, sql, std::shared_ptr<openmldb::sdk::SQLRequestRow>(), status,
-        performance_sensitive);
+                                                                         ::hybridse::sdk::Status* status) {
+    return ExecuteSQLParameterized(db, sql, std::shared_ptr<openmldb::sdk::SQLRequestRow>(), status);
 }
 std::shared_ptr<::hybridse::sdk::ResultSet> SQLClusterRouter::ExecuteSQLParameterized(
     const std::string& db, const std::string& sql, std::shared_ptr<openmldb::sdk::SQLRequestRow> parameter,
-    ::hybridse::sdk::Status* status, bool performance_sensitive) {
+    ::hybridse::sdk::Status* status) {
     auto cntl = std::make_shared<::brpc::Controller>();
     cntl->set_timeout_ms(options_.request_timeout);
     auto response = std::make_shared<::openmldb::api::QueryResponse>();
@@ -930,7 +928,7 @@ std::shared_ptr<::hybridse::sdk::ResultSet> SQLClusterRouter::ExecuteSQLParamete
     }
     DLOG(INFO) << " send query to tablet " << client->GetEndpoint();
     if (!client->Query(db, sql, parameter_types, parameter ? parameter->GetRow() : "", cntl.get(), response.get(),
-                       options_.enable_debug, performance_sensitive)) {
+                       options_.enable_debug, performance_sensitive_)) {
         status->msg = response->msg();
         status->code = -1;
         return {};
@@ -950,7 +948,7 @@ std::shared_ptr<hybridse::sdk::ResultSet> SQLClusterRouter::ExecuteSQLBatchReque
     cntl->set_timeout_ms(options_.request_timeout);
     auto response = std::make_shared<::openmldb::api::SQLBatchRequestQueryResponse>();
     auto client = GetTabletClient(db, sql, hybridse::vm::kBatchRequestMode, std::shared_ptr<SQLRequestRow>(),
-        std::shared_ptr<SQLRequestRow>());
+                                  std::shared_ptr<SQLRequestRow>());
     if (!client) {
         status->code = -1;
         status->msg = "no tablet found";
@@ -1139,13 +1137,12 @@ bool SQLClusterRouter::GetSQLPlan(const std::string& sql, ::hybridse::node::Node
 bool SQLClusterRouter::RefreshCatalog() { return cluster_sdk_->Refresh(); }
 
 std::shared_ptr<ExplainInfo> SQLClusterRouter::Explain(const std::string& db, const std::string& sql,
-                                                       ::hybridse::sdk::Status* status,
-                                                       bool performance_sensitive) {
+                                                       ::hybridse::sdk::Status* status) {
     ::hybridse::vm::ExplainOutput explain_output;
     ::hybridse::base::Status vm_status;
     ::hybridse::codec::Schema parameter_schema;
     bool ok = cluster_sdk_->GetEngine()->Explain(sql, db, ::hybridse::vm::kRequestMode, parameter_schema,
-                                                 &explain_output, &vm_status, performance_sensitive);
+                                                 &explain_output, &vm_status, performance_sensitive_);
     if (!ok) {
         status->code = -1;
         status->msg = vm_status.msg;
@@ -1154,10 +1151,9 @@ std::shared_ptr<ExplainInfo> SQLClusterRouter::Explain(const std::string& db, co
     }
     ::hybridse::sdk::SchemaImpl input_schema(explain_output.input_schema);
     ::hybridse::sdk::SchemaImpl output_schema(explain_output.output_schema);
-    std::shared_ptr<ExplainInfoImpl> impl(new ExplainInfoImpl(input_schema, output_schema, explain_output.logical_plan,
-                                                              explain_output.physical_plan, explain_output.ir,
-                                                              explain_output.request_db_name,
-                                                              explain_output.request_name));
+    std::shared_ptr<ExplainInfoImpl> impl(
+        new ExplainInfoImpl(input_schema, output_schema, explain_output.logical_plan, explain_output.physical_plan,
+                            explain_output.ir, explain_output.request_db_name, explain_output.request_name));
     return impl;
 }
 
@@ -1251,7 +1247,7 @@ std::shared_ptr<hybridse::sdk::ProcedureInfo> SQLClusterRouter::ShowProcedure(co
 }
 
 base::Status SQLClusterRouter::HandleSQLCmd(const hybridse::node::CmdPlanNode* cmd_node, const std::string& db,
-        std::shared_ptr<::openmldb::client::NsClient> ns_ptr) {
+                                            std::shared_ptr<::openmldb::client::NsClient> ns_ptr) {
     if (cmd_node == nullptr || ns_ptr == nullptr) {
         return base::Status(base::ReturnCode::kSQLCmdRunError, "null pointer");
     }
@@ -1284,9 +1280,8 @@ base::Status SQLClusterRouter::HandleSQLCmd(const hybridse::node::CmdPlanNode* c
     return {};
 }
 
-base::Status SQLClusterRouter::HandleSQLCreateTable(hybridse::node::CreatePlanNode* create_node,
-                                                const std::string& db,
-                                                std::shared_ptr<::openmldb::client::NsClient> ns_ptr) {
+base::Status SQLClusterRouter::HandleSQLCreateTable(hybridse::node::CreatePlanNode* create_node, const std::string& db,
+                                                    std::shared_ptr<::openmldb::client::NsClient> ns_ptr) {
     if (create_node == nullptr || ns_ptr == nullptr) {
         return base::Status(base::ReturnCode::kSQLCmdRunError, "fail to execute plan : null pointer");
     }
@@ -1306,8 +1301,8 @@ base::Status SQLClusterRouter::HandleSQLCreateTable(hybridse::node::CreatePlanNo
 }
 
 base::Status SQLClusterRouter::HandleSQLCreateProcedure(hybridse::node::CreateProcedurePlanNode* create_sp,
-                                                const std::string& db, const std::string& sql,
-                                                std::shared_ptr<::openmldb::client::NsClient> ns_ptr) {
+                                                        const std::string& db, const std::string& sql,
+                                                        std::shared_ptr<::openmldb::client::NsClient> ns_ptr) {
     if (create_sp == nullptr) {
         return base::Status(base::ReturnCode::kSQLCmdRunError, "CreateProcedurePlanNode null");
     }
@@ -1337,9 +1332,9 @@ base::Status SQLClusterRouter::HandleSQLCreateProcedure(hybridse::node::CreatePr
             col_desc->set_data_type(rtidb_type);
             col_desc->set_is_constant(input_ptr->GetIsConstant());
         } else {
-            return base::Status(base::ReturnCode::kSQLCmdRunError,
-                    "fail to execute script with unsupported type " +
-                    hybridse::node::NameOfSqlNodeType(input->GetType()));
+            return base::Status(
+                base::ReturnCode::kSQLCmdRunError,
+                "fail to execute script with unsupported type " + hybridse::node::NameOfSqlNodeType(input->GetType()));
         }
     }
     // get input schema, check input parameter, and fill sp_info
@@ -1352,11 +1347,10 @@ base::Status SQLClusterRouter::HandleSQLCreateProcedure(hybridse::node::CreatePr
     bool ok;
     hybridse::vm::ExplainOutput explain_output;
     if (input_common_column_indices.empty()) {
-        ok = cluster_sdk_->GetEngine()->Explain(sql, db, hybridse::vm::kRequestMode, &explain_output,
-                                                &sql_status);
+        ok = cluster_sdk_->GetEngine()->Explain(sql, db, hybridse::vm::kRequestMode, &explain_output, &sql_status);
     } else {
-        ok = cluster_sdk_->GetEngine()->Explain(sql, db, hybridse::vm::kBatchRequestMode,
-                                                input_common_column_indices, &explain_output, &sql_status);
+        ok = cluster_sdk_->GetEngine()->Explain(sql, db, hybridse::vm::kBatchRequestMode, input_common_column_indices,
+                                                &explain_output, &sql_status);
     }
     if (!ok) {
         return base::Status(base::ReturnCode::kSQLCmdRunError, "fail to explain sql" + sql_status.msg);
@@ -1424,7 +1418,7 @@ bool SQLClusterRouter::CheckSQLSyntax(const std::string& sql) {
     return true;
 }
 bool SQLClusterRouter::ExtractDBTypes(const std::shared_ptr<hybridse::sdk::Schema> schema,
-                           std::vector<openmldb::type::DataType>& db_types) {  // NOLINT
+                                      std::vector<openmldb::type::DataType>& db_types) {  // NOLINT
     if (schema) {
         for (int i = 0; i < schema->GetColumnCnt(); i++) {
             openmldb::type::DataType casted_type;
@@ -1519,8 +1513,8 @@ std::shared_ptr<openmldb::sdk::QueryFuture> SQLClusterRouter::CallSQLBatchReques
     return future;
 }
 
-std::shared_ptr<hybridse::sdk::Schema> SQLClusterRouter::GetTableSchema(
-    const std::string& db, const std::string& table_name) {
+std::shared_ptr<hybridse::sdk::Schema> SQLClusterRouter::GetTableSchema(const std::string& db,
+                                                                        const std::string& table_name) {
     auto table_info = cluster_sdk_->GetTableInfo(db, table_name);
     if (!table_info) {
         LOG(ERROR) << "table with name " + table_name + " in db " + db + " does not exist";

--- a/src/sdk/sql_cluster_router.h
+++ b/src/sdk/sql_cluster_router.h
@@ -56,8 +56,7 @@ struct SQLCache {
         : table_info(table_info), default_map(default_map), column_schema(), str_length(str_length) {
         column_schema = openmldb::sdk::ConvertToSchema(table_info);
     }
-    SQLCache(std::shared_ptr<::hybridse::sdk::Schema> column_schema,
-             const ::hybridse::vm::Router& input_router)
+    SQLCache(std::shared_ptr<::hybridse::sdk::Schema> column_schema, const ::hybridse::vm::Router& input_router)
         : table_info(),
           default_map(),
           column_schema(column_schema),
@@ -113,6 +112,8 @@ class SQLClusterRouter : public SQLRouter {
 
     bool ShowDB(std::vector<std::string>* dbs, hybridse::sdk::Status* status) override;
 
+    void SetPerformanceSensitive(const bool performance_sensitive) override;
+
     bool ExecuteDDL(const std::string& db, const std::string& sql, hybridse::sdk::Status* status) override;
 
     bool ExecuteInsert(const std::string& db, const std::string& sql, ::hybridse::sdk::Status* status) override;
@@ -124,8 +125,9 @@ class SQLClusterRouter : public SQLRouter {
                        hybridse::sdk::Status* status) override;
 
     std::shared_ptr<TableReader> GetTableReader();
+
     std::shared_ptr<ExplainInfo> Explain(const std::string& db, const std::string& sql,
-                                         ::hybridse::sdk::Status* status, bool performance_sensitive = true) override;
+                                         ::hybridse::sdk::Status* status) override;
 
     std::shared_ptr<SQLRequestRow> GetRequestRow(const std::string& db, const std::string& sql,
                                                  ::hybridse::sdk::Status* status) override;
@@ -142,13 +144,11 @@ class SQLClusterRouter : public SQLRouter {
                                                                 std::shared_ptr<SQLRequestRow> row,
                                                                 hybridse::sdk::Status* status) override;
     std::shared_ptr<hybridse::sdk::ResultSet> ExecuteSQL(const std::string& db, const std::string& sql,
-                                                         ::hybridse::sdk::Status* status,
-                                                         bool performance_sensitive = true) override;
+                                                         ::hybridse::sdk::Status* status) override;
     /// Execute batch SQL with parameter row
     std::shared_ptr<hybridse::sdk::ResultSet> ExecuteSQLParameterized(const std::string& db, const std::string& sql,
-                                                         std::shared_ptr<SQLRequestRow> parameter,
-                                                         ::hybridse::sdk::Status* status,
-                                                         bool performance_sensitive = true) override;
+                                                                      std::shared_ptr<SQLRequestRow> parameter,
+                                                                      ::hybridse::sdk::Status* status) override;
 
     std::shared_ptr<hybridse::sdk::ResultSet> ExecuteSQLBatchRequest(const std::string& db, const std::string& sql,
                                                                      std::shared_ptr<SQLRequestRowBatch> row_batch,
@@ -187,23 +187,22 @@ class SQLClusterRouter : public SQLRouter {
         const std::string& db, const std::string& sql, const ::hybridse::vm::EngineMode engine_mode,
         const std::shared_ptr<SQLRequestRow>& row, const std::shared_ptr<SQLRequestRow>& parameter_row);
 
-    std::shared_ptr<hybridse::sdk::Schema> GetTableSchema(
-        const std::string& db, const std::string& table_name) override;
+    std::shared_ptr<hybridse::sdk::Schema> GetTableSchema(const std::string& db,
+                                                          const std::string& table_name) override;
 
-    base::Status HandleSQLCreateProcedure(hybridse::node::CreateProcedurePlanNode* plan,
-            const std::string& db, const std::string& sql,
-            std::shared_ptr<::openmldb::client::NsClient> ns_ptr);
+    base::Status HandleSQLCreateProcedure(hybridse::node::CreateProcedurePlanNode* plan, const std::string& db,
+                                          const std::string& sql, std::shared_ptr<::openmldb::client::NsClient> ns_ptr);
 
     base::Status HandleSQLCreateTable(hybridse::node::CreatePlanNode* create_node, const std::string& db,
-            std::shared_ptr<::openmldb::client::NsClient> ns_ptr);
+                                      std::shared_ptr<::openmldb::client::NsClient> ns_ptr);
 
     base::Status HandleSQLCmd(const hybridse::node::CmdPlanNode* cmd_node, const std::string& db,
-            std::shared_ptr<::openmldb::client::NsClient> ns_ptr);
-
+                              std::shared_ptr<::openmldb::client::NsClient> ns_ptr);
 
     std::vector<std::string> ExecuteDDLParse(
-        const std::string& sql, const std::vector<std::pair<std::string,
-        std::vector<std::pair<std::string, hybridse::sdk::DataType>>>>& table_map) override;
+        const std::string& sql,
+        const std::vector<std::pair<std::string, std::vector<std::pair<std::string, hybridse::sdk::DataType>>>>&
+            table_map) override;
 
     static bool GetTTL(openmldb::type::TTLType ttl_type, ::google::protobuf::uint64 abs_ttl,
                        ::google::protobuf::uint64 lat_ttl, std::string* ttl) {
@@ -224,7 +223,7 @@ class SQLClusterRouter : public SQLRouter {
     }
 
     static std::string ToIndexString(const std::string ts, const std::string key_name, openmldb::type::TTLType ttl_type,
-                              const std::string& expire) {
+                                     const std::string& expire) {
         std::string index;
         std::string ttl_type_str;
         SQLClusterRouter::ToTTLTypeString(ttl_type, &ttl_type_str);
@@ -305,9 +304,10 @@ class SQLClusterRouter : public SQLRouter {
     std::shared_ptr<openmldb::client::TabletClient> GetTablet(const std::string& db, const std::string& sp_name,
                                                               hybridse::sdk::Status* status);
     bool ExtractDBTypes(const std::shared_ptr<hybridse::sdk::Schema> schema,
-                               std::vector<openmldb::type::DataType>& parameter_types);  // NOLINT
+                        std::vector<openmldb::type::DataType>& parameter_types);  // NOLINT
 
  private:
+    bool performance_sensitive_ = true;
     SQLRouterOptions options_;
     DBSDK* cluster_sdk_;
     std::map<std::string, boost::compute::detail::lru_cache<std::string, std::shared_ptr<SQLCache>>> input_lru_cache_;

--- a/src/sdk/sql_cluster_router.h
+++ b/src/sdk/sql_cluster_router.h
@@ -307,7 +307,7 @@ class SQLClusterRouter : public SQLRouter {
                         std::vector<openmldb::type::DataType>& parameter_types);  // NOLINT
 
  private:
-    bool performance_sensitive_ = true;
+    std::atomic<bool> performance_sensitive_ = true;
     SQLRouterOptions options_;
     DBSDK* cluster_sdk_;
     std::map<std::string, boost::compute::detail::lru_cache<std::string, std::shared_ptr<SQLCache>>> input_lru_cache_;

--- a/src/sdk/sql_router.h
+++ b/src/sdk/sql_router.h
@@ -68,9 +68,12 @@ class SQLRouter {
     virtual ~SQLRouter() {}
 
     virtual bool ShowDB(std::vector<std::string>* dbs, hybridse::sdk::Status* status) = 0;
+
     virtual bool CreateDB(const std::string& db, hybridse::sdk::Status* status) = 0;
 
     virtual bool DropDB(const std::string& db, hybridse::sdk::Status* status) = 0;
+
+    virtual void SetPerformanceSensitive(const bool performance_sensitive) = 0;
 
     virtual bool ExecuteDDL(const std::string& db, const std::string& sql, hybridse::sdk::Status* status) = 0;
 
@@ -85,8 +88,7 @@ class SQLRouter {
     virtual std::shared_ptr<openmldb::sdk::TableReader> GetTableReader() = 0;
 
     virtual std::shared_ptr<ExplainInfo> Explain(const std::string& db, const std::string& sql,
-                                                 ::hybridse::sdk::Status* status,
-                                                 bool performance_sensitive = true) = 0;
+                                                 ::hybridse::sdk::Status* status) = 0;
 
     virtual std::shared_ptr<openmldb::sdk::SQLRequestRow> GetRequestRow(const std::string& db, const std::string& sql,
                                                                         hybridse::sdk::Status* status) = 0;
@@ -105,12 +107,11 @@ class SQLRouter {
         hybridse::sdk::Status* status) = 0;
 
     virtual std::shared_ptr<hybridse::sdk::ResultSet> ExecuteSQL(const std::string& db, const std::string& sql,
-                                                                 hybridse::sdk::Status* status,
-                                                                 bool performance_sensitive = true) = 0;
+                                                                 hybridse::sdk::Status* status) = 0;
 
     virtual std::shared_ptr<hybridse::sdk::ResultSet> ExecuteSQLParameterized(
         const std::string& db, const std::string& sql, std::shared_ptr<openmldb::sdk::SQLRequestRow> parameter,
-        hybridse::sdk::Status* status, bool performance_sensitive = true) = 0;
+        hybridse::sdk::Status* status) = 0;
 
     virtual std::shared_ptr<hybridse::sdk::ResultSet> ExecuteSQLBatchRequest(
         const std::string& db, const std::string& sql, std::shared_ptr<openmldb::sdk::SQLRequestRowBatch> row_batch,
@@ -139,8 +140,8 @@ class SQLRouter {
         const std::string& db, const std::string& sp_name, int64_t timeout_ms,
         std::shared_ptr<openmldb::sdk::SQLRequestRowBatch> row_batch, hybridse::sdk::Status* status) = 0;
 
-    virtual std::shared_ptr<hybridse::sdk::Schema> GetTableSchema(
-        const std::string& db, const std::string& table_name) = 0;
+    virtual std::shared_ptr<hybridse::sdk::Schema> GetTableSchema(const std::string& db,
+                                                                  const std::string& table_name) = 0;
     /*
      * return ddl statements
      * schemas example:


### PR DESCRIPTION
- Now, it is not standard to define performance_sensitive in sql_cmd.h. And because of this realization, we should set additional options for setting performance_sensitive mode in openmldb JDBC.
- So, in order to solve these problems, I define performance_sensitive in sql_cluster and refactor some functions.
- Linked: https://github.com/4paradigm/OpenMLDB/issues/605