### PR TITLE
feat: download openmldb spark distribution in java cicd

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -116,6 +116,7 @@ jobs:
       SQL_JAVASDK_ENABLE: ON
       OPENMLDB_BUILD_TARGET: 'cp_native_so openmldb'
       MAVEN_OPTS: -Duser.home=/github/home
+      SPARK_HOME: /tmp/spark/
     steps:
       - uses: actions/checkout@v2
 
@@ -166,6 +167,7 @@ jobs:
       - name: start services
         run: |
           sh steps/ut_zookeeper.sh start
+          sh steps/download_openmldb_spark.sh $SPARK_HOME
           cd onebox && sh start_onebox.sh && cd - || exit
 
       - name: run java modules smoke test

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,6 +24,7 @@ jobs:
       SQL_JAVASDK_ENABLE: ON
       TESTING_ENABLE: ON
       NPROC: 8
+      SPARK_HOME: /tmp/spark/
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -48,6 +48,7 @@ jobs:
       - name: start service
         run: |
           sh steps/ut_zookeeper.sh start
+          sh steps/download_openmldb_spark.sh $SPARK_HOME
           cd onebox
           bash start_onebox.sh
 

--- a/steps/download_openmldb_spark.sh
+++ b/steps/download_openmldb_spark.sh
@@ -5,10 +5,10 @@ set -xe
 SPARK_HOME_PATH=$1
 
 # Download OpenMLDB Spark distribution
-wget https://github.com/4paradigm/spark/releases/download/v3.0.0-openmldb0.4.0/spark-3.0.0-bin-openmldbspark.tgz
+curl https://github.com/4paradigm/spark/releases/download/v3.0.0-openmldb0.4.0/spark-3.0.0-bin-openmldbspark.tgz > spark-3.0.0-bin-openmldbspark.tgz
 tar xzf ./spark-3.0.0-bin-openmldbspark.tgz
 
 # Move Spark files to $SPARK_HOME
-mv ./spark-3.0.0-bin-openmldbspark/ $SPARK_HOME_PATH
+mv ./spark-3.0.0-bin-openmldbspark/ "$SPARK_HOME_PATH"
 
 rm ./spark-3.0.0-bin-openmldbspark.tgz

--- a/steps/download_openmldb_spark.sh
+++ b/steps/download_openmldb_spark.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -xe
+
+SPARK_HOME_PATH=$1
+
+# Download OpenMLDB Spark distribution
+wget https://github.com/4paradigm/spark/releases/download/v3.0.0-openmldb0.4.0/spark-3.0.0-bin-openmldbspark.tgz
+tar xzf ./spark-3.0.0-bin-openmldbspark.tgz
+
+# Move Spark files to $SPARK_HOME
+mv ./spark-3.0.0-bin-openmldbspark/ $SPARK_HOME_PATH
+
+rm ./spark-3.0.0-bin-openmldbspark.tgz

--- a/steps/download_openmldb_spark.sh
+++ b/steps/download_openmldb_spark.sh
@@ -5,7 +5,7 @@ set -xe
 SPARK_HOME_PATH=$1
 
 # Download OpenMLDB Spark distribution
-curl https://github.com/4paradigm/spark/releases/download/v3.0.0-openmldb0.4.0/spark-3.0.0-bin-openmldbspark.tgz > spark-3.0.0-bin-openmldbspark.tgz
+curl -L -o spark-3.0.0-bin-openmldbspark.tgz https://github.com/4paradigm/spark/releases/download/v3.0.0-openmldb0.4.0/spark-3.0.0-bin-openmldbspark.tgz
 tar xzf ./spark-3.0.0-bin-openmldbspark.tgz
 
 # Move Spark files to $SPARK_HOME


### PR DESCRIPTION
* Add script to download openmldb spark distribution
* Download and extract spark files in cicd of java

This is useful for unit tests of TaskManager which requires TaskManager with Spark to run test cases.