### PR TITLE
feat: refresh catalog when dropping table and add refresh table api

### DIFF
--- a/java/openmldb-taskmanager/src/main/resources/taskmanager.properties
+++ b/java/openmldb-taskmanager/src/main/resources/taskmanager.properties
@@ -3,7 +3,7 @@ server.host=127.0.0.1
 server.port=9902
 server.worker_threads=4
 server.io_threads=4
-prefetch.jobid.num=10
+prefetch.jobid.num=1
 
 # OpenMLDB Config
 zookeeper.cluster=127.0.0.1:2181

--- a/java/openmldb-taskmanager/src/main/scala/com/_4paradigm/openmldb/taskmanager/JobInfoManager.scala
+++ b/java/openmldb-taskmanager/src/main/scala/com/_4paradigm/openmldb/taskmanager/JobInfoManager.scala
@@ -194,6 +194,8 @@ object JobInfoManager {
   def dropOfflineTable(db: String, table: String): Unit = {
     val tableInfo = sqlExecutor.getTableInfo(db, table)
 
+    // Refresh catalog to get the latest table info
+    sqlExecutor.refreshCatalog()
     if (tableInfo.hasOfflineTableInfo) {
       val offlineTableInfo = tableInfo.getOfflineTableInfo
 

--- a/src/sdk/db_sdk.cc
+++ b/src/sdk/db_sdk.cc
@@ -91,6 +91,11 @@ void ClusterSDK::WatchNotify() {
     zk_client_->WatchItem(notify_path_, [this] { Refresh(); });
 }
 
+bool ClusterSDK::TriggerNotify() const {
+    LOG(INFO) << "Trigger table notify node";
+    return zk_client_->Increment(notify_path_);
+}
+
 bool ClusterSDK::GetNsAddress(std::string* endpoint, std::string* real_endpoint) {
     std::string ns_node = options_.zk_path + "/leader";
     std::vector<std::string> children;

--- a/src/sdk/db_sdk.h
+++ b/src/sdk/db_sdk.h
@@ -118,6 +118,7 @@ class DBSDK {
     std::shared_ptr<hybridse::sdk::ProcedureInfo> GetProcedureInfo(const std::string& db, const std::string& sp_name,
                                                                    std::string* msg);
     std::vector<std::shared_ptr<hybridse::sdk::ProcedureInfo>> GetProcedureInfo(std::string* msg);
+    virtual bool TriggerNotify() const = 0;
 
  protected:
     virtual bool GetNsAddress(std::string* endpoint, std::string* real_endpoint) = 0;
@@ -151,6 +152,7 @@ class ClusterSDK : public DBSDK {
     ~ClusterSDK() override;
     bool Init() override;
     bool IsClusterMode() const override { return true; }
+    bool TriggerNotify() const override;
 
  protected:
     bool BuildCatalog() override;
@@ -182,6 +184,8 @@ class StandAloneSDK : public DBSDK {
     bool Init() override;
 
     bool IsClusterMode() const override { return false; }
+
+    bool TriggerNotify() const override { return false; }
 
  protected:
     // Before connecting to ns, we only have the host&port

--- a/src/sdk/sql_cluster_router.cc
+++ b/src/sdk/sql_cluster_router.cc
@@ -686,16 +686,25 @@ bool SQLClusterRouter::DropTable(const std::string& db, const std::string& table
         return false;
     }
 
+    // RefreshCatalog to avoid getting out-of-date table info
+    if (!RefreshCatalog()) {
+        status->msg = "Fail to refresh catalog";
+        status->code = -1;
+        LOG(WARNING) << status->msg;
+        return false;
+    }
+
     auto tableInfo = GetTableInfo(db, table);
     // Check offline table info first
     if (tableInfo.has_offline_table_info()) {
         auto taskmanager_client_ptr = cluster_sdk_->GetTaskManagerClient();
         if (!taskmanager_client_ptr) {
             status->msg = "no TaskManager exist";
-            status->code = -2;
+            status->code = -1;
             LOG(WARNING) << status->msg;
             return false;
         }
+
         ::openmldb::base::Status rpcStatus = taskmanager_client_ptr->DropOfflineTable(db, table);
         if (rpcStatus.code != 0) {
             status->msg = rpcStatus.msg;
@@ -1688,6 +1697,10 @@ bool SQLClusterRouter::UpdateOfflineTableInfo(const ::openmldb::nameserver::Tabl
         return {-1, "Fail to get TaskManager client"};
     }
     return taskmanager_client_ptr->ImportOfflineData(sql, config, default_db, job_info);
+}
+
+bool SQLClusterRouter::NotifyTableChange() {
+    return cluster_sdk_->TriggerNotify();
 }
 
 }  // namespace sdk

--- a/src/sdk/sql_cluster_router.h
+++ b/src/sdk/sql_cluster_router.h
@@ -244,6 +244,8 @@ class SQLClusterRouter : public SQLRouter {
                                                const std::string& default_db,
                                                ::openmldb::taskmanager::JobInfo& job_info) override;
 
+    bool NotifyTableChange() override;
+
  private:
     void GetTables(::hybridse::vm::PhysicalOpNode* node, std::set<std::string>* tables);
 

--- a/src/sdk/sql_router.h
+++ b/src/sdk/sql_router.h
@@ -178,6 +178,8 @@ class SQLRouter {
                                                        const std::map<std::string, std::string>& config,
                                                        const std::string& default_db,
                                                        ::openmldb::taskmanager::JobInfo& job_info) = 0;
+
+    virtual bool NotifyTableChange() = 0;
 };
 
 std::shared_ptr<SQLRouter> NewClusterSQLRouter(const SQLRouterOptions& options);


### PR DESCRIPTION
* Call `refreshCatalog` in cli and taskmanager to get latest table info when dropping tables.
* Add `NotifyTableChange` in sdk.
* Resolve https://github.com/4paradigm/OpenMLDB/issues/1011 .