### PR TITLE
fix: fix python cicd

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -154,7 +154,7 @@ jobs:
         run: |
           python3 -m easy_install nose pip
           yum install -y net-tools
-          bash steps/fesql_test_python.sh
+          bash steps/test_python.sh
 
       - name: upload python ut results
         if: always()

--- a/steps/test_python.sh
+++ b/steps/test_python.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 4Paradigm
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+ROOT_DIR=$(pwd)
+test -d /rambuild/ut_zookeeper && rm -rf /rambuild/ut_zookeeper/*
+cp steps/zoo.cfg thirdsrc/zookeeper-3.4.14/conf
+cd thirdsrc/zookeeper-3.4.14
+# TODO(hw): macos no -p
+netstat -anp | grep 6181 | awk '{print $NF}' | awk -F '/' '{print $1}'| xargs -I{} kill -9 {}
+./bin/zkServer.sh start && cd "$ROOT_DIR"
+echo "zk started"
+sleep 5
+cd onebox && sh start_onebox.sh && cd "$ROOT_DIR"
+echo "onebox started, check"
+sleep 5
+pgrep -f openmldb
+echo "ROOT_DIR:${ROOT_DIR}"
+
+cd "${ROOT_DIR}"/build/python/dist/
+whl_name=$(ls openmldb*.whl)
+echo "whl_name:${whl_name}"
+python3 -m pip install "${whl_name}" -i https://pypi.tuna.tsinghua.edu.cn/simple
+
+# needs: easy_install nose (sqlalchemy is openmldb required)
+cd "${ROOT_DIR}"/python/test
+nosetests --with-xunit
+
+cd "${ROOT_DIR}"/onebox && sh stop_all.sh && cd "$ROOT_DIR"
+cd thirdsrc/zookeeper-3.4.14 && ./bin/zkServer.sh stop && cd "$ROOT_DIR"

--- a/steps/ut.sh
+++ b/steps/ut.sh
@@ -48,7 +48,7 @@ else
     ROOT_DIR=$(pwd)
     echo "WORK_DIR: ${ROOT_DIR}"
     echo "sql c++ sdk test : case_level ${CASE_LEVEL}, case_file ${CASE_NAME}"
-    GLOG_minloglevel=2 HYBRIDSE_LEVEL=${CASE_LEVEL} YMAL_CASE_BASE_DIR=${ROOT_DIR} ./build/bin/${CASE_NAME} --gtest_output=xml:./reports/${CASE_NAME}.xml
+    GLOG_minloglevel=2 HYBRIDSE_LEVEL=${CASE_LEVEL} YMAL_CASE_BASE_DIR=${ROOT_DIR} "./build/bin/${CASE_NAME}" "--gtest_output=xml:./reports/${CASE_NAME}.xml"
     RET=$?
     echo "${CASE_NAME} result code is: $RET"
     if [ $RET -ne 0 ];then
@@ -57,7 +57,7 @@ else
 fi
 code=$(cat $TMPFILE)
 echo "code result: $code"
-rm $TMPFILE
+rm ${TMPFILE}
 cd thirdsrc/zookeeper-3.4.14 && ./bin/zkServer.sh stop
 cd - || exit
-exit $code
+exit "${code}"

--- a/steps/ut.sh
+++ b/steps/ut.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Copyright 2021 4Paradigm
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# ut.sh
+#
+WORK_DIR=$(pwd)
+# shellcheck disable=SC2039
+ulimit -c unlimited
+test -d reports && rm -rf reports
+mkdir -p reports
+cp steps/zoo.cfg thirdsrc/zookeeper-3.4.14/conf
+cd thirdsrc/zookeeper-3.4.14 && ./bin/zkServer.sh start && cd "$WORK_DIR" || exit
+sleep 5
+TMPFILE="code.tmp"
+echo 0 > $TMPFILE
+if [ $# -eq 0 ];
+then
+    # shellcheck disable=SC2010
+    ls build/bin/ | grep test | grep -v "sql_sdk_test\|sql_cluster_test\|sql_standalone_sdk_test"| grep -v grep | while read -r line
+    do 
+        ./build/bin/"$line" --gtest_output=xml:./reports/"$line".xml 2>/tmp/"${line}"."${USER}".log 1>&2
+        RET=$?
+        echo "$line result code is: $RET"
+        if [ $RET -ne 0 ];then 
+            cat /tmp/"${line}"."${USER}".log
+            echo $RET > $TMPFILE
+        else
+            rm -f /tmp/"${line}"."${USER}".log
+        fi 
+    done
+else    
+    CASE_NAME=$1
+    CASE_LEVEL=$2
+    ROOT_DIR=$(pwd)
+    echo "WORK_DIR: ${ROOT_DIR}"
+    echo "sql c++ sdk test : case_level ${CASE_LEVEL}, case_file ${CASE_NAME}"
+    GLOG_minloglevel=2 HYBRIDSE_LEVEL=${CASE_LEVEL} YMAL_CASE_BASE_DIR=${ROOT_DIR} ./build/bin/${CASE_NAME} --gtest_output=xml:./reports/${CASE_NAME}.xml
+    RET=$?
+    echo "${CASE_NAME} result code is: $RET"
+    if [ $RET -ne 0 ];then
+        echo $RET > $TMPFILE
+    fi
+fi
+code=$(cat $TMPFILE)
+echo "code result: $code"
+rm $TMPFILE
+cd thirdsrc/zookeeper-3.4.14 && ./bin/zkServer.sh stop
+cd - || exit
+exit $code


### PR DESCRIPTION
`steps/fesql_test_python.sh` will be called in python cicd workflow. But this file has been deleted in https://github.com/4paradigm/OpenMLDB/issues/813  mistakenly. So we should add this file again