### PR TITLE
feat: add check for hadoop.conf.dir when it uses yarn mode

### DIFF
--- a/java/openmldb-taskmanager/src/main/java/com/_4paradigm/openmldb/taskmanager/config/TaskManagerConfig.java
+++ b/java/openmldb-taskmanager/src/main/java/com/_4paradigm/openmldb/taskmanager/config/TaskManagerConfig.java
@@ -195,7 +195,7 @@ public class TaskManagerConfig {
         }
 
         HADOOP_CONF_DIR = prop.getProperty("hadoop.conf.dir", "");
-        if (HADOOP_CONF_DIR.isEmpty()) {
+        if (isYarn && HADOOP_CONF_DIR.isEmpty()) {
             try {
                 if(System.getenv("HADOOP_CONF_DIR") == null) {
                     throw new ConfigException("hadoop.conf.dir", "should set config 'hadoop.conf.dir' or environment variable 'HADOOP_CONF_DIR'");
@@ -207,7 +207,6 @@ public class TaskManagerConfig {
             }
         }
         // TODO: Check if we can get core-site.xml
-
     }
 
 }


### PR DESCRIPTION
* Only check `hadoop.conf.dir` when spark yarn mode is used.

Should backport to `0.4.2` as well.