### PR TITLE
feat: a new lru_cache that support upsert

### DIFF
--- a/java/openmldb-jdbc/src/test/java/com/_4paradigm/openmldb/jdbc/SQLRouterSmokeTest.java
+++ b/java/openmldb-jdbc/src/test/java/com/_4paradigm/openmldb/jdbc/SQLRouterSmokeTest.java
@@ -205,13 +205,9 @@ public class SQLRouterSmokeTest {
             String drop = "drop table tsql1010;";
             ok = router.executeDDL(dbname, drop);
             Assert.assertTrue(ok);
-            // insert into deleted table
+            // insert into deleted table, can't get insert row
             SQLInsertRow insertRow = router.getInsertRow(dbname, insertPlaceholder);
-            insertRow.Init(5);
-            insertRow.AppendInt64(1005);
-            insertRow.AppendString("abc");
-            ok = router.executeInsert(dbname, insertPlaceholder, insertRow);
-            Assert.assertFalse(ok);
+            Assert.assertNull(insertRow);
             // drop database
             ok = router.dropDB(dbname);
             Assert.assertTrue(ok);

--- a/src/base/lru_cache.h
+++ b/src/base/lru_cache.h
@@ -1,0 +1,120 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2013 Kyle Lutz <kyle.r.lutz@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://boostorg.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#ifndef SRC_BASE_LRU_CACHE_H_
+#define SRC_BASE_LRU_CACHE_H_
+
+#include <boost/optional.hpp>
+#include <list>
+#include <map>
+#include <utility>
+
+namespace openmldb::base {
+
+// a cache which evicts the least recently used item when it is full
+// we need a new lru_cache, cuz we want a method `upsert` that can `update` the value of existed key and the
+// recently used list
+template <class Key, class Value>
+class lru_cache {
+ public:
+    typedef Key key_type;
+    typedef Value value_type;
+    typedef std::list<key_type> list_type;
+    typedef std::map<key_type, std::pair<value_type, typename list_type::iterator> > map_type;
+
+    explicit lru_cache(size_t capacity) : m_capacity(capacity) {}
+
+    ~lru_cache() = default;
+
+    size_t size() const { return m_map.size(); }
+
+    size_t capacity() const { return m_capacity; }
+
+    bool empty() const { return m_map.empty(); }
+
+    bool contains(const key_type &key) { return m_map.find(key) != m_map.end(); }
+
+    void upsert(const key_type &key, const value_type &value) {
+        typename map_type::iterator i = m_map.find(key);
+        if (i == m_map.end()) {
+            // insert item into the cache, but first check if it is full
+            if (size() >= m_capacity) {
+                // cache is full, evict the least recently used item
+                evict();
+            }
+
+            // insert the new item
+            m_list.push_front(key);
+            m_map[key] = std::make_pair(value, m_list.begin());
+        } else {
+            typename list_type::iterator j = i->second.second;
+            if (j != m_list.begin()) {
+                // move to the front
+                m_list.erase(j);
+                m_list.push_front(key);
+                j = m_list.begin();
+            }
+            // update the value too
+            m_map[key] = std::make_pair(value, j);
+        }
+    }
+
+    boost::optional<value_type> get(const key_type &key) {
+        // lookup value in the cache
+        typename map_type::iterator i = m_map.find(key);
+        if (i == m_map.end()) {
+            // value not in cache
+            return boost::none;
+        }
+
+        // return the value, but first update its place in the most
+        // recently used list
+        typename list_type::iterator j = i->second.second;
+        if (j != m_list.begin()) {
+            // move item to the front of the most recently used list
+            m_list.erase(j);
+            m_list.push_front(key);
+
+            // update iterator in map
+            j = m_list.begin();
+            const value_type &value = i->second.first;
+            m_map[key] = std::make_pair(value, j);
+
+            // return the value
+            return value;
+        } else {
+            // the item is already at the front of the most recently
+            // used list so just return it
+            return i->second.first;
+        }
+    }
+
+    void clear() {
+        m_map.clear();
+        m_list.clear();
+    }
+
+ private:
+    void evict() {
+        // evict item from the end of most recently used list
+        typename list_type::iterator i = --m_list.end();
+        m_map.erase(*i);
+        m_list.erase(i);
+    }
+
+ private:
+    map_type m_map;
+    list_type m_list;
+    size_t m_capacity;
+};
+
+}  // namespace openmldb::base
+
+#endif  // SRC_BASE_LRU_CACHE_H_

--- a/src/base/lru_cache.h
+++ b/src/base/lru_cache.h
@@ -12,6 +12,7 @@
 #define SRC_BASE_LRU_CACHE_H_
 
 #include <boost/optional.hpp>
+#include <boost/optional/optional_io.hpp>
 #include <list>
 #include <map>
 #include <utility>

--- a/src/base/lru_cache_test.cc
+++ b/src/base/lru_cache_test.cc
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 4Paradigm
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "base/lru_cache.h"
+
+#include "gtest/gtest.h"
+
+namespace openmldb::base {
+class LRUCacheTest : public ::testing::Test {};
+
+TEST_F(LRUCacheTest, normalEvict) {
+    lru_cache<int, int> cache(1);
+    cache.upsert(0, 0);
+    // evict 0,0
+    cache.upsert(1, 1);
+    ASSERT_FALSE(cache.contains(0));
+}
+
+TEST_F(LRUCacheTest, upsert) {
+    lru_cache<int, int> cache(2);
+    cache.upsert(0, 0);
+    cache.upsert(1, 1);
+    // update key 0
+    cache.upsert(0, -1);
+    // insert 2, key 1 will be evicted
+    cache.upsert(2, 2);
+    ASSERT_FALSE(cache.contains(1));
+    ASSET_EQ(cache.get(0), -1);
+}
+
+}  // namespace openmldb::base
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/base/lru_cache_test.cc
+++ b/src/base/lru_cache_test.cc
@@ -37,7 +37,7 @@ TEST_F(LRUCacheTest, upsert) {
     // insert 2, key 1 will be evicted
     cache.upsert(2, 2);
     ASSERT_FALSE(cache.contains(1));
-    ASSET_EQ(cache.get(0), -1);
+    ASSERT_EQ(cache.get(0), -1);
 }
 
 }  // namespace openmldb::base

--- a/src/sdk/sql_cluster_router.cc
+++ b/src/sdk/sql_cluster_router.cc
@@ -170,10 +170,10 @@ class BatchQueryFutureImpl : public QueryFuture {
 };
 
 SQLClusterRouter::SQLClusterRouter(const SQLRouterOptions& options)
-    : options_(options), cluster_sdk_(nullptr), input_lru_cache_(), mu_(), rand_(::baidu::common::timer::now_time()) {}
+    : options_(options), cluster_sdk_(nullptr), mu_(), rand_(::baidu::common::timer::now_time()) {}
 
 SQLClusterRouter::SQLClusterRouter(DBSDK* sdk)
-    : options_(), cluster_sdk_(sdk), input_lru_cache_(), mu_(), rand_(::baidu::common::timer::now_time()) {}
+    : options_(), cluster_sdk_(sdk), mu_(), rand_(::baidu::common::timer::now_time()) {}
 
 SQLClusterRouter::~SQLClusterRouter() { delete cluster_sdk_; }
 
@@ -431,7 +431,7 @@ bool SQLClusterRouter::GetInsertInfo(const std::string& db, const std::string& s
 DefaultValueMap SQLClusterRouter::GetDefaultMap(std::shared_ptr<::openmldb::nameserver::TableInfo> table_info,
                                                 const std::map<uint32_t, uint32_t>& column_map,
                                                 ::hybridse::node::ExprListNode* row, uint32_t* str_length) {
-    if (row == NULL || str_length == NULL) {
+    if (row == nullptr || str_length == nullptr) {
         LOG(WARNING) << "row or str length is NULL";
         return {};
     }
@@ -477,14 +477,14 @@ DefaultValueMap SQLClusterRouter::GetDefaultMap(std::shared_ptr<::openmldb::name
             if (primary->IsNull()) {
                 if (column.not_null()) {
                     LOG(WARNING) << "column " << column.name() << " can't be null";
-                    return DefaultValueMap();
+                    return {};
                 }
                 val = std::make_shared<::hybridse::node::ConstNode>(*primary);
             } else {
                 val = NodeAdapter::TransformDataType(*primary, column.data_type());
                 if (!val) {
                     LOG(WARNING) << "default value type mismatch, column " << column.name();
-                    return DefaultValueMap();
+                    return {};
                 }
             }
             default_map->insert(std::make_pair(idx, val));
@@ -503,27 +503,33 @@ std::shared_ptr<SQLCache> SQLClusterRouter::GetCache(const std::string& db, cons
     if (it != input_lru_cache_.end()) {
         auto value = it->second.get(sql);
         if (value != boost::none) {
+            // check cache validation, the name is the same, but the tid may be different
+            auto cached_info = value.value()->table_info;
+            auto current_info = cluster_sdk_->GetTableInfo(db, cached_info->name());
+            if (cached_info->tid() != current_info->tid()) {
+                return {};
+            }
             return value.value();
         }
     }
     return {};
 }
 
-void SQLClusterRouter::SetCache(const std::string& db, const std::string& sql, std::shared_ptr<SQLCache> router_cache) {
+void SQLClusterRouter::SetCache(const std::string& db, const std::string& sql,
+                                const std::shared_ptr<SQLCache>& router_cache) {
     std::lock_guard<::openmldb::base::SpinMutex> lock(mu_);
     auto it = input_lru_cache_.find(db);
     if (it == input_lru_cache_.end()) {
-        boost::compute::detail::lru_cache<std::string, std::shared_ptr<::openmldb::sdk::SQLCache>> sql_cache(
-            options_.max_sql_cache_size);
+        decltype(input_lru_cache_)::mapped_type sql_cache(options_.max_sql_cache_size);
         input_lru_cache_.insert(std::make_pair(db, sql_cache));
         it = input_lru_cache_.find(db);
     }
-    it->second.insert(sql, router_cache);
+    it->second.upsert(sql, router_cache);
 }
 
 std::shared_ptr<SQLInsertRows> SQLClusterRouter::GetInsertRows(const std::string& db, const std::string& sql,
                                                                ::hybridse::sdk::Status* status) {
-    if (status == NULL) {
+    if (status == nullptr) {
         return {};
     }
     std::shared_ptr<SQLCache> cache = GetCache(db, sql);

--- a/src/sdk/sql_cluster_router.cc
+++ b/src/sdk/sql_cluster_router.cc
@@ -507,6 +507,7 @@ std::shared_ptr<SQLCache> SQLClusterRouter::GetCache(const std::string& db, cons
             auto cached_info = value.value()->table_info;
             auto current_info = cluster_sdk_->GetTableInfo(db, cached_info->name());
             if (cached_info->tid() != current_info->tid()) {
+                // just leave, this invalid value will be updated by SetCache()
                 return {};
             }
             return value.value();

--- a/src/sdk/sql_cluster_router.h
+++ b/src/sdk/sql_cluster_router.h
@@ -26,7 +26,7 @@
 
 #include "base/random.h"
 #include "base/spinlock.h"
-#include "boost/compute/detail/lru_cache.hpp"
+#include "base/lru_cache.h"
 #include "catalog/schema_adapter.h"
 #include "client/tablet_client.h"
 #include "sdk/db_sdk.h"
@@ -209,7 +209,7 @@ class SQLClusterRouter : public SQLRouter {
     bool IsConstQuery(::hybridse::vm::PhysicalOpNode* node);
     std::shared_ptr<SQLCache> GetCache(const std::string& db, const std::string& sql);
 
-    void SetCache(const std::string& db, const std::string& sql, std::shared_ptr<SQLCache> router_cache);
+    void SetCache(const std::string& db, const std::string& sql, const std::shared_ptr<SQLCache>& router_cache);
 
     bool GetSQLPlan(const std::string& sql, ::hybridse::node::NodeManager* nm, ::hybridse::node::PlanNodeList* plan);
 
@@ -230,14 +230,14 @@ class SQLClusterRouter : public SQLRouter {
 
     std::shared_ptr<openmldb::client::TabletClient> GetTablet(const std::string& db, const std::string& sp_name,
                                                               hybridse::sdk::Status* status);
-    bool ExtractDBTypes(const std::shared_ptr<hybridse::sdk::Schema> schema,
+    bool ExtractDBTypes(std::shared_ptr<hybridse::sdk::Schema> schema,
                         std::vector<openmldb::type::DataType>& parameter_types);  // NOLINT
 
  private:
     std::atomic<bool> performance_sensitive_ = true;
     SQLRouterOptions options_;
     DBSDK* cluster_sdk_;
-    std::map<std::string, boost::compute::detail::lru_cache<std::string, std::shared_ptr<SQLCache>>> input_lru_cache_;
+    std::map<std::string, base::lru_cache<std::string, std::shared_ptr<SQLCache>>> input_lru_cache_;
     ::openmldb::base::SpinMutex mu_;
     ::openmldb::base::Random rand_;
 };


### PR DESCRIPTION
Closes #604 
Sql cache(by name) may be invalid cuz we may recreate the table(name is the same, but tid changed).
So when we met invalid sql cache, we shouldn't use it, and the sql cache should be update later(by SetCache).
boost::lru_cache doesn't support upsert, so we add a new lru_cache.