### PR TITLE
feat: support dayofyear() built-in function 

### DIFF
--- a/hybridse/src/codegen/udf_ir_builder_test.cc
+++ b/hybridse/src/codegen/udf_ir_builder_test.cc
@@ -115,6 +115,10 @@ TEST_F(UdfIRBuilderTest, dayofweek_date_udf_test) {
     Date date(2020, 05, 22);
     CheckUdf<int32_t, Date>("dayofweek", 6, date);
 }
+TEST_F(UdfIRBuilderTest, dayofyear_date_udf_test) {
+    Date date(2020, 05, 22);
+    CheckUdf<int32_t, Date>("dayofyear", 143, date);
+}
 TEST_F(UdfIRBuilderTest, weekofyear_date_udf_test) {
     {
         Date date(2020, 01, 01);
@@ -179,6 +183,10 @@ TEST_F(UdfIRBuilderTest, dayofweek_timestamp_udf_test) {
     Timestamp time(1590115420000L);
     CheckUdf<int32_t, Timestamp>("dayofweek", 6, time);
 }
+TEST_F(UdfIRBuilderTest, dayofyear_timestamp_udf_test) {
+    Timestamp time(1590115420000L);
+    CheckUdf<int32_t, Timestamp>("dayofyear", 143, time);
+}
 TEST_F(UdfIRBuilderTest, weekofyear_timestamp_udf_test) {
     Timestamp time(1590115420000L);
     CheckUdf<int32_t, Timestamp>("weekofyear", 21, time);
@@ -221,6 +229,12 @@ TEST_F(UdfIRBuilderTest, dayofweek_int64_udf_test) {
     // Sunday
     CheckUdf<int32_t, int64_t>("dayofweek", 1, 1590115420000L + 2 * 86400000L);
     CheckUdf<int32_t, int64_t>("dayofweek", 2, 1590115420000L + 3 * 86400000L);
+}
+TEST_F(UdfIRBuilderTest, dayofyear_int64_udf_test) {
+    CheckUdf<int32_t, int64_t>("dayofyear", 143, 1590115420000L);
+    CheckUdf<int32_t, int64_t>("dayofyear", 144, 1590115420000L + 86400000L);
+    CheckUdf<int32_t, int64_t>("dayofyear", 145, 1590115420000L + 2 * 86400000L);
+    CheckUdf<int32_t, int64_t>("dayofyear", 146, 1590115420000L + 3 * 86400000L);
 }
 TEST_F(UdfIRBuilderTest, weekofyear_int64_udf_test) {
     CheckUdf<int32_t, int64_t>("weekofyear", 21, 1590115420000L);

--- a/hybridse/src/codegen/udf_ir_builder_test.cc
+++ b/hybridse/src/codegen/udf_ir_builder_test.cc
@@ -156,6 +156,14 @@ TEST_F(UdfIRBuilderTest, dayofyear_date_udf_test) {
         Date date(2021, 12, -10);
         CheckUdf<int32_t, Date>("dayofyear", 0, date);
     }
+    {
+        Date date(2021, 2, 29);
+        CheckUdf<int32_t, Date>("dayofyear", 0, date);
+    }
+    {
+        Date date(1969, 1, 1);
+        CheckUdf<int32_t, Date>("dayofyear", 0, date);
+    }
 }
 TEST_F(UdfIRBuilderTest, weekofyear_date_udf_test) {
     {

--- a/hybridse/src/codegen/udf_ir_builder_test.cc
+++ b/hybridse/src/codegen/udf_ir_builder_test.cc
@@ -134,35 +134,31 @@ TEST_F(UdfIRBuilderTest, dayofyear_date_udf_test) {
     }
     {
         Date date(2021, 13, 31);
-        CheckUdf<int32_t, Date>("dayofyear", 0, date);
+        CheckUdf<int32_t, Date>("dayofyear", nullptr, date);
     }
     {
         Date date(2021, 0, 31);
-        CheckUdf<int32_t, Date>("dayofyear", 0, date);
+        CheckUdf<int32_t, Date>("dayofyear", nullptr, date);
     }
     {
         Date date(2021, -1, 31);
-        CheckUdf<int32_t, Date>("dayofyear", 0, date);
+        CheckUdf<int32_t, Date>("dayofyear", nullptr, date);
     }
     {
         Date date(2021, 12, 32);
-        CheckUdf<int32_t, Date>("dayofyear", 0, date);
+        CheckUdf<int32_t, Date>("dayofyear", nullptr, date);
     }
     {
         Date date(2021, 12, 0);
-        CheckUdf<int32_t, Date>("dayofyear", 0, date);
+        CheckUdf<int32_t, Date>("dayofyear", nullptr, date);
     }
     {
         Date date(2021, 12, -10);
-        CheckUdf<int32_t, Date>("dayofyear", 0, date);
+        CheckUdf<int32_t, Date>("dayofyear", nullptr, date);
     }
     {
         Date date(2021, 2, 29);
-        CheckUdf<int32_t, Date>("dayofyear", 0, date);
-    }
-    {
-        Date date(1969, 1, 1);
-        CheckUdf<int32_t, Date>("dayofyear", 0, date);
+        CheckUdf<int32_t, Date>("dayofyear", nullptr, date);
     }
 }
 TEST_F(UdfIRBuilderTest, weekofyear_date_udf_test) {

--- a/hybridse/src/codegen/udf_ir_builder_test.cc
+++ b/hybridse/src/codegen/udf_ir_builder_test.cc
@@ -134,31 +134,31 @@ TEST_F(UdfIRBuilderTest, dayofyear_date_udf_test) {
     }
     {
         Date date(2021, 13, 31);
-        CheckUdf<int32_t, Date>("dayofyear", nullptr, date);
+        CheckUdf<int32_t, Date>("dayofyear", 0, date);
     }
     {
         Date date(2021, 0, 31);
-        CheckUdf<int32_t, Date>("dayofyear", nullptr, date);
+        CheckUdf<int32_t, Date>("dayofyear", 0, date);
     }
     {
         Date date(2021, -1, 31);
-        CheckUdf<int32_t, Date>("dayofyear", nullptr, date);
+        CheckUdf<int32_t, Date>("dayofyear", 0, date);
     }
     {
         Date date(2021, 12, 32);
-        CheckUdf<int32_t, Date>("dayofyear", nullptr, date);
+        CheckUdf<int32_t, Date>("dayofyear", 0, date);
     }
     {
         Date date(2021, 12, 0);
-        CheckUdf<int32_t, Date>("dayofyear", nullptr, date);
+        CheckUdf<int32_t, Date>("dayofyear", 0, date);
     }
     {
         Date date(2021, 12, -10);
-        CheckUdf<int32_t, Date>("dayofyear", nullptr, date);
+        CheckUdf<int32_t, Date>("dayofyear", 0, date);
     }
     {
         Date date(2021, 2, 29);
-        CheckUdf<int32_t, Date>("dayofyear", nullptr, date);
+        CheckUdf<int32_t, Date>("dayofyear", 0, date);
     }
 }
 TEST_F(UdfIRBuilderTest, weekofyear_date_udf_test) {

--- a/hybridse/src/codegen/udf_ir_builder_test.cc
+++ b/hybridse/src/codegen/udf_ir_builder_test.cc
@@ -132,6 +132,30 @@ TEST_F(UdfIRBuilderTest, dayofyear_date_udf_test) {
         Date date(2021, 12, 31);
         CheckUdf<int32_t, Date>("dayofyear", 365, date);
     }
+    {
+        Date date(2021, 13, 31);
+        CheckUdf<int32_t, Date>("dayofyear", 0, date);
+    }
+    {
+        Date date(2021, 0, 31);
+        CheckUdf<int32_t, Date>("dayofyear", 0, date);
+    }
+    {
+        Date date(2021, -1, 31);
+        CheckUdf<int32_t, Date>("dayofyear", 0, date);
+    }
+    {
+        Date date(2021, 12, 32);
+        CheckUdf<int32_t, Date>("dayofyear", 0, date);
+    }
+    {
+        Date date(2021, 12, 0);
+        CheckUdf<int32_t, Date>("dayofyear", 0, date);
+    }
+    {
+        Date date(2021, 12, -10);
+        CheckUdf<int32_t, Date>("dayofyear", 0, date);
+    }
 }
 TEST_F(UdfIRBuilderTest, weekofyear_date_udf_test) {
     {

--- a/hybridse/src/codegen/udf_ir_builder_test.cc
+++ b/hybridse/src/codegen/udf_ir_builder_test.cc
@@ -116,8 +116,22 @@ TEST_F(UdfIRBuilderTest, dayofweek_date_udf_test) {
     CheckUdf<int32_t, Date>("dayofweek", 6, date);
 }
 TEST_F(UdfIRBuilderTest, dayofyear_date_udf_test) {
-    Date date(2020, 05, 22);
-    CheckUdf<int32_t, Date>("dayofyear", 143, date);
+    {
+        Date date(2020, 05, 22);
+        CheckUdf<int32_t, Date>("dayofyear", 143, date);
+    }
+    {
+        Date date(2021, 01, 01);
+        CheckUdf<int32_t, Date>("dayofyear", 1, date);
+    }
+    {
+        Date date(2020, 12, 31);
+        CheckUdf<int32_t, Date>("dayofyear", 366, date);
+    }
+    {
+        Date date(2021, 12, 31);
+        CheckUdf<int32_t, Date>("dayofyear", 365, date);
+    }
 }
 TEST_F(UdfIRBuilderTest, weekofyear_date_udf_test) {
     {

--- a/hybridse/src/udf/default_udf_library.cc
+++ b/hybridse/src/udf/default_udf_library.cc
@@ -1628,9 +1628,9 @@ void DefaultUdfLibrary::InitTimeAndDateUdf() {
                 -- output 143
 
                 select dayofyear(date("2020-05-22"));
-                -- output 143                
+                -- output 143
             @endcode
-            @since 0.4.0
+            @since 0.1.0
         )");
 
     RegisterExternal("weekofyear")

--- a/hybridse/src/udf/default_udf_library.cc
+++ b/hybridse/src/udf/default_udf_library.cc
@@ -1623,6 +1623,12 @@ void DefaultUdfLibrary::InitTimeAndDateUdf() {
             @code{.sql}
                 select dayofyear(timestamp(1590115420000));
                 -- output 143
+
+                select dayofyear(1590115420000);
+                -- output 143
+
+                select dayofyear(date("2020-05-22"));
+                -- output 143                
             @endcode
             @since 0.1.0
         )");

--- a/hybridse/src/udf/default_udf_library.cc
+++ b/hybridse/src/udf/default_udf_library.cc
@@ -1617,7 +1617,7 @@ void DefaultUdfLibrary::InitTimeAndDateUdf() {
         .args<Timestamp>(static_cast<int32_t (*)(Timestamp*)>(v1::dayofyear))
         .args<Date>(static_cast<int32_t (*)(Date*)>(v1::dayofyear))
         .doc(R"(
-            @brief Return the day of year for a timestamp or date. Returns 0 given invalid date.
+            @brief Return the day of year for a timestamp or date. Returns 0 given an invalid date.
 
             Example:
             @code{.sql}

--- a/hybridse/src/udf/default_udf_library.cc
+++ b/hybridse/src/udf/default_udf_library.cc
@@ -1612,6 +1612,21 @@ void DefaultUdfLibrary::InitTimeAndDateUdf() {
             @since 0.1.0
         )");
 
+    RegisterExternal("dayofyear")
+        .args<int64_t>(static_cast<int32_t (*)(int64_t)>(v1::dayofyear))
+        .args<Timestamp>(static_cast<int32_t (*)(Timestamp*)>(v1::dayofyear))
+        .args<Date>(static_cast<int32_t (*)(Date*)>(v1::dayofyear))
+        .doc(R"(
+            @brief Return the day of year for a timestamp or date.
+
+            Example:
+            @code{.sql}
+                select dayofyear(timestamp(1590115420000));
+                -- output 143
+            @endcode
+            @since 0.1.0
+        )");
+
     RegisterExternal("weekofyear")
         .args<int64_t>(static_cast<int32_t (*)(int64_t)>(v1::weekofyear))
         .args<Timestamp>(static_cast<int32_t (*)(Timestamp*)>(v1::weekofyear))

--- a/hybridse/src/udf/default_udf_library.cc
+++ b/hybridse/src/udf/default_udf_library.cc
@@ -1617,7 +1617,7 @@ void DefaultUdfLibrary::InitTimeAndDateUdf() {
         .args<Timestamp>(static_cast<int32_t (*)(Timestamp*)>(v1::dayofyear))
         .args<Date>(static_cast<int32_t (*)(Date*)>(v1::dayofyear))
         .doc(R"(
-            @brief Return the day of year for a timestamp or date.
+            @brief Return the day of year for a timestamp or date. Returns 0 given invalid date.
 
             Example:
             @code{.sql}
@@ -1629,6 +1629,9 @@ void DefaultUdfLibrary::InitTimeAndDateUdf() {
 
                 select dayofyear(date("2020-05-22"));
                 -- output 143
+
+                select dayofyear(date("2020-05-32"));
+                -- output 0
             @endcode
             @since 0.1.0
         )");

--- a/hybridse/src/udf/default_udf_library.cc
+++ b/hybridse/src/udf/default_udf_library.cc
@@ -1609,7 +1609,7 @@ void DefaultUdfLibrary::InitTimeAndDateUdf() {
                 select dayofweek(timestamp(1590115420000));
                 -- output 6
             @endcode
-            @since 0.1.0
+            @since 0.4.0
         )");
 
     RegisterExternal("dayofyear")
@@ -1630,7 +1630,7 @@ void DefaultUdfLibrary::InitTimeAndDateUdf() {
                 select dayofyear(date("2020-05-22"));
                 -- output 143                
             @endcode
-            @since 0.1.0
+            @since 0.4.0
         )");
 
     RegisterExternal("weekofyear")

--- a/hybridse/src/udf/default_udf_library.cc
+++ b/hybridse/src/udf/default_udf_library.cc
@@ -1617,7 +1617,7 @@ void DefaultUdfLibrary::InitTimeAndDateUdf() {
         .args<Timestamp>(static_cast<int32_t (*)(Timestamp*)>(v1::dayofyear))
         .args<Date>(static_cast<int32_t (*)(Date*)>(v1::dayofyear))
         .doc(R"(
-            @brief Return the day of year for a timestamp or date.
+            @brief Return the day of year for a timestamp or date. Returns null for invalid dates.
 
             Example:
             @code{.sql}
@@ -1629,6 +1629,9 @@ void DefaultUdfLibrary::InitTimeAndDateUdf() {
 
                 select dayofyear(date("2020-05-22"));
                 -- output 143
+
+                select dayofyear(date("2020-05-35"));
+                -- output nullptr
             @endcode
             @since 0.1.0
         )");

--- a/hybridse/src/udf/default_udf_library.cc
+++ b/hybridse/src/udf/default_udf_library.cc
@@ -1617,7 +1617,7 @@ void DefaultUdfLibrary::InitTimeAndDateUdf() {
         .args<Timestamp>(static_cast<int32_t (*)(Timestamp*)>(v1::dayofyear))
         .args<Date>(static_cast<int32_t (*)(Date*)>(v1::dayofyear))
         .doc(R"(
-            @brief Return the day of year for a timestamp or date. Returns null for invalid dates.
+            @brief Return the day of year for a timestamp or date.
 
             Example:
             @code{.sql}
@@ -1629,9 +1629,6 @@ void DefaultUdfLibrary::InitTimeAndDateUdf() {
 
                 select dayofyear(date("2020-05-22"));
                 -- output 143
-
-                select dayofyear(date("2020-05-35"));
-                -- output nullptr
             @endcode
             @since 0.1.0
         )");

--- a/hybridse/src/udf/udf.cc
+++ b/hybridse/src/udf/udf.cc
@@ -98,18 +98,18 @@ int32_t dayofyear(codec::Timestamp *ts) { return dayofyear(ts->ts_); }
 int32_t dayofyear(codec::Date *date) {
     int32_t day, month, year;
     if (!codec::Date::Decode(date->date_, &year, &month, &day)) {
-        return 0;
+        return nullptr;
     }
     try {
         if (month <= 0 || month > 12) {
-            return 0;
+            return nullptr;
         } else if (day <= 0 || day > 31) {
-            return 0;
+            return nullptr;
         }
         boost::gregorian::date d(year, month, day);
         return d.day_of_year();
     } catch (...) {
-        return 0;
+        return nullptr;
     }
 }
 int32_t dayofmonth(codec::Timestamp *ts) { return dayofmonth(ts->ts_); }

--- a/hybridse/src/udf/udf.cc
+++ b/hybridse/src/udf/udf.cc
@@ -107,7 +107,7 @@ int32_t dayofyear(codec::Date *date) {
             return 0;
         }
         boost::gregorian::date d(year, month, day);
-        return d.day_of_year() + 1;
+        return d.day_of_year();
     } catch (...) {
         return 0;
     }

--- a/hybridse/src/udf/udf.cc
+++ b/hybridse/src/udf/udf.cc
@@ -98,18 +98,18 @@ int32_t dayofyear(codec::Timestamp *ts) { return dayofyear(ts->ts_); }
 int32_t dayofyear(codec::Date *date) {
     int32_t day, month, year;
     if (!codec::Date::Decode(date->date_, &year, &month, &day)) {
-        return nullptr;
+        return 0;
     }
     try {
         if (month <= 0 || month > 12) {
-            return nullptr;
+            return 0;
         } else if (day <= 0 || day > 31) {
-            return nullptr;
+            return 0;
         }
         boost::gregorian::date d(year, month, day);
         return d.day_of_year();
     } catch (...) {
-        return nullptr;
+        return 0;
     }
 }
 int32_t dayofmonth(codec::Timestamp *ts) { return dayofmonth(ts->ts_); }

--- a/hybridse/src/udf/udf.cc
+++ b/hybridse/src/udf/udf.cc
@@ -52,6 +52,12 @@ const time_t TZ_OFFSET = TZ * 3600000;
 const int MAX_ALLOC_SIZE = 2048;
 bthread_key_t B_THREAD_LOCAL_MEM_POOL_KEY;
 
+int32_t dayofyear(int64_t ts) {
+    time_t time = (ts + TZ_OFFSET) / 1000;
+    struct tm t;
+    gmtime_r(&time, &t);
+    return t.tm_yday + 1;
+}
 int32_t dayofmonth(int64_t ts) {
     time_t time = (ts + TZ_OFFSET) / 1000;
     struct tm t;
@@ -88,6 +94,24 @@ int32_t year(int64_t ts) {
     return t.tm_year + 1900;
 }
 
+int32_t dayofyear(codec::Timestamp *ts) { return dayofyear(ts->ts_); }
+int32_t dayofyear(codec::Date *date) {
+    int32_t day, month, year;
+    if (!codec::Date::Decode(date->date_, &year, &month, &day)) {
+        return 0;
+    }
+    try {
+        if (month <= 0 || month > 12) {
+            return 0;
+        } else if (day <= 0 || day > 31) {
+            return 0;
+        }
+        boost::gregorian::date d(year, month, day);
+        return d.day_of_year() + 1;
+    } catch (...) {
+        return 0;
+    }
+}
 int32_t dayofmonth(codec::Timestamp *ts) { return dayofmonth(ts->ts_); }
 int32_t weekofyear(codec::Timestamp *ts) { return weekofyear(ts->ts_); }
 int32_t month(codec::Timestamp *ts) { return month(ts->ts_); }

--- a/hybridse/src/udf/udf.h
+++ b/hybridse/src/udf/udf.h
@@ -203,6 +203,10 @@ int32_t month(hybridse::codec::Timestamp *ts);
 int32_t year(int64_t ts);
 int32_t year(hybridse::codec::Timestamp *ts);
 
+int32_t dayofyear(int64_t ts);
+int32_t dayofyear(hybridse::codec::Timestamp *ts);
+int32_t dayofyear(hybridse::codec::Date *ts);
+
 int32_t dayofmonth(int64_t ts);
 int32_t dayofmonth(hybridse::codec::Timestamp *ts);
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Adds the dayofyear() function which returns the day of the year for a given date (a number from 1 to 366).

* **What is the current behavior?** (You can also link to an open issue here)

dayofyear function doesn't exist, see issue for more details: #785 

