### PR TITLE
feat: add batchjob in taskmanager and use the default batchjob jar

### DIFF
--- a/java/openmldb-taskmanager/pom.xml
+++ b/java/openmldb-taskmanager/pom.xml
@@ -98,13 +98,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- OpenMLDB -->
-        <dependency>
-            <groupId>com.4paradigm.openmldb</groupId>
-            <artifactId>openmldb-common</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-
         <!-- Hadoop -->
         <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -151,10 +144,22 @@
             <version>13.0.0</version>
         </dependency>
 
-        <!-- OpenMLDB client -->
+        <!-- OpenMLDB -->
         <dependency>
             <groupId>com.4paradigm.openmldb</groupId>
             <artifactId>openmldb-jdbc</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.4paradigm.openmldb</groupId>
+            <artifactId>openmldb-common</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.4paradigm.openmldb</groupId>
+            <artifactId>openmldb-batchjob</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
 

--- a/java/openmldb-taskmanager/src/main/resources/taskmanager.properties
+++ b/java/openmldb-taskmanager/src/main/resources/taskmanager.properties
@@ -15,11 +15,11 @@ zookeeper.base_sleep_time=1000
 zookeeper.max_connect_waitTime=30000
 
 # BatchJob Config
-batchjob.jar.path=/Users/tobe/code/4pd/OpenMLDB/java/openmldb-batchjob/target/openmldb-batchjob-0.4.0-SNAPSHOT.jar
+batchjob.jar.path=../lib/openmldb-batchjob-0.4.0-SNAPSHOT.jar
 
 # Hadoop Config
 namenode.uri=
-offline.data.prefix = file:///tmp/openmldb_offline/
+offline.data.prefix = file:///tmp/openmldb_offline_storage/
 
 # Spark Config
 spark.master=local

--- a/src/sdk/CMakeLists.txt
+++ b/src/sdk/CMakeLists.txt
@@ -184,7 +184,7 @@ if(SQL_JAVASDK_ENABLE)
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/java)
     add_dependencies(sql_javasdk_package cp_native_so)
 
-
+    # Install TaskManager binary and libraries
     FILE(GLOB TASKMANAGER_BIN "${PROJECT_SOURCE_DIR}/java/openmldb-taskmanager/target/openmldb-taskmanager-binary/bin/*")
     FILE(GLOB TASKMANAGER_CONF "${PROJECT_SOURCE_DIR}/java/openmldb-taskmanager/target/openmldb-taskmanager-binary/conf/*")
     FILE(GLOB TASKMANAGER_LIB "${PROJECT_SOURCE_DIR}/java/openmldb-taskmanager/target/openmldb-taskmanager-binary/lib/*")
@@ -196,10 +196,5 @@ if(SQL_JAVASDK_ENABLE)
             PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
     install(FILES ${TASKMANAGER_LIB}
             DESTINATION taskmanager/lib/
-            PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
-
-    FILE(GLOB BATCHJOB_JAR "${PROJECT_SOURCE_DIR}/java/openmldb-batchjob/target/openmldb-batchjob*.jar")
-    install(FILES ${BATCHJOB_JAR}
-            DESTINATION batchjob/
             PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
 endif()


### PR DESCRIPTION
* Include batchjob in taskmanager binary.
* Set `batchjob.jar.path` to find the default jar so that users do not need to set config before running taskmanager.
* Remove batchjob when installing the project which is included in taskmanager libraries
