### PR TITLE
fix: method GetTableInfo may get nullptr

### DIFF
--- a/src/sdk/sql_cluster_router.cc
+++ b/src/sdk/sql_cluster_router.cc
@@ -1468,6 +1468,9 @@ std::vector<std::string> SQLClusterRouter::GetTableNames(const std::string& db) 
 
 ::openmldb::nameserver::TableInfo SQLClusterRouter::GetTableInfo(const std::string& db, const std::string& table) {
     auto table_infos = cluster_sdk_->GetTableInfo(db, table);
+    if(!table_infos){
+        return {};
+    }
     return *table_infos;
 }
 


### PR DESCRIPTION
If `cluster_sdk_->GetTableInfo` get nullptr, we can't do `*table_infos`, it'll core.