### PR TITLE
feat: fix git plugin and return version of openmldb-batch

### DIFF
--- a/java/openmldb-batch/pom.xml
+++ b/java/openmldb-batch/pom.xml
@@ -438,6 +438,22 @@
 			<plugin>
 				<groupId>pl.project13.maven</groupId>
 				<artifactId>git-commit-id-plugin</artifactId>
+				<version>2.2.4</version>
+				<executions>
+					<execution>
+						<id>get-the-git-infos</id>
+						<goals>
+							<goal>revision</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<generateGitPropertiesFilename>${project.build.outputDirectory}/openmldb_git.properties</generateGitPropertiesFilename>
+					<injectAllReactorProjects>true</injectAllReactorProjects>
+					<dateFormat>yyyy.MM.dd HH:mm:ss</dateFormat>
+					<verbose>true</verbose>
+					<generateGitPropertiesFile>true</generateGitPropertiesFile>
+				</configuration>
 			</plugin>
 
 			<!-- Generate report for spotbugs -->

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/api/OpenmldbSession.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/api/OpenmldbSession.scala
@@ -18,9 +18,8 @@ package com._4paradigm.openmldb.batch.api
 
 import com._4paradigm.openmldb.batch.catalog.OpenmldbCatalogService
 import com._4paradigm.openmldb.batch.{OpenmldbBatchConfig, SparkPlanner}
-import com._4paradigm.openmldb.sdk.impl.SqlClusterExecutor
 import org.apache.commons.io.IOUtils
-import org.apache.spark.SparkConf
+import org.apache.spark.{SPARK_VERSION, SparkConf}
 import org.apache.spark.sql.catalyst.QueryPlanningTracker
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
@@ -196,10 +195,9 @@ class OpenmldbSession {
     val stream = this.getClass.getClassLoader.getResourceAsStream("openmldb_git.properties")
     if (stream == null) {
       logger.error("OpenMLDB git properties is missing")
-      s"${sparkSession.version}"
+      SPARK_VERSION
     } else {
-      val gitInfo = IOUtils.toString(stream, "UTF-8")
-      s"${sparkSession.version}\n$gitInfo"
+      s"$SPARK_VERSION\n${IOUtils.toString(stream, "UTF-8")}"
     }
   }
 


### PR DESCRIPTION
* Fix to get the right version from git plugin.
* Do not call `spark.version()` to avoid StackOverflow.

Here is the version from `OpenmldbSession.version()`.

```
3.0.0
#Generated by Git-Commit-Id-Plugin
#Thu Jan 27 14:45:32 CST 2022
git.branch=main
git.build.host=mbp16.local
git.build.time=2022.01.27 14\:45\:32
git.build.user.email=tobeg3oogle@gmail.com
git.build.user.name=tobe
git.build.version=0.5.0-SNAPSHOT
git.closest.tag.commit.count=623
git.closest.tag.name=v0.3.0
git.commit.id=632bbd41681229841ea0e32e8313906b90187c61
git.commit.id.abbrev=632bbd4
git.commit.id.describe=v0.3.0-623-g632bbd4-dirty
git.commit.id.describe-short=v0.3.0-623-dirty
git.commit.message.full=Merge pull request \#1132 from tobegit3hub/feat/simplfy_python_in_cmake\n\nfeat\: merge the similar commands to package python in macos and linux
git.commit.message.short=Merge pull request \#1132 from tobegit3hub/feat/simplfy_python_in_cmake
git.commit.time=2022.01.21 16\:29\:43
git.commit.user.email=tobeg3oogle@gmail.com
git.commit.user.name=tobe
git.dirty=true
git.remote.origin.url=git@github.com\:tobegit3hub/OpenMLDB.git
git.tags=
```