### PR TITLE
fix: detect incorrect sql like `select 10s` or `select 10s + 1`

### DIFF
--- a/cases/query/const_query.yaml
+++ b/cases/query/const_query.yaml
@@ -133,4 +133,4 @@ cases:
     expect:
       columns: ['c1 bool', 'c2 int16', 'c3 int', 'c4 double', 'c5 string', 'c6 date', 'c7 timestamp' ]
       rows:
-        - [ true, 3, 13, 10.0, 'a string', '2020-05-22', '2020-05-22 10:43:40' ]
+        - [ true, 3, 13, 10.0, 'a string', '2020-05-22', 1590115420000 ]

--- a/cases/query/const_query.yaml
+++ b/cases/query/const_query.yaml
@@ -125,3 +125,12 @@ cases:
       columns: ["c1 int", "c2 bigint", "c3 float", "c4 double", "c5 timestamp", "c6 date", "c7 string"]
       rows:
         - [NULL, NULL, NULL, NULL, NULL, NULL, NULL]
+  - id: 9
+    desc: differnt const node type
+    mode: request-unsupport
+    sql: |
+      select true c1, int16(3) c2, 13 c3, 10.0 c4, 'a string' c5, date(timestamp(1590115420000)) c6, timestamp(1590115420000) c7;
+    expect:
+      columns: ['c1 bool', 'c2 int16', 'c3 int', 'c4 double', 'c5 string', 'c6 date', 'c7 timestamp' ]
+      rows:
+        - [ true, 3, 13, 10.0, 'a string', '2020-05-22', '2020-05-22 10:43:40' ]

--- a/cases/query/fail_query.yaml
+++ b/cases/query/fail_query.yaml
@@ -14,8 +14,8 @@
 
 db: test_zw
 cases:
-  -
-    id: 0
+  # 0
+  - id: 0
     desc: window名不存在
     inputs:
       -
@@ -29,5 +29,23 @@ cases:
           - [5,"ee",21,34,1.5,2.5,1590738994000,"2020-05-05"]
     sql: |
       SELECT id, c1, c3, sum(c4) OVER w2 as w1_c4_sum FROM {0} WINDOW w1 AS (PARTITION BY {0}.c3 ORDER BY {0}.c7 ROWS BETWEEN 2 PRECEDING AND CURRENT ROW);
+    expect:
+      success: false
+
+    # 1
+  - id: un-support const node
+    desc: select interval literal as project output
+    mode: request-unsupport
+    sql: |
+      SELECT 1s;
+    expect:
+      success: false
+
+    # 2
+  - id: un-support interval literal inside expr
+    desc: select interval literal as project output
+    mode: request-unsupport
+    sql: |
+      SELECT 100 + 1s;
     expect:
       success: false

--- a/hybridse/include/node/sql_node.h
+++ b/hybridse/include/node/sql_node.h
@@ -857,7 +857,9 @@ class ConstNode : public ExprNode {
         }
     }
 
-    ConstNode(int64_t val, DataType time_type) : ExprNode(kExprPrimary), data_type_(time_type) { val_.vlong = val; }
+    explicit ConstNode(int64_t val, DataType time_type) : ExprNode(kExprPrimary), data_type_(time_type) {
+        val_.vlong = val;
+    }
 
     ~ConstNode() {
         if (data_type_ == hybridse::node::kVarchar) {

--- a/hybridse/include/vm/physical_op.h
+++ b/hybridse/include/vm/physical_op.h
@@ -421,7 +421,7 @@ class PhysicalOpNode : public node::NodeBase<PhysicalOpNode> {
 
     virtual void PrintSchema() const;
 
-    virtual std::string SchemaToString(const std::string &tab = "") const;
+    virtual std::string SchemaToString(const std::string &tab) const;
 
     const std::vector<PhysicalOpNode *> &GetProducers() const {
         return producers_;

--- a/hybridse/src/node/expr_node.cc
+++ b/hybridse/src/node/expr_node.cc
@@ -881,30 +881,43 @@ ParameterExpr *ParameterExpr::ShadowCopy(NodeManager *nm) const {
     return nm->MakeParameterExpr(position());
 }
 ConstNode* ConstNode::ShadowCopy(NodeManager* nm) const {
-    switch (this->GetDataType()) {
-        case node::kBool:
+    switch (GetDataType()) {
+        case DataType::kBool:
             return nm->MakeConstNode(GetBool());
-        case node::kInt16:
+        case DataType::kInt16:
             return nm->MakeConstNode(GetSmallInt());
-        case node::kInt32:
+        case DataType::kInt32:
             return nm->MakeConstNode(GetInt());
-        case node::kInt64:
+        case DataType::kInt64:
             return nm->MakeConstNode(GetLong());
-        case node::kFloat:
+        case DataType::kFloat:
             return nm->MakeConstNode(GetFloat());
-        case node::kDouble:
+        case DataType::kDouble:
             return nm->MakeConstNode(GetDouble());
-        case node::kVarchar:
+        case DataType::kVarchar:
             return nm->MakeConstNode(std::string(GetStr()));
-        case node::kDate:
+        case DataType::kDate:
             return nm->MakeConstNode(GetLong(), GetDataType());
-        case node::kTimestamp:
+        case DataType::kTimestamp:
             return nm->MakeConstNode(GetLong(), GetDataType());
-        case node::kNull:
+        case DataType::kNull:
             return nm->MakeConstNode();
-        default: {
-            LOG(WARNING) << "Fail to copy primary expr of type " +
-                                node::DataTypeName(GetDataType());
+        case DataType::kDay:
+        case DataType::kHour:
+        case DataType::kMinute:
+        case DataType::kSecond:
+            return nm->MakeConstNode(GetLong(), GetDataType());
+
+        case DataType::kList:
+        case DataType::kIterator:
+        case DataType::kMap:
+        case DataType::kRow:
+        case DataType::kInt8Ptr:
+        case DataType::kTuple:
+        case DataType::kOpaque:
+        case DataType::kPlaceholder:
+        case DataType::kVoid: {
+            LOG(WARNING) << "Fail to copy primary expr of type " << node::DataTypeName(GetDataType());
             return nm->MakeConstNode();
         }
     }

--- a/hybridse/src/node/expr_node.cc
+++ b/hybridse/src/node/expr_node.cc
@@ -888,25 +888,23 @@ ConstNode* ConstNode::ShadowCopy(NodeManager* nm) const {
             return nm->MakeConstNode(GetSmallInt());
         case DataType::kInt32:
             return nm->MakeConstNode(GetInt());
-        case DataType::kInt64:
-            return nm->MakeConstNode(GetLong());
         case DataType::kFloat:
             return nm->MakeConstNode(GetFloat());
         case DataType::kDouble:
             return nm->MakeConstNode(GetDouble());
         case DataType::kVarchar:
             return nm->MakeConstNode(std::string(GetStr()));
+
+        case DataType::kInt64:
         case DataType::kDate:
-            return nm->MakeConstNode(GetLong(), GetDataType());
         case DataType::kTimestamp:
-            return nm->MakeConstNode(GetLong(), GetDataType());
-        case DataType::kNull:
-            return nm->MakeConstNode();
         case DataType::kDay:
         case DataType::kHour:
         case DataType::kMinute:
         case DataType::kSecond:
             return nm->MakeConstNode(GetLong(), GetDataType());
+        case DataType::kNull:
+            return nm->MakeConstNode();
 
         case DataType::kList:
         case DataType::kIterator:

--- a/hybridse/src/node/expr_node.cc
+++ b/hybridse/src/node/expr_node.cc
@@ -916,7 +916,7 @@ ConstNode* ConstNode::ShadowCopy(NodeManager* nm) const {
         case DataType::kPlaceholder:
         case DataType::kVoid: {
             LOG(WARNING) << "Fail to copy primary expr of type " << node::DataTypeName(GetDataType());
-            return nm->MakeConstNode();
+            return nm->MakeConstNode(GetDataType());
         }
     }
 }

--- a/hybridse/src/passes/physical/batch_request_optimize.cc
+++ b/hybridse/src/passes/physical/batch_request_optimize.cc
@@ -341,7 +341,7 @@ Status CommonColumnOptimize::ProcessSimpleProject(
             CHECK_STATUS(
                 UpdateProjectExpr(ctx, expr, input_op, new_id_map, &new_expr),
                 "Fail to resolve expr ", expr->GetExprString(),
-                " on project input:\n", new_input->SchemaToString());
+                " on project input:\n", new_input->SchemaToString(""));
             expr = new_expr;
         }
 
@@ -461,7 +461,7 @@ Status CommonColumnOptimize::ProcessProject(PhysicalPlanContext* ctx,
             CHECK_STATUS(
                 UpdateProjectExpr(ctx, expr, input_op, new_id_map, &new_expr),
                 "Fail to resolve expr ", expr->GetExprString(),
-                " on project input:\n", new_input->SchemaToString());
+                " on project input:\n", new_input->SchemaToString(""));
             expr = new_expr;
         }
 
@@ -758,7 +758,7 @@ Status CommonColumnOptimize::ProcessWindow(PhysicalPlanContext* ctx,
             CHECK_STATUS(
                 UpdateProjectExpr(ctx, expr, input, new_id_map, &new_expr),
                 "Fail to resolve expr ", expr->GetExprString(),
-                " on project input:\n", new_union->SchemaToString());
+                " on project input:\n", new_union->SchemaToString(""));
             expr = new_expr;
         }
         bool expr_is_common =

--- a/hybridse/src/vm/physical_op.cc
+++ b/hybridse/src/vm/physical_op.cc
@@ -1025,7 +1025,7 @@ Status PhysicalPartitionProviderNode::WithNewChildren(node::NodeManager* nm,
     return Status::OK();
 }
 
-void PhysicalOpNode::PrintSchema() const { std::cout << SchemaToString() << std::endl; }
+void PhysicalOpNode::PrintSchema() const { std::cout << SchemaToString("") << std::endl; }
 
 std::string PhysicalOpNode::SchemaToString(const std::string& tab) const {
     std::stringstream ss;

--- a/hybridse/src/vm/schemas_context_test.cc
+++ b/hybridse/src/vm/schemas_context_test.cc
@@ -152,7 +152,7 @@ void CheckColumnResolveCase(const YAML::Node& resolve_case,
 }
 
 void CheckColumnResolveCases(const SqlCase& sql_case, PhysicalOpNode* node) {
-    LOG(INFO) << "Physical plan:\n" << node->SchemaToString();
+    LOG(INFO) << "Physical plan:\n" << node->SchemaToString("");
 
     auto& raw_node = sql_case.raw_node();
     const auto& expect = raw_node["expect"];

--- a/hybridse/src/vm/transform.cc
+++ b/hybridse/src/vm/transform.cc
@@ -899,9 +899,9 @@ Status ExtractProjectInfos(const node::PlanNodeList& projects,
                            ColumnProjects* output) {
     for (auto plan_node : projects) {
         auto pp_node = dynamic_cast<node::ProjectNode*>(plan_node);
-        CHECK_TRUE(pp_node != nullptr, kPlanError);
+        CHECK_TRUE(pp_node != nullptr, kPlanError, "project node is null");
         auto expr = pp_node->GetExpression();
-        CHECK_TRUE(expr != nullptr, kPlanError);
+        CHECK_TRUE(expr != nullptr, kPlanError, "expr in project node is null");
         if (expr->GetExprType() == node::kExprAll) {
             // expand *
             for (size_t slice = 0; slice < schemas_ctx->GetSchemaSourceSize();
@@ -1681,6 +1681,9 @@ Status BatchModeTransformer::TransformPhysicalPlan(const ::hybridse::node::PlanN
                 std::set<PhysicalOpNode*> node_visited_dict;
                 CHECK_STATUS(InitFnInfo(optimized_physical_plan, &node_visited_dict),
                              "Fail to generate functions for physical plan");
+
+                // assert un-supported output column type
+
                 *output = optimized_physical_plan;
                 break;
             }

--- a/hybridse/src/vm/transform.cc
+++ b/hybridse/src/vm/transform.cc
@@ -1681,9 +1681,6 @@ Status BatchModeTransformer::TransformPhysicalPlan(const ::hybridse::node::PlanN
                 std::set<PhysicalOpNode*> node_visited_dict;
                 CHECK_STATUS(InitFnInfo(optimized_physical_plan, &node_visited_dict),
                              "Fail to generate functions for physical plan");
-
-                // assert un-supported output column type
-
                 *output = optimized_physical_plan;
                 break;
             }

--- a/third-party/cmake/FetchZetasql.cmake
+++ b/third-party/cmake/FetchZetasql.cmake
@@ -14,7 +14,7 @@
 
 set(ZETASQL_HOME https://github.com/4paradigm/zetasql)
 set(ZETASQL_VERSION 0.2.6)
-set(ZETASQL_TAG 3963378fff58870ca3800144006de56792a7d86e) # the commit hash for v0.2.6
+set(ZETASQL_TAG 4af08ff0bd8d8b46c420b550a01a6542b5718804) # the commit hash for v0.2.6
 
 function(init_zetasql_urls)
   if (CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/third-party/cmake/FetchZetasql.cmake
+++ b/third-party/cmake/FetchZetasql.cmake
@@ -14,7 +14,7 @@
 
 set(ZETASQL_HOME https://github.com/4paradigm/zetasql)
 set(ZETASQL_VERSION 0.2.6)
-set(ZETASQL_TAG 4af08ff0bd8d8b46c420b550a01a6542b5718804) # the commit hash for v0.2.6
+set(ZETASQL_TAG b08253b635bebfee9ee85aea16b281a831de5165) # the commit hash for v0.2.6
 
 function(init_zetasql_urls)
   if (CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/third-party/cmake/FetchZetasql.cmake
+++ b/third-party/cmake/FetchZetasql.cmake
@@ -14,7 +14,7 @@
 
 set(ZETASQL_HOME https://github.com/4paradigm/zetasql)
 set(ZETASQL_VERSION 0.2.6)
-set(ZETASQL_TAG b08253b635bebfee9ee85aea16b281a831de5165) # the commit hash for v0.2.6
+set(ZETASQL_TAG 3963378fff58870ca3800144006de56792a7d86e) # the commit hash for v0.2.6
 
 function(init_zetasql_urls)
   if (CMAKE_SYSTEM_NAME STREQUAL "Linux")


### PR DESCRIPTION
close #1208

reason: `ConstNode` 's `ShadowCopy` not cover for time interval. The patch fix `ShadowCopy` method for time interval.
After patch the original infer attr flow for `select 10s` or `select 10s + 1` work as expected.

Other changes:

- rm default parameter for `PhysicalOpNode::SchemaToString`, not recommended for virtual method 