### PR TITLE
fix: transform test column resolve fail test

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -221,6 +221,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
+      - name: Cache thirdparty
+        uses: actions/cache@v2
+        with:
+          path: |
+            .deps/
+            thirdsrc
+          key: ${{ runner.os }}-thirdparty-${{ hashFiles('third-party/**/CMakeLists.txt', 'third-party/**/*.cmake', 'third-party/**/*.sh') }}
+
       - uses: actions/setup-java@v2
         with:
           distribution: 'adopt'

--- a/.github/workflows/hybridse-ci.yml
+++ b/.github/workflows/hybridse-ci.yml
@@ -58,6 +58,14 @@ jobs:
         run: |
           brew install coreutils
 
+      - name: Cache thirdparty
+        uses: actions/cache@v2
+        with:
+          path: |
+            .deps/
+            thirdsrc
+          key: ${{ runner.os }}-thirdparty-${{ hashFiles('third-party/**/CMakeLists.txt', 'third-party/**/*.cmake', 'third-party/**/*.sh') }}
+
       - name: Build Core
         run: |
           make hybridse-build

--- a/hybridse/src/vm/transform_test.cc
+++ b/hybridse/src/vm/transform_test.cc
@@ -575,40 +575,35 @@ TEST_F(TransformTest, PhysicalColumnResolveFailTest) {
 
     PhysicalPlanFailCheck(
         catalog,
-        "select * from\n"
-        "      (\n"
-        "      SELECT\n"
-        "      col1 as id,\n"
-        "      col1 as id,\n"
-        "      sum(col2) OVER w1 as w1_col2_sum,\n"
-        "      FROM t1 WINDOW\n"
-        "      w1 AS (PARTITION BY col1 ORDER BY col5 ROWS BETWEEN 10 OPEN PRECEDING AND CURRENT ROW)\n"
-        "      ) as out0 LAST JOIN\n"
-        "      (\n"
-        "      SELECT\n"
-        "      col1 as id,\n"
-        "      sum(col2) OVER w2 as w2_col2_sum FROM t1 WINDOW\n"
-        "      w2 AS (PARTITION BY col1 ORDER BY col5 ROWS_RANGE BETWEEN 1d OPEN PRECEDING AND CURRENT ROW)\n"
-        "      ) as out1 ON out0.id = out1.id;",
-        kRequestMode, common::kOk,
-        "ok");
+        R"sql(select * from
+              (
+                SELECT col1 as id, col1 as id, sum(col2) OVER w1 as w1_col2_sum,
+                FROM t1
+                WINDOW w1 AS (PARTITION BY col1 ORDER BY col5 ROWS BETWEEN 10 OPEN PRECEDING AND CURRENT ROW)
+              ) as out0
+              LAST JOIN
+              (
+                SELECT col1 as id, sum(col2) OVER w2 as w2_col2_sum
+                FROM t1
+                WINDOW w2 AS (PARTITION BY col1 ORDER BY col5 ROWS_RANGE BETWEEN 1d OPEN PRECEDING AND CURRENT ROW)
+              ) as out1
+              ON out0.id = out1.id;)sql",
+        kBatchMode, common::kOk, "ok");
+
     PhysicalPlanFailCheck(
         catalog,
-        "select * from\n"
-        "      (\n"
-        "      SELECT\n"
-        "      col1 as id,\n"
-        "      col2 as id,\n"
-        "      sum(col2) OVER w1 as w1_col2_sum,\n"
-        "      FROM t1 WINDOW\n"
-        "      w1 AS (PARTITION BY col1 ORDER BY col5 ROWS BETWEEN 10 OPEN PRECEDING AND CURRENT ROW)\n"
-        "      ) as out0 LAST JOIN\n"
-        "      (\n"
-        "      SELECT\n"
-        "      col1 as id,\n"
-        "      sum(col2) OVER w2 as w2_col2_sum FROM t1 WINDOW\n"
-        "      w2 AS (PARTITION BY col1 ORDER BY col5 ROWS_RANGE BETWEEN 1d OPEN PRECEDING AND CURRENT ROW)\n"
-        "      ) as out1 ON out0.id = out1.id;",
+        R"sql(select * from
+              (
+                SELECT col1 as id, col2 as id, sum(col2) OVER w1 as w1_col2_sum,
+                FROM t1
+                WINDOW w1 AS (PARTITION BY col1 ORDER BY col5 ROWS BETWEEN 10 OPEN PRECEDING AND CURRENT ROW)
+              ) as out0
+              LAST JOIN
+              (
+                SELECT col1 as id, sum(col2) OVER w2 as w2_col2_sum
+                FROM t1
+                WINDOW w2 AS (PARTITION BY col1 ORDER BY col5 ROWS_RANGE BETWEEN 1d OPEN PRECEDING AND CURRENT ROW)
+              ) as out1 ON out0.id = out1.id;)sql",
         kRequestMode, common::kColumnAmbiguous,
         "Ambiguous column name .out0.id");
 }

--- a/hybridse/src/vm/transform_test.cc
+++ b/hybridse/src/vm/transform_test.cc
@@ -604,7 +604,7 @@ TEST_F(TransformTest, PhysicalColumnResolveFailTest) {
                 FROM t1
                 WINDOW w2 AS (PARTITION BY col1 ORDER BY col5 ROWS_RANGE BETWEEN 1d OPEN PRECEDING AND CURRENT ROW)
               ) as out1 ON out0.id = out1.id;)sql",
-        kRequestMode, common::kColumnAmbiguous,
+        kBatchMode, common::kColumnAmbiguous,
         "Ambiguous column name .out0.id");
 }
 


### PR DESCRIPTION
two major changes:

- fix `transform_test` 
- add a cache step for macos job, that cache thirdparty components
