### PR TITLE
feat: add `lower()` and `lcase()`

### DIFF
--- a/hybridse/src/codegen/udf_ir_builder_test.cc
+++ b/hybridse/src/codegen/udf_ir_builder_test.cc
@@ -623,6 +623,16 @@ TEST_F(UdfIRBuilderTest, upper_ucase) {
     CheckUdf<Nullable<StringRef>, Nullable<StringRef>>("upper", nullptr, nullptr);
 }
 
+TEST_F(UdfIRBuilderTest, lower_lcase) {
+    CheckUdf<Nullable<StringRef>, Nullable<StringRef>>("lower", StringRef("sql"), StringRef("SQl"));
+    CheckUdf<Nullable<StringRef>, Nullable<StringRef>>("lcase", StringRef("sql"), StringRef("SQl"));
+    CheckUdf<Nullable<StringRef>, Nullable<StringRef>>("lcase", StringRef("!abc?"), StringRef("!Abc?"));
+    CheckUdf<Nullable<StringRef>, Nullable<StringRef>>("lcase", StringRef(""), StringRef(""));
+    CheckUdf<Nullable<StringRef>, Nullable<StringRef>>("lpper", StringRef(""), StringRef(""));
+    CheckUdf<Nullable<StringRef>, Nullable<StringRef>>("lcase", nullptr, nullptr);
+    CheckUdf<Nullable<StringRef>, Nullable<StringRef>>("lpper", nullptr, nullptr);
+}
+
 TEST_F(UdfIRBuilderTest, concat_str_udf_test) {
     //    concat("12345") == "12345"
     CheckUdf<StringRef, StringRef>("concat", StringRef("12345"),

--- a/hybridse/src/codegen/udf_ir_builder_test.cc
+++ b/hybridse/src/codegen/udf_ir_builder_test.cc
@@ -628,9 +628,9 @@ TEST_F(UdfIRBuilderTest, lower_lcase) {
     CheckUdf<Nullable<StringRef>, Nullable<StringRef>>("lcase", StringRef("sql"), StringRef("SQl"));
     CheckUdf<Nullable<StringRef>, Nullable<StringRef>>("lcase", StringRef("!abc?"), StringRef("!Abc?"));
     CheckUdf<Nullable<StringRef>, Nullable<StringRef>>("lcase", StringRef(""), StringRef(""));
-    CheckUdf<Nullable<StringRef>, Nullable<StringRef>>("lpper", StringRef(""), StringRef(""));
+    CheckUdf<Nullable<StringRef>, Nullable<StringRef>>("lower", StringRef(""), StringRef(""));
     CheckUdf<Nullable<StringRef>, Nullable<StringRef>>("lcase", nullptr, nullptr);
-    CheckUdf<Nullable<StringRef>, Nullable<StringRef>>("lpper", nullptr, nullptr);
+    CheckUdf<Nullable<StringRef>, Nullable<StringRef>>("lower", nullptr, nullptr);
 }
 
 TEST_F(UdfIRBuilderTest, concat_str_udf_test) {

--- a/hybridse/src/udf/default_udf_library.cc
+++ b/hybridse/src/udf/default_udf_library.cc
@@ -857,7 +857,7 @@ void DefaultUdfLibrary::InitStringUdf() {
                 SELECT LCASE('SQl') as str1;
                 --output "sql"
             @endcode
-            @since 0.4.0)");
+            @since 0.5.0)");
     RegisterExternal("reverse")
         .args<codec::StringRef>(
             reinterpret_cast<void*>(static_cast<void (*)(codec::StringRef*, codec::StringRef*, bool*)>(udf::v1::reverse)))

--- a/hybridse/src/udf/default_udf_library.cc
+++ b/hybridse/src/udf/default_udf_library.cc
@@ -843,6 +843,21 @@ void DefaultUdfLibrary::InitStringUdf() {
                 --output "SQL"
             @endcode
             @since 0.4.0)");
+    RegisterExternal("lcase")
+        .args<codec::StringRef>(
+            reinterpret_cast<void*>(static_cast<void (*)(codec::StringRef*, codec::StringRef*, bool*)>(udf::v1::lcase)))
+        .return_by_arg(true)
+        .returns<Nullable<codec::StringRef>>()
+        .doc(R"(
+            @brief Convert all the characters to lowercase. Note that characters with values > 127 are simply returned.
+
+            Example:
+
+            @code{.sql}
+                SELECT LCASE('SQl') as str1;
+                --output "sql"
+            @endcode
+            @since 0.4.0)");
     RegisterExternal("reverse")
         .args<codec::StringRef>(
             reinterpret_cast<void*>(static_cast<void (*)(codec::StringRef*, codec::StringRef*, bool*)>(udf::v1::reverse)))
@@ -858,6 +873,7 @@ void DefaultUdfLibrary::InitStringUdf() {
                 --output "cba"
             @endcode
             @since 0.4.0)");
+    RegisterAlias("lower", "lcase");
     RegisterAlias("upper", "ucase");
 }
 

--- a/hybridse/src/udf/udf.cc
+++ b/hybridse/src/udf/udf.cc
@@ -854,6 +854,19 @@ void reverse(codec::StringRef *str, codec::StringRef *output, bool *is_null_ptr)
     *is_null_ptr = false;
 }
 
+void lcase(codec::StringRef *str, codec::StringRef *output, bool *is_null_ptr) {
+    if (str == nullptr || str->size_ == 0 || output == nullptr || is_null_ptr == nullptr) {
+        return;
+    }
+    char *buffer = AllocManagedStringBuf(str->size_);
+    for (uint32_t i = 0; i < str->size_; i++) {
+        buffer[i] = absl::ascii_tolower(static_cast<unsigned char>(str->data_[i]));
+    }
+    output->size_ = str->size_;
+    output->data_ = buffer;
+    *is_null_ptr = false;
+}
+
 //
 
 template <>

--- a/hybridse/src/udf/udf.h
+++ b/hybridse/src/udf/udf.h
@@ -262,7 +262,7 @@ void string_to_bigint(codec::StringRef *str, int64_t *v, bool *is_null_ptr);
 void string_to_float(codec::StringRef *str, float *v, bool *is_null_ptr);
 void string_to_double(codec::StringRef *str, double *v, bool *is_null_ptr);
 void reverse(codec::StringRef *str, codec::StringRef *output, bool *is_null_ptr);
-
+void lcase(codec::StringRef *str, codec::StringRef *output, bool *is_null_ptr);
 void ucase(codec::StringRef *str, codec::StringRef *output, bool *is_null_ptr);
 /**
  * Allocate string buffer from jit runtime.


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

   Adds the `lcase()` and `lower()` functions.

* **What is the current behavior?** (You can also link to an open issue here)

   The two functions have not been implemented.

   close #784 
  
* **What is the new behavior (if this is a feature change)?**
   These two functions convert all characters in a string into lower cases.
