### PR TITLE
fix: fix incorrect job type of select into job

### DIFF
--- a/src/sdk/sql_cluster_router.cc
+++ b/src/sdk/sql_cluster_router.cc
@@ -1696,7 +1696,7 @@ bool SQLClusterRouter::UpdateOfflineTableInfo(const ::openmldb::nameserver::Tabl
     if (!taskmanager_client_ptr) {
         return {-1, "Fail to get TaskManager client"};
     }
-    return taskmanager_client_ptr->ImportOfflineData(sql, config, default_db, job_info);
+    return taskmanager_client_ptr->ExportOfflineData(sql, config, default_db, job_info);
 }
 
 bool SQLClusterRouter::NotifyTableChange() {


### PR DESCRIPTION
* The job type of offline `select into` is incorrect and we should fix by invoking the correct api.