### PR TITLE
feat: [Python SDK]Raise Error for unsupported methods & new unittest for cicd

### DIFF
--- a/python/sqlalchemy-openmldb/sqlalchemy_openmldb/openmldbapi/_openmldbapi.py
+++ b/python/sqlalchemy-openmldb/sqlalchemy_openmldb/openmldbapi/_openmldbapi.py
@@ -304,7 +304,7 @@ class Cursor(object):
 
     @connected
     def executemany(self, operation, parameters=()):
-        pass
+        raise NotSupportedError("executemany() is currently unsupported in OpenMLDB")
 
     def fetchone(self):
         if self._resultSet is None: return "call fetchone"
@@ -325,20 +325,20 @@ class Cursor(object):
 
     @connected
     def fetchmany(self, size=None):
-        pass
+        raise NotSupportedError("fetchmany() is currently unsupported in OpenMLDB")
 
     def nextset(self):
-        pass
+        raise NotSupportedError("nextset() is currently unsupported in OpenMLDB")
 
     def setinputsizes(self, size):
-        pass
+        raise NotSupportedError("setinputsizes() is currently unsupported in OpenMLDB")
 
     def setoutputsize(self, size, columns=()):
-        pass
+        raise NotSupportedError("setoutputsizes() is currently unsupported in OpenMLDB")
         
     @connected
     def fetchall(self):
-        pass
+        raise NotSupportedError("fetchall() is currently unsupported in OpenMLDB")
 
 
     @staticmethod
@@ -365,13 +365,13 @@ class Cursor(object):
 
     @connected
     def get_query_metadata(self):
-        pass
+        raise NotSupportedError("get_query_metadata() is currently unsupported in OpenMLDB")
 
     def get_default_plugin(self):
-        pass
+        raise NotSupportedError("get_default_plugin() is currently unsupported in OpenMLDB")
 
     def __iter__(self):
-        pass
+        raise NotSupportedError("__iter__() is currently unsupported in OpenMLDB")
 
     def batch_row_request(self, sql, commonCol, parameters):
         ok, rs = self.connection._sdk.doBatchRowRequest(self.db, sql, commonCol, parameters)
@@ -418,16 +418,15 @@ class Connection(object):
 
 
     def execute(self):
-        pass
+        raise NotSupportedError("Connection.execute() is currently unsupported in OpenMLDB")
 
     @connected
     def _cursor_execute(self, cursor, statement, parameters):
-        pass
+        raise NotSupportedError("_cursor_execute() is currently unsupported in OpenMLDB")
 
     @connected
     def do_rollback(self, dbapi_connection):
-        pass
-
+        raise NotSupportedError("do_rollback() is currently unsupported in OpenMLDB")
 
     @connected
     def rollback(self):
@@ -442,7 +441,7 @@ class Connection(object):
         pass
 
     def close(self):
-        pass
+        raise NotSupportedError("Connection.close() is currently unsupported in OpenMLDB")
 
     def cursor(self):
         return Cursor(self._db, self._zk, self._zkPath, self)

--- a/python/sqlalchemy-openmldb/sqlalchemy_openmldb/openmldbapi/_openmldbapi.py
+++ b/python/sqlalchemy-openmldb/sqlalchemy_openmldb/openmldbapi/_openmldbapi.py
@@ -304,7 +304,7 @@ class Cursor(object):
 
     @connected
     def executemany(self, operation, parameters=()):
-        raise NotSupportedError("executemany() is currently unsupported in OpenMLDB")
+        raise NotSupportedError("Unsupported in OpenMLDB")
 
     def fetchone(self):
         if self._resultSet is None: return "call fetchone"
@@ -325,20 +325,20 @@ class Cursor(object):
 
     @connected
     def fetchmany(self, size=None):
-        raise NotSupportedError("fetchmany() is currently unsupported in OpenMLDB")
+        raise NotSupportedError("Unsupported in OpenMLDB")
 
     def nextset(self):
-        raise NotSupportedError("nextset() is currently unsupported in OpenMLDB")
+        raise NotSupportedError("Unsupported in OpenMLDB")
 
     def setinputsizes(self, size):
-        raise NotSupportedError("setinputsizes() is currently unsupported in OpenMLDB")
+        raise NotSupportedError("Unsupported in OpenMLDB")
 
     def setoutputsize(self, size, columns=()):
-        raise NotSupportedError("setoutputsizes() is currently unsupported in OpenMLDB")
+        raise NotSupportedError("Unsupported in OpenMLDB")
         
     @connected
     def fetchall(self):
-        raise NotSupportedError("fetchall() is currently unsupported in OpenMLDB")
+        raise NotSupportedError("Unsupported in OpenMLDB")
 
 
     @staticmethod
@@ -365,13 +365,13 @@ class Cursor(object):
 
     @connected
     def get_query_metadata(self):
-        raise NotSupportedError("get_query_metadata() is currently unsupported in OpenMLDB")
+        raise NotSupportedError("Unsupported in OpenMLDB")
 
     def get_default_plugin(self):
-        raise NotSupportedError("get_default_plugin() is currently unsupported in OpenMLDB")
+        raise NotSupportedError("Unsupported in OpenMLDB")
 
     def __iter__(self):
-        raise NotSupportedError("__iter__() is currently unsupported in OpenMLDB")
+        raise NotSupportedError("Unsupported in OpenMLDB")
 
     def batch_row_request(self, sql, commonCol, parameters):
         ok, rs = self.connection._sdk.doBatchRowRequest(self.db, sql, commonCol, parameters)
@@ -418,15 +418,15 @@ class Connection(object):
 
 
     def execute(self):
-        raise NotSupportedError("Connection.execute() is currently unsupported in OpenMLDB")
+        raise NotSupportedError("Unsupported in OpenMLDB")
 
     @connected
     def _cursor_execute(self, cursor, statement, parameters):
-        raise NotSupportedError("_cursor_execute() is currently unsupported in OpenMLDB")
+        raise NotSupportedError("Unsupported in OpenMLDB")
 
     @connected
     def do_rollback(self, dbapi_connection):
-        raise NotSupportedError("do_rollback() is currently unsupported in OpenMLDB")
+        raise NotSupportedError("Unsupported in OpenMLDB")
 
     @connected
     def rollback(self):
@@ -441,7 +441,7 @@ class Connection(object):
         pass
 
     def close(self):
-        raise NotSupportedError("Connection.close() is currently unsupported in OpenMLDB")
+        raise NotSupportedError("Unsupported in OpenMLDB")
 
     def cursor(self):
         return Cursor(self._db, self._zk, self._zkPath, self)

--- a/python/test/openmldb_client_test.py
+++ b/python/test/openmldb_client_test.py
@@ -52,6 +52,9 @@ class TestOpenMLDBClient(unittest.TestCase):
     connection.execute(insert3, ({"col3":"fujian", "col4":"fuzhou"}));
     connection.execute(insert4, ({"col1":1003, "col2":"2020-12-28", "col3":"jiangxi", "col4":"nanchang", "col5":4}));
     connection.execute(insert5, ({"col2":"2020-12-29"}));
+    self.check_dbapi(connection)
+    self.check_exectute_many(connection,insert4)
+
     data = {1000 : [1000, '2020-12-25', 'guangdon', '广州', 1],
         1001 : [1001, '2020-12-26', 'hefei', 'anhui', 2],
         1002 : [1002, '2020-12-27', 'fujian', 'fuzhou', 3],
@@ -166,7 +169,7 @@ class TestOpenMLDBClient(unittest.TestCase):
     logging.info("result size: %d", len(rs))
     for row in rs:
       logging.info(row)
-    
+
   def check_result(self, rs, expectRows, orderIdx = 0):
     rs = sorted(rs, key=lambda x: x[orderIdx])
     expectRows = sorted(expectRows, key=lambda x: x[orderIdx])
@@ -176,7 +179,23 @@ class TestOpenMLDBClient(unittest.TestCase):
     for row in rs:
       self.assertEqual(row, expectRows[i], "not equal row: {}\n{}".format(row, expectRows[i]))
       i+=1
-    
+
+  def check_exectute_many(self,connection,sql):
+    try:
+      connection.execute(sql,[{"col1":1005, "col2":"2020-12-29", "col3":"shandong", "col4":"jinan", "col5":6},
+                              {"col1":1006, "col2":"2020-12-30", "col3":"fujian", "col4":"fuzhou", "col5":7}]);
+    except Exception as e:
+      self.assertTrue(False)
+
+  def check_dbapi(self,connection):
+    try:
+      result = connection.execute("select * from tsql1010;")
+      print(result.fetchmany(size=2))
+      print(result.fetchall())
+    except Exception as e:
+      self.assertTrue(False)
+
+
   def test_parameterized_query(self):
     logging.info("test_parameterized_query...")
     engine = db.create_engine('openmldb:///db_test?zk=127.0.0.1:6181&zkPath=/onebox')

--- a/python/test/openmldb_client_test.py
+++ b/python/test/openmldb_client_test.py
@@ -52,7 +52,9 @@ class TestOpenMLDBClient(unittest.TestCase):
     connection.execute(insert3, ({"col3":"fujian", "col4":"fuzhou"}));
     connection.execute(insert4, ({"col1":1003, "col2":"2020-12-28", "col3":"jiangxi", "col4":"nanchang", "col5":4}));
     connection.execute(insert5, ({"col2":"2020-12-29"}));
-    self.check_dbapi(connection)
+    
+    self.check_fetchmany(connection)
+    self.check_fetchall(connection)
     self.check_exectute_many(connection,insert4)
 
     data = {1000 : [1000, '2020-12-25', 'guangdon', '广州', 1],
@@ -187,14 +189,19 @@ class TestOpenMLDBClient(unittest.TestCase):
     except Exception as e:
       self.assertTrue(False)
 
-  def check_dbapi(self,connection):
+  def check_fetchmany(self,connection):
     try:
       result = connection.execute("select * from tsql1010;")
       print(result.fetchmany(size=2))
+    except Exception as e:
+      self.assertTrue(False)
+      
+  def check_fetchall(self,connection):
+    try:
+      result = connection.execute("select * from tsql1010;")
       print(result.fetchall())
     except Exception as e:
       self.assertTrue(False)
-
 
   def test_parameterized_query(self):
     logging.info("test_parameterized_query...")

--- a/python/test/openmldb_client_test.py
+++ b/python/test/openmldb_client_test.py
@@ -186,22 +186,25 @@ class TestOpenMLDBClient(unittest.TestCase):
     try:
       connection.execute(sql,[{"col1":1005, "col2":"2020-12-29", "col3":"shandong", "col4":"jinan", "col5":6},
                               {"col1":1006, "col2":"2020-12-30", "col3":"fujian", "col4":"fuzhou", "col5":7}]);
-    except Exception as e:
       self.assertTrue(False)
+    except Exception as e:
+      pass
 
   def check_fetchmany(self,connection):
     try:
       result = connection.execute("select * from tsql1010;")
       print(result.fetchmany(size=2))
-    except Exception as e:
       self.assertTrue(False)
+    except Exception as e:
+      pass
       
   def check_fetchall(self,connection):
     try:
       result = connection.execute("select * from tsql1010;")
       print(result.fetchall())
-    except Exception as e:
       self.assertTrue(False)
+    except Exception as e:
+      pass
 
   def test_parameterized_query(self):
     logging.info("test_parameterized_query...")


### PR DESCRIPTION
1, Raise NotSupportedError for all unsupported methods;
2, add new unittest for three examples APIs: Cursor.executemany(),Cursor.fetchmany(size=N),Cursor.fetchall().