### PR TITLE
feat: support function fetchmany() and fetchall() in python SDK and UT

### DIFF
--- a/python/openmldb/dbapi/dbapi.py
+++ b/python/openmldb/dbapi/dbapi.py
@@ -343,7 +343,7 @@ class Cursor(object):
         return self.connection._sdk.getDatabases()
 
     def fetchone(self):
-        if self._resultSet is None: raise Exception("query data failed")
+        if self._resultSet is None: raise DatabaseError("query data failed")
         ok = self._resultSet.Next()
         if not ok:
             return None
@@ -357,7 +357,7 @@ class Cursor(object):
 
     @connected
     def fetchmany(self, size=None):
-        if self._resultSet is None: raise Exception("query data failed")
+        if self._resultSet is None: raise DatabaseError("query data failed")
         if size is None:
             size = self.arraysize
         elif size < 0:

--- a/python/openmldb/dbapi/dbapi.py
+++ b/python/openmldb/dbapi/dbapi.py
@@ -356,11 +356,9 @@ class Cursor(object):
         return tuple(values)
 
     @connected
-    def fetchmany(self, size=None):
+    def fetchmany(self, size=self.arraysize):
         if self._resultSet is None: raise Exception("query data failed")
-        if size is None:
-            size = self.arraysize
-        elif size < 0:
+        if size < 0:
             raise Exception(f"Given size should greater than zero")
         values = []
         for k in range(size):
@@ -387,21 +385,8 @@ class Cursor(object):
         
     @connected
     def fetchall(self):
-        if self._resultSet is None: raise Exception("query data failed")
-        values = []
-        for k in range(self.rowcount):
-            ok = self._resultSet.Next()
-            if not ok:
-                break
-            row = []
-            for i in range(self.__schema.GetColumnCnt()):
-                if self._resultSet.IsNULL(i):
-                    row.append(None)
-                else:
-                    row.append(self.__getMap[self.__schema.GetColumnType(i)](i))
-            values.append(tuple(row))
-        return values
-
+        return self.fetchmany(size=self.rowcount)
+    
     @staticmethod
     def substitute_in_query(string_query, parameters):
         query = string_query

--- a/python/openmldb/dbapi/dbapi.py
+++ b/python/openmldb/dbapi/dbapi.py
@@ -343,14 +343,9 @@ class Cursor(object):
         return self.connection._sdk.getDatabases()
 
     def fetchone(self):
-
-        if self._resultSet is None: return "call fetchone"
+        if self._resultSet is None: raise Exception("query data failed")
         ok = self._resultSet.Next()
         if not ok:
-            self.rowcount = -1
-            self._resultSet = None
-            self.__schema = None
-            self.__getMap = None
             return None
         values = []
         for i in range(self.__schema.GetColumnCnt()):
@@ -362,7 +357,24 @@ class Cursor(object):
 
     @connected
     def fetchmany(self, size=None):
-        raise NotSupportedError("Unsupported in OpenMLDB")
+        if self._resultSet is None: raise Exception("query data failed")
+        if size is None:
+            size = self.arraysize
+        elif size < 0:
+            raise Exception(f"Given size should greater than zero")
+        values = []
+        for k in range(size):
+            ok = self._resultSet.Next()
+            if not ok:
+                break
+            row = []
+            for i in range(self.__schema.GetColumnCnt()):
+                if self._resultSet.IsNULL(i):
+                    row.append(None)
+                else:
+                    row.append(self.__getMap[self.__schema.GetColumnType(i)](i))
+            values.append(tuple(row))
+        return values
 
     def nextset(self):
         raise NotSupportedError("Unsupported in OpenMLDB")
@@ -375,7 +387,20 @@ class Cursor(object):
         
     @connected
     def fetchall(self):
-        raise NotSupportedError("Unsupported in OpenMLDB")
+        if self._resultSet is None: raise Exception("query data failed")
+        values = []
+        for k in range(self.rowcount):
+            ok = self._resultSet.Next()
+            if not ok:
+                break
+            row = []
+            for i in range(self.__schema.GetColumnCnt()):
+                if self._resultSet.IsNULL(i):
+                    row.append(None)
+                else:
+                    row.append(self.__getMap[self.__schema.GetColumnType(i)](i))
+            values.append(tuple(row))
+        return values
 
     @staticmethod
     def substitute_in_query(string_query, parameters):

--- a/python/openmldb/dbapi/dbapi.py
+++ b/python/openmldb/dbapi/dbapi.py
@@ -356,9 +356,11 @@ class Cursor(object):
         return tuple(values)
 
     @connected
-    def fetchmany(self, size=self.arraysize):
+    def fetchmany(self, size=None):
         if self._resultSet is None: raise Exception("query data failed")
-        if size < 0:
+        if size is None:
+            size = self.arraysize
+        elif size < 0:
             raise Exception(f"Given size should greater than zero")
         values = []
         for k in range(size):

--- a/python/openmldb/test/openmldb_client_test.py
+++ b/python/openmldb/test/openmldb_client_test.py
@@ -215,7 +215,7 @@ class TestOpenMLDBClient(unittest.TestCase):
   def check_fetchall(self,connection, expect_row):
     result = connection.execute("select * from tsql1010;")
     result = sorted(result.fetchall(), key=lambda x: x[0])
-    self.assertTrue(result.fetchall() == expect_row)
+    self.assertTrue(result == expect_row)
                     
   def test_parameterized_query(self):
     logging.info("test_parameterized_query...")

--- a/python/openmldb/test/openmldb_client_test.py
+++ b/python/openmldb/test/openmldb_client_test.py
@@ -208,7 +208,7 @@ class TestOpenMLDBClient(unittest.TestCase):
 
   def check_fetchmany(self,connection):
     result = connection.execute("select * from tsql1010;")
-    self.assertTrue(result.fetchmany() == [(1000, '2020-12-25', 'guangdon', '广州', 1)]
+    self.assertTrue(result.fetchmany() == [(1000, '2020-12-25', 'guangdon', '广州', 1)])
     self.assertTrue(result.fetchmany(size=2) == [(1001, '2020-12-26', 'hefei', 'anhui', 2),(1002, '2020-12-27', 'fujian', 'fuzhou', 3)])
     self.assertTrue(result.fetchmany(size=4) == [(1003, '2020-12-28', 'jiangxi', 'nanchang', 4),(1004, '2020-12-29', 'hubei', 'wuhan', 5)])
       

--- a/python/openmldb/test/openmldb_client_test.py
+++ b/python/openmldb/test/openmldb_client_test.py
@@ -59,7 +59,6 @@ class TestOpenMLDBClient(unittest.TestCase):
     connection.execute(insert5, ({"col2":"2020-12-29"}));
     
     self.check_fetchmany(connection)
-    self.check_fetchall(connection)
     self.check_exectute_many(connection,insert4)
 
     data = {1000 : [1000, '2020-12-25', 'guangdon', '广州', 1],
@@ -88,6 +87,7 @@ class TestOpenMLDBClient(unittest.TestCase):
         (1003, '2020-12-28', 'jiangxi', 'nanchang', 4),
         (1004, '2020-12-29', 'hubei', 'wuhan', 5),
     ]
+    self.check_fetchall(connection, expectRows)
     self.check_result(rs, expectRows, 0);
     # test condition select
     rs = connection.execute("select * from tsql1010 where col3 = 'hefei';");
@@ -207,21 +207,17 @@ class TestOpenMLDBClient(unittest.TestCase):
       pass
 
   def check_fetchmany(self,connection):
-    try:
-      result = connection.execute("select * from tsql1010;")
-      print(result.fetchmany(size=2))
-      self.assertTrue(False)
-    except Exception as e:
-      pass
+    result = connection.execute("select * from tsql1010;")
+    self.assertTrue(result.fetchmany() == [(1000, '2020-12-25', 'guangdon', '广州', 1)]
+    self.assertTrue(result.fetchmany(size=2) == [(1001, '2020-12-26', 'hefei', 'anhui', 2),
+                                                 (1002, '2020-12-27', 'fujian', 'fuzhou', 3)])
+    self.assertTrue(result.fetchmany(size=4) == [(1003, '2020-12-28', 'jiangxi', 'nanchang', 4),
+                                                 (1004, '2020-12-29', 'hubei', 'wuhan', 5)])
       
-  def check_fetchall(self,connection):
-    try:
-      result = connection.execute("select * from tsql1010;")
-      print(result.fetchall())
-      self.assertTrue(False)
-    except Exception as e:
-      pass
-
+  def check_fetchall(self,connection, expect_row):
+    result = connection.execute("select * from tsql1010;")
+    self.assertTrue(result.fetchall() == expect_row)
+                    
   def test_parameterized_query(self):
     logging.info("test_parameterized_query...")
     engine = db.create_engine('openmldb:///db_test?zk=127.0.0.1:6181&zkPath=/onebox')

--- a/python/openmldb/test/openmldb_client_test.py
+++ b/python/openmldb/test/openmldb_client_test.py
@@ -209,10 +209,8 @@ class TestOpenMLDBClient(unittest.TestCase):
   def check_fetchmany(self,connection):
     result = connection.execute("select * from tsql1010;")
     self.assertTrue(result.fetchmany() == [(1000, '2020-12-25', 'guangdon', '广州', 1)]
-    self.assertTrue(result.fetchmany(size=2) == [(1001, '2020-12-26', 'hefei', 'anhui', 2),
-                                                 (1002, '2020-12-27', 'fujian', 'fuzhou', 3)])
-    self.assertTrue(result.fetchmany(size=4) == [(1003, '2020-12-28', 'jiangxi', 'nanchang', 4),
-                                                 (1004, '2020-12-29', 'hubei', 'wuhan', 5)])
+    self.assertTrue(result.fetchmany(size=2) == [(1001, '2020-12-26', 'hefei', 'anhui', 2),(1002, '2020-12-27', 'fujian', 'fuzhou', 3)])
+    self.assertTrue(result.fetchmany(size=4) == [(1003, '2020-12-28', 'jiangxi', 'nanchang', 4),(1004, '2020-12-29', 'hubei', 'wuhan', 5)])
       
   def check_fetchall(self,connection, expect_row):
     result = connection.execute("select * from tsql1010;")

--- a/python/openmldb/test/openmldb_client_test.py
+++ b/python/openmldb/test/openmldb_client_test.py
@@ -208,12 +208,13 @@ class TestOpenMLDBClient(unittest.TestCase):
 
   def check_fetchmany(self,connection):
     result = connection.execute("select * from tsql1010;")
-    self.assertTrue(result.fetchmany() == [(1000, '2020-12-25', 'guangdon', '广州', 1)])
-    self.assertTrue(result.fetchmany(size=2) == [(1001, '2020-12-26', 'hefei', 'anhui', 2),(1002, '2020-12-27', 'fujian', 'fuzhou', 3)])
-    self.assertTrue(result.fetchmany(size=4) == [(1003, '2020-12-28', 'jiangxi', 'nanchang', 4),(1004, '2020-12-29', 'hubei', 'wuhan', 5)])
+    self.assertTrue(result.fetchmany() == [(1002, '2020-12-27', 'fujian', 'fuzhou', 3)])
+    self.assertTrue(result.fetchmany(size=2) == [(1001, '2020-12-26', 'hefei', 'anhui', 2),(1000, '2020-12-25', 'guangdon', '广州', 1)])
+    self.assertTrue(result.fetchmany(size=4) == [(1004, '2020-12-29', 'hubei', 'wuhan', 5),(1003, '2020-12-28', 'jiangxi', 'nanchang', 4)])
       
   def check_fetchall(self,connection, expect_row):
     result = connection.execute("select * from tsql1010;")
+    result = sorted(result.fetchall(), key=lambda x: x[0])
     self.assertTrue(result.fetchall() == expect_row)
                     
   def test_parameterized_query(self):


### PR DESCRIPTION
Reference: [Standard DBAPI](https://www.python.org/dev/peps/pep-0249/#fetchone)
*.fetchone()
Fetch the next row of a query result set, returning a single sequence, None when no more data is available.

*.fetchmany(size=None)
Fetch the next set of rows of a query result, returning a sequence of sequences (e.g. a list of tuples). An empty sequence is returned when no more rows are available.
The number of rows to fetch per call is specified by the parameter. If it is not given, the cursor's arraysize determines the number of rows to be fetched. 

*.fetchall()
Fetch all (remaining) rows of a query result, returning them as a sequence of sequences (e.g. a list of tuples).