### PR TITLE
feat: refresh catalog before getting table info in taskmanager

### DIFF
--- a/java/openmldb-taskmanager/src/main/scala/com/_4paradigm/openmldb/taskmanager/JobInfoManager.scala
+++ b/java/openmldb-taskmanager/src/main/scala/com/_4paradigm/openmldb/taskmanager/JobInfoManager.scala
@@ -193,10 +193,10 @@ object JobInfoManager {
   }
 
   def dropOfflineTable(db: String, table: String): Unit = {
-    val tableInfo = sqlExecutor.getTableInfo(db, table)
-
     // Refresh catalog to get the latest table info
     sqlExecutor.refreshCatalog()
+    val tableInfo = sqlExecutor.getTableInfo(db, table)
+
     if (tableInfo.hasOfflineTableInfo) {
       val offlineTableInfo = tableInfo.getOfflineTableInfo
 


### PR DESCRIPTION
* Refresh catalog before getting table info when dropping tables.
* Resolve https://github.com/4paradigm/OpenMLDB/issues/1070 .