### PR TITLE
fix: quit/exit ignore case

### DIFF
--- a/src/cmd/sql_cmd.h
+++ b/src/cmd/sql_cmd.h
@@ -27,10 +27,12 @@
 #include <vector>
 
 #include "../../hybridse/include/node/node_enum.h"
+#include "absl/strings/match.h"
 #include "base/ddl_parser.h"
 #include "base/file_util.h"
 #include "base/linenoise.h"
 #include "base/texttable.h"
+#include "boost/regex.hpp"
 #include "client/taskmanager_client.h"
 #include "cmd/display.h"
 #include "cmd/file_option_parser.h"
@@ -46,8 +48,6 @@
 #include "sdk/node_adapter.h"
 #include "sdk/sql_cluster_router.h"
 #include "version.h"  // NOLINT
-#include "boost/regex.hpp"
-
 DEFINE_string(database, "", "Set database");
 DECLARE_string(zk_cluster);
 DECLARE_string(zk_root_path);
@@ -357,7 +357,7 @@ void PrintProcedureInfo(const hybridse::sdk::ProcedureInfo& sp_info) {
         std::string pattern_blank = "(.*)(\\(.*\\) )(BEGIN )(.*)( END;)";
         sql = boost::regex_replace(sql, boost::regex(pattern_blank), "$1$4");
     }
-    
+
     PrintItemTable(std::cout, {"DB", type_name}, {vec});
     std::vector<std::string> items{sql};
     PrintItemTable(std::cout, {"SQL"}, {items}, true);
@@ -1436,9 +1436,12 @@ void Shell() {
             }
         }
         sql.append(buffer);
-        if (sql == "quit;" || sql == "exit;" || sql == "quit" || sql == "exit") {
-            std::cout << "Bye" << std::endl;
-            return;
+        if (sql.length() == 4 || sql.length() == 5) {
+            if (absl::EqualsIgnoreCase(sql, "quit;") || absl::EqualsIgnoreCase(sql, "exit;") ||
+                absl::EqualsIgnoreCase(sql, "quit") || absl::EqualsIgnoreCase(sql, "exit")) {
+                std::cout << "Bye" << std::endl;
+                return;
+            }
         }
         if (sql.back() == ';') {
             HandleSQL(sql);


### PR DESCRIPTION
In sql client or standalone client, `quit`/`exit` should ignore case.