### PR TITLE
fix: fix string columns as null for UnsafeRowOpt

### DIFF
--- a/hybridse/src/codec/type_codec.cc
+++ b/hybridse/src/codec/type_codec.cc
@@ -188,6 +188,15 @@ int32_t AppendString(int8_t* buf_ptr, uint32_t buf_size, uint32_t col_idx,
                      int8_t* val, uint32_t size, int8_t is_null,
                      uint32_t str_start_offset, uint32_t str_field_offset,
                      uint32_t str_addr_space, uint32_t str_body_offset) {
+
+    if (is_null) {
+        AppendNullBit(buf_ptr, col_idx, true);
+        size_t str_addr_length = GetAddrLength(buf_size);
+        FillNullStringOffset(buf_ptr, str_start_offset, str_addr_length,
+                             str_field_offset, str_body_offset);
+        return str_body_offset;
+    }
+
     if (FLAGS_enable_spark_unsaferow_format) {
         // TODO(chenjing): Refactor to support multiple codec instead of reusing the variable
         // For UnsafeRow opt, str_start_offset is the nullbitmap size
@@ -203,14 +212,6 @@ int32_t AppendString(int8_t* buf_ptr, uint32_t buf_size, uint32_t col_idx,
         }
 
         return str_body_offset + size;
-    }
-
-    if (is_null) {
-        AppendNullBit(buf_ptr, col_idx, true);
-        size_t str_addr_length = GetAddrLength(buf_size);
-        FillNullStringOffset(buf_ptr, str_start_offset, str_addr_length,
-                             str_field_offset, str_body_offset);
-        return str_body_offset;
     }
 
     uint32_t str_offset = str_start_offset + str_field_offset * str_addr_space;

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/DataUtil.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/DataUtil.scala
@@ -16,8 +16,10 @@
 
 package com._4paradigm.openmldb.batch.end2end
 
-import org.apache.spark.sql.types.{IntegerType, LongType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{BooleanType, DateType, DoubleType, FloatType, IntegerType, LongType, ShortType,
+  StringType, StructField, StructType, TimestampType}
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import java.sql.{Date, Timestamp}
 
 object DataUtil {
 
@@ -45,6 +47,24 @@ object DataUtil {
       StructField("name", StringType),
       StructField("trans_amount", LongType),
       StructField("trans_time", IntegerType)))
+    spark.createDataFrame(spark.sparkContext.makeRDD(data), schema)
+  }
+
+  def getAllTypesDfWithNull(spark: SparkSession): DataFrame = {
+    val data = Seq(
+      Row(true, 1.toShort, 1, 1L, 1.0F, 1.0D, new Timestamp(1), new Date(1), "string1"),
+      Row(null, null, null, null, null, null, null, null, null))
+    val schema = StructType(List(
+      StructField("bool_col", BooleanType),
+      StructField("short_col", ShortType),
+      StructField("int_col", IntegerType),
+      StructField("long_col", LongType),
+      StructField("float_col", FloatType),
+      StructField("double_col", DoubleType),
+      StructField("timestamp_col", TimestampType),
+      StructField("date_col", DateType),
+      StructField("string_col", StringType)
+    ))
     spark.createDataFrame(spark.sparkContext.makeRDD(data), schema)
   }
 

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/TestProject.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/TestProject.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 4Paradigm
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com._4paradigm.openmldb.batch.end2end
+
+import com._4paradigm.openmldb.batch.SparkTestSuite
+import com._4paradigm.openmldb.batch.api.OpenmldbSession
+import com._4paradigm.openmldb.batch.utils.SparkUtil
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+
+
+class TestProject extends SparkTestSuite {
+
+  test("Test end2end window aggregation") {
+
+    val spark = getSparkSession
+    val sess = new OpenmldbSession(spark)
+
+    val df = DataUtil.getTestDf(spark)
+
+    sess.registerTable("t1", df)
+    df.createOrReplaceTempView("t1")
+
+    val sql = "SELECT id + 10 AS id_10, name FROM t1"
+
+    val outputDf = sess.sql(sql)
+    val sparkOutputDf = sess.sparksql(sql)
+    assert(SparkUtil.approximateDfEqual(outputDf.getSparkDf(), sparkOutputDf, false))
+
+  }
+
+}

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/unsafe/TestUnsafeProjectWithNull.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/unsafe/TestUnsafeProjectWithNull.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 4Paradigm
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com._4paradigm.openmldb.batch.end2end.unsafe
+
+import com._4paradigm.openmldb.batch.SparkTestSuite
+import com._4paradigm.openmldb.batch.api.OpenmldbSession
+import com._4paradigm.openmldb.batch.end2end.DataUtil
+import com._4paradigm.openmldb.batch.utils.SparkUtil
+
+class TestUnsafeProjectWithNull extends SparkTestSuite {
+
+  override def customizedBefore(): Unit = {
+    val spark = getSparkSession
+    spark.conf.set("spark.openmldb.unsaferow.opt", true)
+  }
+
+  test("Test unsafe project with null data") {
+    val spark = getSparkSession
+    val sess = new OpenmldbSession(spark)
+
+    val df = DataUtil.getAllTypesDfWithNull(spark)
+    sess.registerTable("t1", df)
+    df.createOrReplaceTempView("t1")
+
+    val sqlText = "SELECT bool_col, short_col + 100 as short_add_100, int_col, long_col, float_col, double_col," +
+      " timestamp_col, date_col, string_col FROM t1"
+
+    val outputDf = sess.sql(sqlText)
+    val sparksqlOutputDf = sess.sparksql(sqlText)
+    assert(SparkUtil.approximateDfEqual(outputDf.getSparkDf(), sparksqlOutputDf, false))
+  }
+
+  override def customizedAfter(): Unit = {
+    val spark = getSparkSession
+    spark.conf.set("spark.openmldb.unsaferow.opt", false)
+  }
+
+}


### PR DESCRIPTION
* Resolve https://github.com/4paradigm/OpenMLDB/issues/1315 .
* Add unit test for null string columns with unsaferow opt.