### PR TITLE
feat: change testing framework of Python SDK and add new unittest for sqlalchemy API

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -339,7 +339,7 @@ jobs:
 
       - name: prepare python deps
         run: |
-          python3 -m easy_install nose pip
+          python3 -m easy_install pytest pip
           pip install setuptools wheel twine
           yum install -y net-tools
 
@@ -353,7 +353,7 @@ jobs:
         with:
           name: linux-ut-result-python-${{ github.sha }}
           path: |
-            python/test/nosetests.xml
+            python/test/pytest.xml
 
       - name: upload to pypi
         if: >

--- a/python/test/openmldb_client_test.py
+++ b/python/test/openmldb_client_test.py
@@ -315,7 +315,7 @@ class TestOpenMLDBClient(unittest.TestCase):
       ]
     self.check_result(rs, expectRows)
 
-# test sqlalchemy Table-object-based API of pytest style
+# test sqlalchemy Table-object-based API in pytest style
 class TestSqlalchemyAPI:
 
     def setup_module(self):

--- a/python/test/openmldb_client_test.py
+++ b/python/test/openmldb_client_test.py
@@ -330,7 +330,7 @@ class TestSqlalchemyAPI:
         self.metadata.create_all(self.engine)
         
     def test_create_table(self):
-        assert self.connection.dialect.has_table('test_table')
+        assert self.connection.dialect.has_table(self.connection,'test_table')
 
     def test_insert(self):
         try:

--- a/python/test/openmldb_client_test.py
+++ b/python/test/openmldb_client_test.py
@@ -341,10 +341,8 @@ class TestSqlalchemyAPI:
 
     def test_select(self):
           for row in self.connection.execute(select([self.test_table])):
-             if 'first' in list(row):
-                assert 100 in list(row)
-            else:
-                assert False
+             assert 'first' in list(row)
+             assert 100 in list(row)
 
     def teardown_class(self):
         self.connection.execute(self.test_table.delete())

--- a/python/test/openmldb_client_test.py
+++ b/python/test/openmldb_client_test.py
@@ -350,10 +350,10 @@ class TestSqlalchemyAPI:
     def test_select(self):
         try:
             for row in self.connection.execute(select([self.test_table])):
-                if 'first' not in row:
+                if 'first' not in list(row):
                     logging.warning("Insert failed, 'first' not in the row")
                     assert False
-                elif 100 not in row:
+                elif 100 not in list(row):
                     logging.warning("Insert failed, 100 not in the row")
                     assert False
         except Exception as e:

--- a/python/test/openmldb_client_test.py
+++ b/python/test/openmldb_client_test.py
@@ -345,7 +345,7 @@ class TestSqlalchemyAPI:
              assert 100 in list(row)
 
     def teardown_class(self):
-        self.connection.execute(self.test_table.delete())
+        self.connection.execute("drop table test_table;")
         self.connection.close()
 
 

--- a/python/test/openmldb_client_test.py
+++ b/python/test/openmldb_client_test.py
@@ -320,7 +320,7 @@ class TestOpenMLDBClient(unittest.TestCase):
 # test sqlalchemy Table-object-based API in pytest style
 class TestSqlalchemyAPI:
 
-    def setup_module(self):
+    def setup_class(self):
         self.engine = db.create_engine('openmldb:///db_test?zk=127.0.0.1:6181&zkPath=/onebox')
         self.connection = self.engine.connect()
 
@@ -361,7 +361,7 @@ class TestSqlalchemyAPI:
         except Exception as e:
             pass
 
-    def teardown_module(self):
+    def teardown_class(self):
         self.connection.close()
 
 

--- a/python/test/openmldb_client_test.py
+++ b/python/test/openmldb_client_test.py
@@ -323,16 +323,10 @@ class TestSqlalchemyAPI:
     def setup_class(self):
         self.engine = db.create_engine('openmldb:///db_test?zk=127.0.0.1:6181&zkPath=/onebox')
         self.connection = self.engine.connect()
-
-    def test_create_table_object(self):
-        try:
-            self.metadata = MetaData()
-            self.test_table = Table('test_table', self.metadata,
-                                            Column('x', String),
-                                            Column('y', Integer))
-        except Exception as e:
-            logging.warning("error occured {}".format(e))
-            assert False
+        self.metadata = MetaData()
+        self.test_table = Table('test_table', self.metadata,
+                                          Column('x', String),
+                                          Column('y', Integer))
 
     def test_create_table(self):
         try:

--- a/python/test/openmldb_client_test.py
+++ b/python/test/openmldb_client_test.py
@@ -315,7 +315,7 @@ class TestOpenMLDBClient(unittest.TestCase):
       ]
     self.check_result(rs, expectRows)
 
-# test sqlalchemy Table-object-based API
+# test sqlalchemy Table-object-based API of pytest style
 class TestSqlalchemyAPI:
 
     def setup_module(self):

--- a/python/test/openmldb_client_test.py
+++ b/python/test/openmldb_client_test.py
@@ -21,6 +21,8 @@ from datetime import date
 from datetime import datetime
 
 import sqlalchemy as db
+from sqlalchemy import Table, Column, Integer, String, MetaData
+from sqlalchemy.sql import select
 
 logging.basicConfig(level=logging.WARNING)
 class TestOpenMLDBClient(unittest.TestCase):

--- a/python/test/openmldb_client_test.py
+++ b/python/test/openmldb_client_test.py
@@ -330,7 +330,7 @@ class TestSqlalchemyAPI:
         self.metadata.create_all(self.engine)
         
     def test_create_table(self):
-        assert self.connection.dialect.has_table('test_table'):
+        assert self.connection.dialect.has_table('test_table')
 
     def test_insert(self):
         try:

--- a/python/test/openmldb_client_test.py
+++ b/python/test/openmldb_client_test.py
@@ -327,35 +327,27 @@ class TestSqlalchemyAPI:
         self.test_table = Table('test_table', self.metadata,
                                           Column('x', String),
                                           Column('y', Integer))
-
+        self.metadata.create_all(self.engine)
+        
     def test_create_table(self):
-        try:
-            self.metadata.create_all(self.engine)
-            if not self.connection.dialect.has_table('test_table'):
-                assert False
-        except Exception as e:
-            pass
+        assert self.connection.dialect.has_table('test_table'):
 
     def test_insert(self):
         try:
             self.connection.execute(self.test_table.insert().values(x='first', y=100))
         except Exception as e:
-            logging.warning("error occured {}".format(e))
+            # insert failed
             assert False
 
     def test_select(self):
-        try:
-            for row in self.connection.execute(select([self.test_table])):
-                if 'first' not in list(row):
-                    logging.warning("Insert failed, 'first' not in the row")
-                    assert False
-                elif 100 not in list(row):
-                    logging.warning("Insert failed, 100 not in the row")
-                    assert False
-        except Exception as e:
-            pass
+          for row in self.connection.execute(select([self.test_table])):
+             if 'first' in list(row):
+                assert 100 in list(row)
+            else:
+                assert False
 
     def teardown_class(self):
+        self.connection.execute(self.test_table.delete())
         self.connection.close()
 
 

--- a/steps/test_python.sh
+++ b/steps/test_python.sh
@@ -42,6 +42,6 @@ python3 -m pip install "${whl_name}" -i https://pypi.tuna.tsinghua.edu.cn/simple
 
 # needs: easy_install nose (sqlalchemy is openmldb required)
 cd "${ROOT_DIR}"/python/test
-nosetests --with-xunit
+pytest --junit-xml=pytest.xml
 cd "${ROOT_DIR}"/onebox && sh stop_all.sh && cd "$ROOT_DIR"
 cd "$THIRDSRC/zookeeper-3.4.14" && ./bin/zkServer.sh stop && cd "$ROOT_DIR"


### PR DESCRIPTION
1. Change the original `nose` test framework to `pytest` framework for its convenient in both coding and implementing.
2. Add new UT for sqlalchemy table-object-based api in pytest style. the `openmldb_client_test.py` will be further rewritten into pytest style in a new PR.