### PR TITLE
feat: use prepared statement for taskmanager and fix jobinfo null values

### DIFF
--- a/java/openmldb-taskmanager/src/main/java/com/_4paradigm/openmldb/taskmanager/server/impl/TaskManagerImpl.java
+++ b/java/openmldb-taskmanager/src/main/java/com/_4paradigm/openmldb/taskmanager/server/impl/TaskManagerImpl.java
@@ -30,6 +30,12 @@ import java.util.List;
 @Slf4j
 public class TaskManagerImpl implements TaskManagerInterface {
 
+    /**
+     * Covert JobInfo object to protobuf object.
+     *
+     * @param job the object of class JobInfo
+     * @return the protobuf object
+     */
     public TaskManager.JobInfo jobInfoToProto(JobInfo job) {
         TaskManager.JobInfo.Builder builder =  TaskManager.JobInfo.newBuilder();
         builder.setId(job.getId());

--- a/java/openmldb-taskmanager/src/main/java/com/_4paradigm/openmldb/taskmanager/server/impl/TaskManagerImpl.java
+++ b/java/openmldb-taskmanager/src/main/java/com/_4paradigm/openmldb/taskmanager/server/impl/TaskManagerImpl.java
@@ -32,11 +32,25 @@ public class TaskManagerImpl implements TaskManagerInterface {
 
     public TaskManager.JobInfo jobInfoToProto(JobInfo job) {
         TaskManager.JobInfo.Builder builder =  TaskManager.JobInfo.newBuilder();
-        builder.setId(job.getId()).setJobType(job.getJobType()).setState(job.getState()).setStartTime(job.getStartTime().getTime());
+        builder.setId(job.getId());
+        if (job.getJobType() != null) {
+            builder.setJobType(job.getJobType());
+        }
+        if (job.getState() != null) {
+            builder.setState(job.getState());
+        }
+        if (job.getStartTime() != null) {
+            builder.setEndTime(job.getStartTime().getTime());
+        }
         if (job.getEndTime() != null) {
             builder.setEndTime(job.getEndTime().getTime());
         }
-        builder.setParameter(job.getParameter()).setCluster(job.getCluster());
+        if (job.getParameter() != null) {
+            builder.setParameter(job.getParameter());
+        }
+        if (job.getCluster() != null) {
+            builder.setCluster(job.getCluster());
+        }
         if (job.getApplicationId() != null) {
             builder.setApplicationId(job.getApplicationId());
         }

--- a/java/openmldb-taskmanager/src/main/scala/com/_4paradigm/openmldb/taskmanager/JobInfoManager.scala
+++ b/java/openmldb-taskmanager/src/main/scala/com/_4paradigm/openmldb/taskmanager/JobInfoManager.scala
@@ -46,26 +46,6 @@ object JobInfoManager {
   option.setZkPath(TaskManagerConfig.ZK_ROOT_PATH)
   val sqlExecutor = new SqlClusterExecutor(option)
 
-  def createJobSystemTable(): Unit = {
-    // TODO: Check db
-    sqlExecutor.createDB(dbName)
-
-    val createTableSql = s"CREATE TABLE $tableName ( \n" +
-      "                   id int,\n" +
-      "                   job_type string,\n" +
-      "                   state string,\n" +
-      "                   start_time timestamp,\n" +
-      "                   end_time timestamp,\n" +
-      "                   parameter string,\n" +
-      "                   cluster string,\n" +
-      "                   application_id string,\n" +
-      "                   error string,\n" +
-      "                   index(key=id, ttl=1, ttl_type=latest)\n" +
-      "                   )"
-    // TODO: Check table
-    sqlExecutor.executeDDL(dbName, createTableSql)
-  }
-
   def createJobInfo(jobType: String, args: List[String] = List(), sparkConf: Map[String, String] = Map()): JobInfo = {
     val jobId = JobIdGenerator.getUniqueId
     val startTime = new java.sql.Timestamp(Calendar.getInstance.getTime().getTime())

--- a/java/openmldb-taskmanager/src/test/scala/com/_4paradigm/openmldb/taskmanager/spark/TestSparkJobManager.scala
+++ b/java/openmldb-taskmanager/src/test/scala/com/_4paradigm/openmldb/taskmanager/spark/TestSparkJobManager.scala
@@ -30,8 +30,6 @@ class TestSparkJobManager extends FunSuite {
   }
 
   test("Test submitSparkJob") {
-    JobInfoManager.createJobSystemTable()
-
     val mainClass = classOf[DummySparkApp].getName
     //val mainClass = "com._4paradigm.openmldb.batchjob.SparkVersionApp"
 


### PR DESCRIPTION
* Use prepared statement to avoid sql injection and support double quoted string.
* Fix null pointer exception when converting protobuf job info message.
* Remove useless function to create job info table in TaskManager.
* Resolve https://github.com/4paradigm/OpenMLDB/issues/975 .