### PR TITLE
feat: replace hybridse library loader with openmldb jsdk library loader

### DIFF
--- a/java/hybridse-sdk/src/main/java/com/_4paradigm/hybridse/HybridSeLibrary.java
+++ b/java/hybridse-sdk/src/main/java/com/_4paradigm/hybridse/HybridSeLibrary.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
+ * TODO: This class is deprecated and we should load the library by SqlClusterExecutor.initJavaSdkLibrary()
  * Library loader for hybridse jsdk core.
  */
 public class HybridSeLibrary {

--- a/java/hybridse-sdk/src/main/java/com/_4paradigm/hybridse/sdk/JitManager.java
+++ b/java/hybridse-sdk/src/main/java/com/_4paradigm/hybridse/sdk/JitManager.java
@@ -117,26 +117,9 @@ public class JitManager {
      * @param moduleBuffer ByteBuffer used to initialize native module
      */
     public static synchronized void initJitModule(String tag, ByteBuffer moduleBuffer) {
-        // ensure worker native
-        HybridSeLibrary.initCore();
-        Engine.InitializeGlobalLLVM();
+        // Notice that we should load library before calling this, invoke SqlClusterExecutor.initJavaSdkLibrary()
 
-        // ensure worker side module
-        if (!JitManager.hasModule(tag)) {
-            JitManager.initModule(tag, moduleBuffer);
-        }
-    }
-
-    /**
-     * Init llvm module specified by tag. Init native module with module byte buffer.
-     *
-     * @param tag tag specified a jit
-     * @param moduleBuffer ByteBuffer used to initialize native module
-     * @param jsdkCoreLibraryPath the file path of jsdk core library
-     */
-    public static synchronized void initJitModule(String tag, ByteBuffer moduleBuffer, String jsdkCoreLibraryPath) {
         // ensure worker native
-        HybridSeLibrary.initCore(jsdkCoreLibraryPath);
         Engine.InitializeGlobalLLVM();
 
         // ensure worker side module

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/OpenmldbBatchConfig.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/OpenmldbBatchConfig.scala
@@ -124,8 +124,8 @@ class OpenmldbBatchConfig extends Serializable {
   var disableOpenmldb = false
 
   // OpenMLDB Java SDK dynamic library path, notice that this should not be set hybridse jsdk so
-  @ConfigOption(name = "openmldb.hybridse.jsdk.path", doc = "The path of HybridSE jsdk core file path")
-  var hybridseJsdkLibraryPath = ""
+  @ConfigOption(name = "openmldb.jsdk.library.path", doc = "The path of OpenMLDB Java SDK core file path")
+  var openmldbJsdkLibraryPath = ""
 
   @ConfigOption(name = "openmldb.zk.cluster", doc = "The cluster of ZooKeeper for NameServer")
   var openmldbZkCluster = ""

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/SparkPlanner.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/SparkPlanner.scala
@@ -42,17 +42,11 @@ class SparkPlanner(session: SparkSession, config: OpenmldbBatchConfig, sparkAppN
 
   var openmldbSession: OpenmldbSession = _
 
-  if (this.config.hybridseJsdkLibraryPath.equals("")) {
-    // Set library path to the one in openmldb jsdk
-    config.hybridseJsdkLibraryPath = SqlClusterExecutor.findSdkLibraryPath()
-  }
-
   // Ensure native initialized
-  if (config.hybridseJsdkLibraryPath.equals("")) {
-    // Should not load hybridse jsdk so and openmldb jsdk so at the same time
+  if (config.openmldbJsdkLibraryPath.equals("")) {
     SqlClusterExecutor.initJavaSdkLibrary()
   } else {
-    HybridSeLibrary.initCore(config.hybridseJsdkLibraryPath)
+    SqlClusterExecutor.initJavaSdkLibrary(config.openmldbJsdkLibraryPath)
   }
   Engine.InitializeGlobalLLVM()
 

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/SparkPlanner.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/SparkPlanner.scala
@@ -43,11 +43,7 @@ class SparkPlanner(session: SparkSession, config: OpenmldbBatchConfig, sparkAppN
   var openmldbSession: OpenmldbSession = _
 
   // Ensure native initialized
-  if (config.openmldbJsdkLibraryPath.equals("")) {
-    SqlClusterExecutor.initJavaSdkLibrary()
-  } else {
-    SqlClusterExecutor.initJavaSdkLibrary(config.openmldbJsdkLibraryPath)
-  }
+  SqlClusterExecutor.initJavaSdkLibrary(config.openmldbJsdkLibraryPath)
   Engine.InitializeGlobalLLVM()
 
   def this(session: SparkSession, sparkAppName: String) = {

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/api/OpenmldbSession.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/api/OpenmldbSession.scala
@@ -19,6 +19,7 @@ package com._4paradigm.openmldb.batch.api
 import com._4paradigm.hybridse.sdk.HybridSeException
 import com._4paradigm.openmldb.batch.catalog.OpenmldbCatalogService
 import com._4paradigm.openmldb.batch.{OpenmldbBatchConfig, SparkPlanner}
+import com._4paradigm.openmldb.sdk.impl.SqlClusterExecutor
 import org.apache.commons.io.IOUtils
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.QueryPlanningTracker
@@ -58,7 +59,8 @@ class OpenmldbSession {
     this.setDefaultSparkConfig()
 
     if (this.config.openmldbZkCluster.nonEmpty && this.config.openmldbZkRootPath.nonEmpty) {
-      openmldbCatalogService = new OpenmldbCatalogService(this.config.openmldbZkCluster, this.config.openmldbZkRootPath)
+      openmldbCatalogService = new OpenmldbCatalogService(this.config.openmldbZkCluster, this.config.openmldbZkRootPath,
+        config.openmldbJsdkLibraryPath)
       registerOpenmldbOfflineTable(openmldbCatalogService)
     }
   }

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/catalog/OpenmldbCatalogService.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/catalog/OpenmldbCatalogService.scala
@@ -22,13 +22,18 @@ import com._4paradigm.openmldb.sdk.SdkOption
 import scala.collection.JavaConverters.asScalaBufferConverter
 import scala.collection.mutable
 
-class OpenmldbCatalogService(val zkCluster: String, val zkPath: String) {
+class OpenmldbCatalogService(val zkCluster: String, val zkPath: String, val openmldbJsdkPath: String) {
 
   val option = new SdkOption
   option.setZkCluster(zkCluster)
   option.setZkPath(zkPath)
 
-  val sqlExecutor = new SqlClusterExecutor(option)
+  val sqlExecutor = if (openmldbJsdkPath.isEmpty) {
+    new SqlClusterExecutor(option)
+  } else {
+    SqlClusterExecutor.initJavaSdkLibrary(openmldbJsdkPath)
+    new SqlClusterExecutor(option, false)
+  }
 
   def getDatabases: Array[String] = {
     sqlExecutor.showDatabases().asScala.toArray

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/catalog/OpenmldbCatalogService.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/catalog/OpenmldbCatalogService.scala
@@ -27,13 +27,7 @@ class OpenmldbCatalogService(val zkCluster: String, val zkPath: String, val open
   val option = new SdkOption
   option.setZkCluster(zkCluster)
   option.setZkPath(zkPath)
-
-  val sqlExecutor = if (openmldbJsdkPath.isEmpty) {
-    new SqlClusterExecutor(option)
-  } else {
-    SqlClusterExecutor.initJavaSdkLibrary(openmldbJsdkPath)
-    new SqlClusterExecutor(option, false)
-  }
+  val sqlExecutor = new SqlClusterExecutor(option, openmldbJsdkPath)
 
   def getDatabases: Array[String] = {
     sqlExecutor.showDatabases().asScala.toArray

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/catalog/OpenmldbCatalogService.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/catalog/OpenmldbCatalogService.scala
@@ -29,6 +29,10 @@ class OpenmldbCatalogService(val zkCluster: String, val zkPath: String, val open
   option.setZkPath(zkPath)
   val sqlExecutor = new SqlClusterExecutor(option, openmldbJsdkPath)
 
+  def this(zkCluster: String, zkPath: String) = {
+    this(zkCluster, zkPath, "")
+  }
+
   def getDatabases: Array[String] = {
     sqlExecutor.showDatabases().asScala.toArray
   }

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/FilterPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/FilterPlan.scala
@@ -57,7 +57,7 @@ object FilterPlan {
         outputSchema = filter.fn_info().fn_schema(),
         moduleTag = ctx.getTag,
         moduleBroadcast = ctx.getSerializableModuleBuffer,
-        hybridseJsdkLibraryPath = ctx.getConf.hybridseJsdkLibraryPath
+        hybridseJsdkLibraryPath = ctx.getConf.openmldbJsdkLibraryPath
       )
       ctx.getSparkSession.udf.register(regName, conditionUDF)
 

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/GroupByAggregationPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/GroupByAggregationPlan.scala
@@ -91,12 +91,7 @@ object GroupByAggregationPlan {
         // Init JIT
         val tag = projectConfig.moduleTag
         val buffer = projectConfig.moduleNoneBroadcast.getBuffer
-
-        if (openmldbJsdkLibraryPath.equals("")) {
-          SqlClusterExecutor.initJavaSdkLibrary()
-        } else {
-          SqlClusterExecutor.initJavaSdkLibrary(openmldbJsdkLibraryPath)
-        }
+        SqlClusterExecutor.initJavaSdkLibrary(openmldbJsdkLibraryPath)
         JitManager.initJitModule(tag, buffer)
 
         val jit = JitManager.getJit(tag)

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/GroupByAggregationPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/GroupByAggregationPlan.scala
@@ -22,6 +22,7 @@ import com._4paradigm.hybridse.vm.{CoreAPI, GroupbyInterface, PhysicalGroupAggre
 import com._4paradigm.openmldb.batch.nodes.RowProjectPlan.ProjectConfig
 import com._4paradigm.openmldb.batch.utils.{HybridseUtil, SparkColumnUtil}
 import com._4paradigm.openmldb.batch.{PlanContext, SparkInstance, SparkRowCodec}
+import com._4paradigm.openmldb.sdk.impl.SqlClusterExecutor
 import org.apache.spark.sql.types.LongType
 import org.apache.spark.sql.{Column, Row}
 import org.slf4j.LoggerFactory
@@ -78,7 +79,7 @@ object GroupByAggregationPlan {
     )
     val groupKeyComparator = HybridseUtil.createGroupKeyComparator(groupIdxs.toArray)
 
-    val hybridseJsdkLibraryPath = ctx.getConf.hybridseJsdkLibraryPath
+    val openmldbJsdkLibraryPath = ctx.getConf.openmldbJsdkLibraryPath
 
     // Map partition
     val resultRDD = sortedInputDf.rdd.mapPartitions(iter => {
@@ -91,11 +92,12 @@ object GroupByAggregationPlan {
         val tag = projectConfig.moduleTag
         val buffer = projectConfig.moduleNoneBroadcast.getBuffer
 
-        if (hybridseJsdkLibraryPath.equals("")) {
-          JitManager.initJitModule(tag, buffer)
+        if (openmldbJsdkLibraryPath.equals("")) {
+          SqlClusterExecutor.initJavaSdkLibrary()
         } else {
-          JitManager.initJitModule(tag, buffer, hybridseJsdkLibraryPath)
+          SqlClusterExecutor.initJavaSdkLibrary(openmldbJsdkLibraryPath)
         }
+        JitManager.initJitModule(tag, buffer)
 
         val jit = JitManager.getJit(tag)
         val fn = jit.FindFunction(projectConfig.functionName)

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/JoinPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/JoinPlan.scala
@@ -24,6 +24,7 @@ import com._4paradigm.hybridse.node.{ExprListNode, JoinType}
 import com._4paradigm.hybridse.vm.{CoreAPI, HybridSeJitWrapper, PhysicalJoinNode}
 import com._4paradigm.openmldb.batch.utils.{HybridseUtil, SparkColumnUtil, SparkRowUtil, SparkUtil}
 import com._4paradigm.openmldb.batch.{PlanContext, SparkInstance, SparkRowCodec}
+import com._4paradigm.openmldb.sdk.impl.SqlClusterExecutor
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{Column, DataFrame, Row, functions}
 import org.slf4j.LoggerFactory
@@ -112,7 +113,7 @@ object JoinPlan {
         outputSchema = filter.fn_info().fn_schema(),
         moduleTag = ctx.getTag,
         moduleBroadcast = ctx.getSerializableModuleBuffer,
-        hybridseJsdkLibraryPath = ctx.getConf.hybridseJsdkLibraryPath
+        hybridseJsdkLibraryPath = ctx.getConf.openmldbJsdkLibraryPath
       )
       spark.udf.register(regName, conditionUDF)
 
@@ -216,7 +217,7 @@ object JoinPlan {
                                    outputSchema: java.util.List[ColumnDef],
                                    moduleTag: String,
                                    moduleBroadcast: SerializableByteBuffer,
-                                   hybridseJsdkLibraryPath: String
+                                   openmldbJsdkLibraryPath: String
                                   ) extends Function1[Row, Boolean] with Serializable {
     private val jit = initJIT()
 
@@ -233,11 +234,12 @@ object JoinPlan {
       // ensure worker native
       val buffer = moduleBroadcast.getBuffer
 
-      if (hybridseJsdkLibraryPath.equals("")) {
-        JitManager.initJitModule(moduleTag, buffer)
+      if (openmldbJsdkLibraryPath.equals("")) {
+        SqlClusterExecutor.initJavaSdkLibrary()
       } else {
-        JitManager.initJitModule(moduleTag, buffer, hybridseJsdkLibraryPath)
+        SqlClusterExecutor.initJavaSdkLibrary(openmldbJsdkLibraryPath)
       }
+      JitManager.initJitModule(moduleTag, buffer)
 
       JitManager.getJit(moduleTag)
     }

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/JoinPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/JoinPlan.scala
@@ -233,12 +233,7 @@ object JoinPlan {
     def initJIT(): HybridSeJitWrapper = {
       // ensure worker native
       val buffer = moduleBroadcast.getBuffer
-
-      if (openmldbJsdkLibraryPath.equals("")) {
-        SqlClusterExecutor.initJavaSdkLibrary()
-      } else {
-        SqlClusterExecutor.initJavaSdkLibrary(openmldbJsdkLibraryPath)
-      }
+      SqlClusterExecutor.initJavaSdkLibrary(openmldbJsdkLibraryPath)
       JitManager.initJitModule(moduleTag, buffer)
 
       JitManager.getJit(moduleTag)

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/RowProjectPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/RowProjectPlan.scala
@@ -21,6 +21,7 @@ import com._4paradigm.hybridse.sdk.{JitManager, SerializableByteBuffer}
 import com._4paradigm.hybridse.vm.{CoreAPI, PhysicalTableProjectNode}
 import com._4paradigm.openmldb.batch.utils.{AutoDestructibleIterator, HybridseUtil, SparkUtil, UnsafeRowUtil}
 import com._4paradigm.openmldb.batch.{PlanContext, SparkInstance, SparkRowCodec}
+import com._4paradigm.openmldb.sdk.impl.SqlClusterExecutor
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.sql.types.{LongType, StructType}
@@ -68,7 +69,7 @@ object RowProjectPlan {
       inputTable.getDfConsideringIndex(ctx, node.GetNodeId())
     }
 
-    val hybridseJsdkLibraryPath = ctx.getConf.hybridseJsdkLibraryPath
+    val openmldbJsdkLibraryPath = ctx.getConf.openmldbJsdkLibraryPath
 
     val outputDf = if (ctx.getConf.enableUnsafeRowOptimization) { // Use UnsafeRow optimization
 
@@ -76,11 +77,12 @@ object RowProjectPlan {
         val tag = projectConfig.moduleTag
         val buffer = projectConfig.moduleNoneBroadcast.getBuffer
 
-        if (hybridseJsdkLibraryPath.equals("")) {
-          JitManager.initJitModule(tag, buffer)
+        if (openmldbJsdkLibraryPath.equals("")) {
+          SqlClusterExecutor.initJavaSdkLibrary()
         } else {
-          JitManager.initJitModule(tag, buffer, hybridseJsdkLibraryPath)
+          SqlClusterExecutor.initJavaSdkLibrary(openmldbJsdkLibraryPath)
         }
+        JitManager.initJitModule(tag, buffer)
 
         val jit = JitManager.getJit(tag)
         val fn = jit.FindFunction(projectConfig.functionName)
@@ -114,12 +116,12 @@ object RowProjectPlan {
         val tag = projectConfig.moduleTag
         val buffer = projectConfig.moduleNoneBroadcast
 
-        if (hybridseJsdkLibraryPath.equals("")) {
-          JitManager.initJitModule(tag, buffer.getBuffer)
+        if (openmldbJsdkLibraryPath.equals("")) {
+          SqlClusterExecutor.initJavaSdkLibrary()
         } else {
-          JitManager.initJitModule(tag, buffer.getBuffer, hybridseJsdkLibraryPath)
+          SqlClusterExecutor.initJavaSdkLibrary(openmldbJsdkLibraryPath)
         }
-
+        JitManager.initJitModule(tag, buffer.getBuffer)
 
         val jit = JitManager.getJit(tag)
         val fn = jit.FindFunction(projectConfig.functionName)

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/RowProjectPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/RowProjectPlan.scala
@@ -76,12 +76,7 @@ object RowProjectPlan {
       val outputInternalRowRdd = inputDf.queryExecution.toRdd.mapPartitions(partitionIter => {
         val tag = projectConfig.moduleTag
         val buffer = projectConfig.moduleNoneBroadcast.getBuffer
-
-        if (openmldbJsdkLibraryPath.equals("")) {
-          SqlClusterExecutor.initJavaSdkLibrary()
-        } else {
-          SqlClusterExecutor.initJavaSdkLibrary(openmldbJsdkLibraryPath)
-        }
+        SqlClusterExecutor.initJavaSdkLibrary(openmldbJsdkLibraryPath)
         JitManager.initJitModule(tag, buffer)
 
         val jit = JitManager.getJit(tag)
@@ -115,12 +110,7 @@ object RowProjectPlan {
         // TODO: Do not use broadcast for prophet HybridSE op
         val tag = projectConfig.moduleTag
         val buffer = projectConfig.moduleNoneBroadcast
-
-        if (openmldbJsdkLibraryPath.equals("")) {
-          SqlClusterExecutor.initJavaSdkLibrary()
-        } else {
-          SqlClusterExecutor.initJavaSdkLibrary(openmldbJsdkLibraryPath)
-        }
+        SqlClusterExecutor.initJavaSdkLibrary(openmldbJsdkLibraryPath)
         JitManager.initJitModule(tag, buffer.getBuffer)
 
         val jit = JitManager.getJit(tag)

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/window/WindowAggPlanUtil.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/window/WindowAggPlanUtil.scala
@@ -209,12 +209,7 @@ object WindowAggPlanUtil {
     // get jit in executor process
     val tag = config.moduleTag
     val buffer = config.moduleNoneBroadcast.getBuffer
-
-    if (sqlConfig.openmldbJsdkLibraryPath.equals("")) {
-      SqlClusterExecutor.initJavaSdkLibrary()
-    } else {
-      SqlClusterExecutor.initJavaSdkLibrary(sqlConfig.openmldbJsdkLibraryPath)
-    }
+    SqlClusterExecutor.initJavaSdkLibrary(sqlConfig.openmldbJsdkLibraryPath)
     JitManager.initJitModule(tag, buffer)
 
     val jit = JitManager.getJit(tag)

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/window/WindowAggPlanUtil.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/window/WindowAggPlanUtil.scala
@@ -21,7 +21,8 @@ import com._4paradigm.hybridse.sdk.{HybridSeException, JitManager, SerializableB
 import com._4paradigm.hybridse.vm.PhysicalWindowAggrerationNode
 import com._4paradigm.hybridse.vm.Window.WindowFrameType
 import com._4paradigm.openmldb.batch.utils.{HybridseUtil, SparkColumnUtil, SparkUtil}
-import com._4paradigm.openmldb.batch.{PlanContext, OpenmldbBatchConfig, SparkInstance}
+import com._4paradigm.openmldb.batch.{OpenmldbBatchConfig, PlanContext, SparkInstance}
+import com._4paradigm.openmldb.sdk.impl.SqlClusterExecutor
 import org.apache.hadoop.fs.FileSystem
 import org.apache.spark.sql.{DataFrame, functions}
 import org.apache.spark.sql.types.{LongType, StructType}
@@ -208,7 +209,14 @@ object WindowAggPlanUtil {
     // get jit in executor process
     val tag = config.moduleTag
     val buffer = config.moduleNoneBroadcast.getBuffer
+
+    if (sqlConfig.openmldbJsdkLibraryPath.equals("")) {
+      SqlClusterExecutor.initJavaSdkLibrary()
+    } else {
+      SqlClusterExecutor.initJavaSdkLibrary(sqlConfig.openmldbJsdkLibraryPath)
+    }
     JitManager.initJitModule(tag, buffer)
+
     val jit = JitManager.getJit(tag)
 
     // create stateful computer

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/window/WindowSampleSupport.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/window/WindowSampleSupport.scala
@@ -22,6 +22,7 @@ import com._4paradigm.hybridse.sdk.JitManager
 import com._4paradigm.hybridse.vm.{CoreAPI, HybridSeJitWrapper}
 import com._4paradigm.openmldb.batch.OpenmldbBatchConfig
 import com._4paradigm.openmldb.batch.window.WindowAggPlanUtil.WindowAggConfig
+import com._4paradigm.openmldb.sdk.impl.SqlClusterExecutor
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.sql.Row
@@ -203,7 +204,14 @@ object WindowSampleSupport {
 
     private val jit = {
       val buffer = config.moduleNoneBroadcast.getBuffer
+
+      if (sqlConfig.openmldbJsdkLibraryPath.equals("")) {
+        SqlClusterExecutor.initJavaSdkLibrary()
+      } else {
+        SqlClusterExecutor.initJavaSdkLibrary(sqlConfig.openmldbJsdkLibraryPath)
+      }
       JitManager.initJitModule(config.moduleTag, buffer)
+
       JitManager.getJit(config.moduleTag)
     }
 

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/window/WindowSampleSupport.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/window/WindowSampleSupport.scala
@@ -204,14 +204,8 @@ object WindowSampleSupport {
 
     private val jit = {
       val buffer = config.moduleNoneBroadcast.getBuffer
-
-      if (sqlConfig.openmldbJsdkLibraryPath.equals("")) {
-        SqlClusterExecutor.initJavaSdkLibrary()
-      } else {
-        SqlClusterExecutor.initJavaSdkLibrary(sqlConfig.openmldbJsdkLibraryPath)
-      }
+      SqlClusterExecutor.initJavaSdkLibrary(sqlConfig.openmldbJsdkLibraryPath)
       JitManager.initJitModule(config.moduleTag, buffer)
-
       JitManager.getJit(config.moduleTag)
     }
 

--- a/java/openmldb-jdbc/src/main/java/com/_4paradigm/openmldb/sdk/impl/SqlClusterExecutor.java
+++ b/java/openmldb-jdbc/src/main/java/com/_4paradigm/openmldb/sdk/impl/SqlClusterExecutor.java
@@ -77,7 +77,7 @@ public class SqlClusterExecutor implements SqlExecutor {
         this(option, "sql_jsdk");
     }
 
-    synchronized private static void initJavaSdkLibrary(String libraryPath) {
+    synchronized public static void initJavaSdkLibrary(String libraryPath) {
         if (!initialized) {
             if (libraryPath == null || libraryPath.isEmpty()) {
                 LibraryLoader.loadLibrary("sql_jsdk");
@@ -292,7 +292,7 @@ public class SqlClusterExecutor implements SqlExecutor {
 
     public static List<String> genDDL(String sql, Map<String, Map<String, Schema>> tableSchema)
             throws SQLException {
-        SqlClusterExecutor.initJavaSdkLibrary();
+        SqlClusterExecutor.initJavaSdkLibrary("");
 
         if (null == tableSchema || tableSchema.isEmpty()) {
             throw new SQLException("input schema is null or empty");
@@ -311,7 +311,7 @@ public class SqlClusterExecutor implements SqlExecutor {
     }
 
     public static Schema genOutputSchema(String sql, Map<String, Map<String, Schema>> tableSchema) throws SQLException {
-        SqlClusterExecutor.initJavaSdkLibrary();
+        SqlClusterExecutor.initJavaSdkLibrary("");
 
         if (null == tableSchema || tableSchema.isEmpty()) {
             throw new SQLException("input schema is null or empty");

--- a/java/openmldb-jdbc/src/main/java/com/_4paradigm/openmldb/sdk/impl/SqlClusterExecutor.java
+++ b/java/openmldb-jdbc/src/main/java/com/_4paradigm/openmldb/sdk/impl/SqlClusterExecutor.java
@@ -57,17 +57,6 @@ public class SqlClusterExecutor implements SqlExecutor {
     private static boolean initialized = false;
     private SQLRouter sqlRouter;
 
-    public static void initJavaSdkLibrary(String libraryPath) {
-        if (!initialized) {
-            LibraryLoader.loadLibrary(libraryPath);
-            initialized = true;
-        }
-    }
-
-    public static void initJavaSdkLibrary() {
-        initJavaSdkLibrary("sql_jsdk");
-    }
-
     public SqlClusterExecutor(SdkOption option, boolean initializeLibrary) throws SqlException {
         if (initializeLibrary) {
             initJavaSdkLibrary();
@@ -89,19 +78,15 @@ public class SqlClusterExecutor implements SqlExecutor {
         this(option, true);
     }
 
-    public static String findSdkLibraryPath() throws UnsatisfiedLinkError {
-        String libraryPath = "sql_jsdk";
-        String osName = System.getProperty("os.name").toLowerCase();
-        if (osName.equals("mac os x")) {
-            libraryPath = "lib" + libraryPath + ".dylib";
-        } else if (osName.contains("linux")) {
-            libraryPath = "lib" + libraryPath + ".so";
+    public static void initJavaSdkLibrary(String libraryPath) {
+        if (!initialized) {
+            LibraryLoader.loadLibrary(libraryPath);
+            initialized = true;
         }
-        URL resource = LibraryLoader.class.getClassLoader().getResource(libraryPath);
-        if (resource == null) {
-            throw new UnsatisfiedLinkError(String.format("Fail to load library %s", libraryPath));
-        }
-        return resource.getPath();
+    }
+
+    public static void initJavaSdkLibrary() {
+        initJavaSdkLibrary("sql_jsdk");
     }
 
     @Override
@@ -288,7 +273,7 @@ public class SqlClusterExecutor implements SqlExecutor {
         return spInfo;
     }
 
-    static private TableColumnDescPairVector convertSchema(Map<String, Schema> tables) throws SQLException {
+    private static TableColumnDescPairVector convertSchema(Map<String, Schema> tables) throws SQLException {
         TableColumnDescPairVector result = new TableColumnDescPairVector();
         for (Map.Entry<String, Schema> entry : tables.entrySet()) {
             String table = entry.getKey();
@@ -305,8 +290,10 @@ public class SqlClusterExecutor implements SqlExecutor {
         return result;
     }
 
-    static public List<String> genDDL(String sql, Map<String, Map<String, Schema>> tableSchema)
+    public static List<String> genDDL(String sql, Map<String, Map<String, Schema>> tableSchema)
             throws SQLException {
+        SqlClusterExecutor.initJavaSdkLibrary();
+
         if (null == tableSchema || tableSchema.isEmpty()) {
             throw new SQLException("input schema is null or empty");
         }
@@ -323,7 +310,9 @@ public class SqlClusterExecutor implements SqlExecutor {
         return results;
     }
 
-    static public Schema genOutputSchema(String sql, Map<String, Map<String, Schema>> tableSchema) throws SQLException {
+    public static Schema genOutputSchema(String sql, Map<String, Map<String, Schema>> tableSchema) throws SQLException {
+        SqlClusterExecutor.initJavaSdkLibrary();
+
         if (null == tableSchema || tableSchema.isEmpty()) {
             throw new SQLException("input schema is null or empty");
         }

--- a/java/openmldb-jdbc/src/main/java/com/_4paradigm/openmldb/sdk/impl/SqlClusterExecutor.java
+++ b/java/openmldb-jdbc/src/main/java/com/_4paradigm/openmldb/sdk/impl/SqlClusterExecutor.java
@@ -57,10 +57,9 @@ public class SqlClusterExecutor implements SqlExecutor {
     private static boolean initialized = false;
     private SQLRouter sqlRouter;
 
-    public SqlClusterExecutor(SdkOption option, boolean initializeLibrary) throws SqlException {
-        if (initializeLibrary) {
-            initJavaSdkLibrary();
-        }
+    public SqlClusterExecutor(SdkOption option, String libraryPath) throws SqlException {
+        initJavaSdkLibrary(libraryPath);
+
         SQLRouterOptions sqlOpt = new SQLRouterOptions();
         sqlOpt.setSession_timeout(option.getSessionTimeout());
         sqlOpt.setZk_cluster(option.getZkCluster());
@@ -75,18 +74,19 @@ public class SqlClusterExecutor implements SqlExecutor {
     }
 
     public SqlClusterExecutor(SdkOption option) throws SqlException {
-        this(option, true);
+        this(option, "sql_jsdk");
     }
 
-    public static void initJavaSdkLibrary(String libraryPath) {
+    synchronized private static void initJavaSdkLibrary(String libraryPath) {
         if (!initialized) {
+            if (libraryPath == null || libraryPath.isEmpty()) {
+                LibraryLoader.loadLibrary("sql_jsdk");
+            } else {
+                LibraryLoader.loadLibrary(libraryPath);
+            }
             LibraryLoader.loadLibrary(libraryPath);
             initialized = true;
         }
-    }
-
-    public static void initJavaSdkLibrary() {
-        initJavaSdkLibrary("sql_jsdk");
     }
 
     @Override

--- a/java/openmldb-jdbc/src/main/java/com/_4paradigm/openmldb/sdk/impl/SqlClusterExecutor.java
+++ b/java/openmldb-jdbc/src/main/java/com/_4paradigm/openmldb/sdk/impl/SqlClusterExecutor.java
@@ -54,22 +54,24 @@ import java.util.Map;
 public class SqlClusterExecutor implements SqlExecutor {
     private static final Logger logger = LoggerFactory.getLogger(SqlClusterExecutor.class);
 
-    static {
-        initJavaSdkLibrary();
-    }
-
     private static boolean initialized = false;
     private SQLRouter sqlRouter;
 
-    public static void initJavaSdkLibrary() {
+    public static void initJavaSdkLibrary(String libraryPath) {
         if (!initialized) {
-            LibraryLoader.loadLibrary("sql_jsdk");
+            LibraryLoader.loadLibrary(libraryPath);
             initialized = true;
         }
     }
 
-    public SqlClusterExecutor(SdkOption option) throws SqlException {
+    public static void initJavaSdkLibrary() {
+        initJavaSdkLibrary("sql_jsdk");
+    }
 
+    public SqlClusterExecutor(SdkOption option, boolean initializeLibrary) throws SqlException {
+        if (initializeLibrary) {
+            initJavaSdkLibrary();
+        }
         SQLRouterOptions sqlOpt = new SQLRouterOptions();
         sqlOpt.setSession_timeout(option.getSessionTimeout());
         sqlOpt.setZk_cluster(option.getZkCluster());
@@ -81,6 +83,10 @@ public class SqlClusterExecutor implements SqlExecutor {
         if (sqlRouter == null) {
             throw new SqlException("fail to create sql executor");
         }
+    }
+
+    public SqlClusterExecutor(SdkOption option) throws SqlException {
+        this(option, true);
     }
 
     public static String findSdkLibraryPath() throws UnsatisfiedLinkError {

--- a/java/openmldb-jdbc/src/test/java/com/_4paradigm/openmldb/jdbc/SQLRouterSmokeTest.java
+++ b/java/openmldb-jdbc/src/test/java/com/_4paradigm/openmldb/jdbc/SQLRouterSmokeTest.java
@@ -578,7 +578,6 @@ public class SQLRouterSmokeTest {
         Map<String, Schema> dbSchema = new HashMap<>();
         dbSchema.put("t1", sch);
         schemaMaps.put("db1", dbSchema);
-        SqlClusterExecutor.initJavaSdkLibrary();
         List<String> ddls = SqlClusterExecutor.genDDL("select c1 from t1;", schemaMaps);
         Assert.assertEquals(ddls.size(), 1);
         List<Column> schema = SqlClusterExecutor.genOutputSchema("select c1 from t1;", schemaMaps).getColumnList();

--- a/java/openmldb-jdbc/src/test/java/com/_4paradigm/openmldb/jdbc/SQLRouterSmokeTest.java
+++ b/java/openmldb-jdbc/src/test/java/com/_4paradigm/openmldb/jdbc/SQLRouterSmokeTest.java
@@ -578,6 +578,7 @@ public class SQLRouterSmokeTest {
         Map<String, Schema> dbSchema = new HashMap<>();
         dbSchema.put("t1", sch);
         schemaMaps.put("db1", dbSchema);
+        SqlClusterExecutor.initJavaSdkLibrary();
         List<String> ddls = SqlClusterExecutor.genDDL("select c1 from t1;", schemaMaps);
         Assert.assertEquals(ddls.size(), 1);
         List<Column> schema = SqlClusterExecutor.genOutputSchema("select c1 from t1;", schemaMaps).getColumnList();

--- a/java/openmldb-taskmanager/src/main/java/com/_4paradigm/openmldb/taskmanager/server/impl/TaskManagerImpl.java
+++ b/java/openmldb-taskmanager/src/main/java/com/_4paradigm/openmldb/taskmanager/server/impl/TaskManagerImpl.java
@@ -30,13 +30,33 @@ import java.util.List;
 @Slf4j
 public class TaskManagerImpl implements TaskManagerInterface {
 
+    /**
+     * Covert JobInfo object to protobuf object.
+     *
+     * @param job the object of class JobInfo
+     * @return the protobuf object
+     */
     public TaskManager.JobInfo jobInfoToProto(JobInfo job) {
         TaskManager.JobInfo.Builder builder =  TaskManager.JobInfo.newBuilder();
-        builder.setId(job.getId()).setJobType(job.getJobType()).setState(job.getState()).setStartTime(job.getStartTime().getTime());
+        builder.setId(job.getId());
+        if (job.getJobType() != null) {
+            builder.setJobType(job.getJobType());
+        }
+        if (job.getState() != null) {
+            builder.setState(job.getState());
+        }
+        if (job.getStartTime() != null) {
+            builder.setEndTime(job.getStartTime().getTime());
+        }
         if (job.getEndTime() != null) {
             builder.setEndTime(job.getEndTime().getTime());
         }
-        builder.setParameter(job.getParameter()).setCluster(job.getCluster());
+        if (job.getParameter() != null) {
+            builder.setParameter(job.getParameter());
+        }
+        if (job.getCluster() != null) {
+            builder.setCluster(job.getCluster());
+        }
         if (job.getApplicationId() != null) {
             builder.setApplicationId(job.getApplicationId());
         }

--- a/java/openmldb-taskmanager/src/main/scala/com/_4paradigm/openmldb/taskmanager/JobInfoManager.scala
+++ b/java/openmldb-taskmanager/src/main/scala/com/_4paradigm/openmldb/taskmanager/JobInfoManager.scala
@@ -46,26 +46,6 @@ object JobInfoManager {
   option.setZkPath(TaskManagerConfig.ZK_ROOT_PATH)
   val sqlExecutor = new SqlClusterExecutor(option)
 
-  def createJobSystemTable(): Unit = {
-    // TODO: Check db
-    sqlExecutor.createDB(dbName)
-
-    val createTableSql = s"CREATE TABLE $tableName ( \n" +
-      "                   id int,\n" +
-      "                   job_type string,\n" +
-      "                   state string,\n" +
-      "                   start_time timestamp,\n" +
-      "                   end_time timestamp,\n" +
-      "                   parameter string,\n" +
-      "                   cluster string,\n" +
-      "                   application_id string,\n" +
-      "                   error string,\n" +
-      "                   index(key=id, ttl=1, ttl_type=latest)\n" +
-      "                   )"
-    // TODO: Check table
-    sqlExecutor.executeDDL(dbName, createTableSql)
-  }
-
   def createJobInfo(jobType: String, args: List[String] = List(), sparkConf: Map[String, String] = Map()): JobInfo = {
     val jobId = JobIdGenerator.getUniqueId
     val startTime = new java.sql.Timestamp(Calendar.getInstance.getTime().getTime())

--- a/java/openmldb-taskmanager/src/main/scala/com/_4paradigm/openmldb/taskmanager/spark/SparkJobManager.scala
+++ b/java/openmldb-taskmanager/src/main/scala/com/_4paradigm/openmldb/taskmanager/spark/SparkJobManager.scala
@@ -48,8 +48,6 @@ object SparkJobManager {
         launcher.setMaster("yarn")
           .setDeployMode("cluster")
           .setConf("spark.yarn.maxAppAttempts", "1")
-          // TODO: Set this so that Spark executors will extract jar file and load so for yarn-cluster mode
-          .setConf("spark.openmldb.hybridse.jsdk.path", "sql_jsdk")
       }
       case _ => throw new Exception(s"Unsupported Spark master ${TaskManagerConfig.SPARK_MASTER}")
     }

--- a/java/openmldb-taskmanager/src/test/scala/com/_4paradigm/openmldb/taskmanager/spark/TestSparkJobManager.scala
+++ b/java/openmldb-taskmanager/src/test/scala/com/_4paradigm/openmldb/taskmanager/spark/TestSparkJobManager.scala
@@ -30,8 +30,6 @@ class TestSparkJobManager extends FunSuite {
   }
 
   test("Test submitSparkJob") {
-    JobInfoManager.createJobSystemTable()
-
     val mainClass = classOf[DummySparkApp].getName
     //val mainClass = "com._4paradigm.openmldb.batchjob.SparkVersionApp"
 


### PR DESCRIPTION
* Do not use hybridse library loader, and only use openmldb jsdk library loader to avoid loading conflict libraries
* Add parameter the load custom sql_jsdk library path
* Remove the special flag for yarn-cluster to force-load sql_jsdk library in TaskManager
* Resolve https://github.com/4paradigm/OpenMLDB/issues/1001 .