### PR TITLE
fix: fix load library for multiple times in sql cluster executor

### DIFF
--- a/java/hybridse-sdk/src/test/java/com/_4paradigm/hybridse/sdk/SqlEngineTest.java
+++ b/java/hybridse-sdk/src/test/java/com/_4paradigm/hybridse/sdk/SqlEngineTest.java
@@ -333,7 +333,6 @@ public class SqlEngineTest {
             Assert.assertNull(engine.getPlan());
             Assert.fail("Expect getPlan fail");
         } catch (UnsupportedHybridSeException e) {
-            e.printStackTrace();
             Assert.assertTrue(e.getMessage().contains(errorMsg));
         }
     }

--- a/java/openmldb-jdbc/src/main/java/com/_4paradigm/openmldb/common/LibraryLoader.java
+++ b/java/openmldb-jdbc/src/main/java/com/_4paradigm/openmldb/common/LibraryLoader.java
@@ -41,7 +41,7 @@ public class LibraryLoader {
                 logger.info("Successfully load library {}", libraryPath);
                 return;
             } catch (Throwable t) {
-                logger.debug(String.format("Failed to load %s", libraryPath), t);
+                logger.debug(String.format("Failed to load %s", libraryPath));
             }
         }
         if (!isPath) {
@@ -61,7 +61,7 @@ public class LibraryLoader {
             logger.info("Successfully load library from {}", libraryPath);
             return;
         } catch (Throwable t) {
-            logger.debug(String.format("Failed to load from %s", libraryPath), t);
+            logger.debug(String.format("Failed to load from %s", libraryPath));
         }
 
         // load from resource

--- a/java/openmldb-jdbc/src/main/java/com/_4paradigm/openmldb/sdk/impl/SqlClusterExecutor.java
+++ b/java/openmldb-jdbc/src/main/java/com/_4paradigm/openmldb/sdk/impl/SqlClusterExecutor.java
@@ -50,11 +50,12 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class SqlClusterExecutor implements SqlExecutor {
     private static final Logger logger = LoggerFactory.getLogger(SqlClusterExecutor.class);
 
-    private static boolean initialized = false;
+    private static final AtomicBoolean initialized = new AtomicBoolean(false);;
     private SQLRouter sqlRouter;
 
     public SqlClusterExecutor(SdkOption option, String libraryPath) throws SqlException {
@@ -78,14 +79,13 @@ public class SqlClusterExecutor implements SqlExecutor {
     }
 
     synchronized public static void initJavaSdkLibrary(String libraryPath) {
-        if (!initialized) {
+        if (!initialized.get()) {
             if (libraryPath == null || libraryPath.isEmpty()) {
                 LibraryLoader.loadLibrary("sql_jsdk");
             } else {
                 LibraryLoader.loadLibrary(libraryPath);
             }
-            LibraryLoader.loadLibrary(libraryPath);
-            initialized = true;
+            initialized.set(true);
         }
     }
 


### PR DESCRIPTION
* Fix the bug of loading library for multiple times.
* Remove the log of expected stacktrace.