### PR TITLE
fix: timestamp type and catch all in DataWriter

### DIFF
--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/utils/SparkRowUtil.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/utils/SparkRowUtil.scala
@@ -19,8 +19,10 @@ package com._4paradigm.openmldb.batch.utils
 import com._4paradigm.hybridse.sdk.{HybridSeException, UnsupportedHybridSeException}
 import com._4paradigm.openmldb.proto.Type
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.types.{BooleanType, DataType, DateType, DoubleType, FloatType, IntegerType, LongType,
-  ShortType, StringType, TimestampType}
+import org.apache.spark.sql.types.{
+  BooleanType, DataType, DateType, DoubleType, FloatType, IntegerType, LongType,
+  ShortType, StringType, TimestampType
+}
 
 object SparkRowUtil {
 
@@ -45,7 +47,8 @@ object SparkRowUtil {
       case Type.DataType.kFloat => FloatType
       case Type.DataType.kDouble => DoubleType
       case Type.DataType.kDate => DateType
-      // In online storage, timestamp format is int64. But in offline storage, we use the spark sql timestamp type(DateTime)
+      // In online storage, timestamp format is int64. But in offline storage, we use the spark sql timestamp type
+      // (DateTime)
       case Type.DataType.kTimestamp => TimestampType
       case Type.DataType.kVarchar | Type.DataType.kString => StringType
       case e: Any => throw new UnsupportedHybridSeException(s"unsupported proto DataType $e")

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/utils/SparkRowUtil.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/utils/SparkRowUtil.scala
@@ -45,7 +45,8 @@ object SparkRowUtil {
       case Type.DataType.kFloat => FloatType
       case Type.DataType.kDouble => DoubleType
       case Type.DataType.kDate => DateType
-      case Type.DataType.kTimestamp => LongType // in openmldb, timestamp format is int64
+      // In online storage, timestamp format is int64. But in offline storage, we use the spark sql timestamp type(DateTime)
+      case Type.DataType.kTimestamp => TimestampType
       case Type.DataType.kVarchar | Type.DataType.kString => StringType
       case e: Any => throw new UnsupportedHybridSeException(s"unsupported proto DataType $e")
     }

--- a/java/openmldb-spark-connector/src/main/java/com/_4paradigm/openmldb/spark/write/OpenmldbDataWriter.java
+++ b/java/openmldb-spark-connector/src/main/java/com/_4paradigm/openmldb/spark/write/OpenmldbDataWriter.java
@@ -72,9 +72,8 @@ public class OpenmldbDataWriter implements DataWriter<InternalRow> {
             Preconditions.checkState(record.numFields() == metaData.getColumnCount());
             addRow(record, preparedStatement);
             preparedStatement.addBatch();
-        } catch (SQLException e) {
-            e.printStackTrace();
-            throw new IOException(e.getMessage());
+        } catch (Exception e) {
+            throw new IOException("convert to openmldb row failed", e);
         }
     }
 
@@ -114,7 +113,7 @@ public class OpenmldbDataWriter implements DataWriter<InternalRow> {
                     preparedStatement.setDate(i + 1, new Date(record.getInt(i)));
                     break;
                 case Types.TIMESTAMP:
-                    // record.getLong(i) gets us timestamp, and sql timestamp unit is ms.
+                    // record.getLong(spark sql TimestampType) gets us timestamp, and sql timestamp unit is ms
                     preparedStatement.setTimestamp(i + 1, new Timestamp(record.getLong(i) / 1000));
                     break;
                 default:

--- a/java/openmldb-spark-connector/src/test/scala/TestWrite.scala
+++ b/java/openmldb-spark-connector/src/test/scala/TestWrite.scala
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
+import java.lang.Thread.currentThread
+
 import com._4paradigm.openmldb.sdk.SdkOption
 import com._4paradigm.openmldb.sdk.impl.SqlClusterExecutor
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.scalatest.FunSuite
-
-import java.lang.Thread.currentThread
 
 class TestWrite extends FunSuite {
   test("Test write a local file to openmldb") {
@@ -51,7 +51,8 @@ class TestWrite extends FunSuite {
     option.setZkPath(zkPath)
     val executor = new SqlClusterExecutor(option)
     executor.createDB(db)
-    executor.executeDDL(db, "create table " + table + "(c1 bool, c2 smallint, c3 int, c4 bigint, c5 float, c6 double," +
+    executor.executeDDL(db, s"drop table $table")
+    executor.executeDDL(db, s"create table $table(c1 bool, c2 smallint, c3 int, c4 bigint, c5 float, c6 double," +
       "c7 string, c8 date, c9 timestamp, c10_str string);")
 
     // batch write can't use ErrorIfExists


### PR DESCRIPTION
use normal timestamp in offline storage
df use sql timestamp(s), df write InternalRow use spark sql TimestampType(us), openmldb use long(int64, ms)