### PR TITLE
fix: missing nproc when compiling OpenMLDB on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,15 @@
 
 MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 MAKEFILE_DIR  := $(dir $(MAKEFILE_PATH))
-NPROC ?= $(shell (nproc))
+
+# Processor count with OS detection
+ifeq ($(shell (uname -s)), Linux)
+	NPROC ?= $(shell (nproc))
+endif
+ifeq ($(shell (uname -s)), Darwin)
+	NPROC ?= $(shell (sysctl -n hw.ncpu))
+endif
+
 
 CMAKE_PRG ?= $(shell (command -v cmake3 || echo cmake))
 CMAKE_BUILD_TYPE ?= RelWithDebInfo


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- The commit message follows our guidelines
- Tests for the changes have been added (for bug fixes / features)
- Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
A bug fix for missing nproc when compiling


* **What is the current behavior?** (You can also link to an open issue here)
See the screenshot below
![Screen Shot 2021-12-09 at 1 20 24 PM](https://user-images.githubusercontent.com/1401515/145339921-902e2ed7-03a2-4125-a5a5-0f2f31ade5c6.png)



* **What is the new behavior (if this is a feature change)?**
No more error of ```nproc: command not found```


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No, 



* **Other information**:
