### PR TITLE
feat: update default execute mode

### DIFF
--- a/src/cmd/sql_cmd.h
+++ b/src/cmd/sql_cmd.h
@@ -80,7 +80,7 @@ std::string db = "";  // NOLINT
 ::openmldb::sdk::SQLClusterRouter* sr = nullptr;
 using VariableMap = std::map<std::string, std::string>;
 VariableMap session_variables = {
-    VariableMap::value_type("execute_mode", "online"),
+    VariableMap::value_type("execute_mode", "offline"),
     VariableMap::value_type("enable_trace", "false")
 };
 


### PR DESCRIPTION
Update the default value of `execute mode` from `online` to `offline`.
The `main` branch will be modified in #1231 