### PR TITLE
feat: support unsaferow format for codec

### DIFF
--- a/hybridse/src/codec/fe_row_codec.cc
+++ b/hybridse/src/codec/fe_row_codec.cc
@@ -473,16 +473,9 @@ std::string RowView::GetStringUnsafe(uint32_t idx) {
     const char* val;
     uint32_t length;
 
-    if (FLAGS_enable_spark_unsaferow_format) {
-        v1::GetStrFieldUnsafe(row_, idx, field_offset, next_str_field_offset,
-                              BitMapSize(schema_.size()), str_addr_length_, &val,
-                              &length);
-    } else {
-        v1::GetStrFieldUnsafe(row_, idx, field_offset, next_str_field_offset,
-                              str_field_start_offset_, str_addr_length_, &val,
-                              &length);
-    }
-
+    v1::GetStrFieldUnsafe(row_, idx, field_offset, next_str_field_offset,
+                          str_field_start_offset_, str_addr_length_, &val,
+                          &length);
     return std::string(val, length);
 }
 
@@ -878,15 +871,9 @@ int32_t RowView::GetValue(const int8_t* row, uint32_t idx, const char** val,
         next_str_field_offset = field_offset + 1;
     }
 
-    if (FLAGS_enable_spark_unsaferow_format) {
-        return v1::GetStrFieldUnsafe(row, idx, field_offset, next_str_field_offset,
-                                     BitMapSize(schema_.size()), GetAddrLength(size),
-                                     val, length);
-    } else {
-        return v1::GetStrFieldUnsafe(row, idx, field_offset, next_str_field_offset,
-                                     str_field_start_offset_, GetAddrLength(size),
-                                     val, length);
-    }
+    return v1::GetStrFieldUnsafe(row, idx, field_offset, next_str_field_offset,
+                                 str_field_start_offset_, GetAddrLength(size),
+                                 val, length);
 }
 
 int32_t RowView::GetString(uint32_t idx, const char** val, uint32_t* length) {
@@ -910,15 +897,9 @@ int32_t RowView::GetString(uint32_t idx, const char** val, uint32_t* length) {
     if (offset_vec_.at(idx) < string_field_cnt_ - 1) {
         next_str_field_offset = field_offset + 1;
     }
-    if (FLAGS_enable_spark_unsaferow_format) {
-        return v1::GetStrFieldUnsafe(row_, idx, field_offset, next_str_field_offset,
-                                     BitMapSize(schema_.size()), str_addr_length_, val,
-                                     length);
-    } else {
-        return v1::GetStrFieldUnsafe(row_, idx, field_offset, next_str_field_offset,
-                                     str_field_start_offset_, str_addr_length_, val,
-                                     length);
-    }
+    return v1::GetStrFieldUnsafe(row_, idx, field_offset, next_str_field_offset,
+                                 str_field_start_offset_, str_addr_length_, val,
+                                 length);
 }
 
 RowFormat::RowFormat(const hybridse::codec::Schema* schema)
@@ -1002,14 +983,8 @@ bool RowFormat::GetStringColumnInfo(size_t idx, StringColInfo* res) const {
                << next_offset << " str_field_start_offset "
                << str_field_start_offset_ << " for col " << base_col_info.name;
 
-    if (FLAGS_enable_spark_unsaferow_format) {
-        // Notice that we pass the nullbitmap size as str_field_start_offset
-        *res = StringColInfo(base_col_info.name, ty, col_idx, offset, next_offset,
-                            BitMapSize(schema_->size()));
-    } else {
-        *res = StringColInfo(base_col_info.name, ty, col_idx, offset, next_offset,
-                            str_field_start_offset_);
-    }
+    *res = StringColInfo(base_col_info.name, ty, col_idx, offset, next_offset,
+                        str_field_start_offset_);
     return true;
 }
 

--- a/hybridse/src/codec/fe_row_codec.cc
+++ b/hybridse/src/codec/fe_row_codec.cc
@@ -931,8 +931,15 @@ RowFormat::RowFormat(const hybridse::codec::Schema* schema)
     for (int32_t i = 0; i < schema_->size(); i++) {
         const ::hybridse::type::ColumnDef& column = schema_->Get(i);
         if (column.type() == ::hybridse::type::kVarchar) {
-            infos_.push_back(
-                ColInfo(column.name(), column.type(), i, string_field_cnt));
+
+            if (FLAGS_enable_spark_unsaferow_format) {
+                infos_.push_back(
+                    ColInfo(column.name(), column.type(), i, offset));
+            } else {
+                infos_.push_back(
+                    ColInfo(column.name(), column.type(), i, string_field_cnt));
+            }
+
             infos_dict_[column.name()] = i;
             next_str_pos_.insert(
                 std::make_pair(string_field_cnt, string_field_cnt));

--- a/hybridse/src/codec/fe_row_codec.cc
+++ b/hybridse/src/codec/fe_row_codec.cc
@@ -976,13 +976,17 @@ bool RowFormat::GetStringColumnInfo(size_t idx, StringColInfo* res) const {
     auto ty = base_col_info.type;
     uint32_t col_idx = base_col_info.idx;
     uint32_t offset = base_col_info.offset;
-    uint32_t next_offset;
+    uint32_t next_offset = -1;
     auto nit = next_str_pos_.find(offset);
     if (nit != next_str_pos_.end()) {
         next_offset = nit->second;
     } else {
-        LOG(WARNING) << "fail to get string field next offset";
-        return false;
+        if (FLAGS_enable_spark_unsaferow_format) {
+            // Do not need to get next offset for UnsafeRowOpt
+        } else {
+            LOG(WARNING) << "fail to get string field next offset";
+            return false;
+        }
     }
     DLOG(INFO) << "get string with offset " << offset << " next offset "
                << next_offset << " str_field_start_offset "

--- a/hybridse/src/codec/type_codec.cc
+++ b/hybridse/src/codec/type_codec.cc
@@ -84,7 +84,7 @@ int32_t GetStrFieldUnsafe(const int8_t* row, uint32_t col_idx,
 
     // Support Spark UnsafeRow format
     if (FLAGS_enable_spark_unsaferow_format) {
-        // For UnsafeRow opt, str_start_offset is the nullbitmap size
+        // Notice that for UnsafeRowOpt str_start_offset should be passed as the nullbitmap size
         const uint32_t bitmap_size = str_start_offset;
         const int8_t* row_with_col_offset = row + HEADER_LENGTH + bitmap_size + col_idx * 8;
 

--- a/hybridse/src/codec/type_codec.cc
+++ b/hybridse/src/codec/type_codec.cc
@@ -84,14 +84,11 @@ int32_t GetStrFieldUnsafe(const int8_t* row, uint32_t col_idx,
 
     // Support Spark UnsafeRow format
     if (FLAGS_enable_spark_unsaferow_format) {
-        // Notice that for UnsafeRowOpt str_start_offset should be passed as the nullbitmap size
-        const uint32_t bitmap_size = str_start_offset;
-        const int8_t* row_with_col_offset = row + HEADER_LENGTH + bitmap_size + col_idx * 8;
+        // Notice that for UnsafeRowOpt field_offset should be the actual offset of string column
 
-        // For Spark UnsafeRow, the first 32 bits is for length and the last
-        // 32 bits is for offset.
-        *size = *(reinterpret_cast<const uint32_t*>(row_with_col_offset));
-        uint32_t str_value_offset = *(reinterpret_cast<const uint32_t*>(row_with_col_offset + 4)) + HEADER_LENGTH;
+        // For Spark UnsafeRow, the first 32 bits is for length and the last 32 bits is for offset.
+        *size = *(reinterpret_cast<const uint32_t*>(row + field_offset));
+        uint32_t str_value_offset = *(reinterpret_cast<const uint32_t*>(row + field_offset + 4)) + HEADER_LENGTH;
         *data = reinterpret_cast<const char*>(row + str_value_offset);
 
         return 0;

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/OpenmldbBatchConfig.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/OpenmldbBatchConfig.scala
@@ -122,6 +122,12 @@ class OpenmldbBatchConfig extends Serializable {
   @ConfigOption(name = "openmldb.unsaferow.opt", doc = "Enable UnsafeRow optimization or not")
   var enableUnsafeRowOptimization = false
 
+  @ConfigOption(name = "openmldb.opt.unsaferow.project", doc = "Enable UnsafeRow optimization for project")
+  var enableUnsafeRowOptForProject = false
+
+  @ConfigOption(name = "openmldb.opt.unsaferow.window", doc = "Enable UnsafeRow optimization for window")
+  var enableUnsafeRowOptForWindow = false
+
   // Switch for disable OpenMLDB
   @ConfigOption(name = "openmldb.disable", doc = "Disable OpenMLDB optimization or not")
   var disableOpenmldb = false

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/OpenmldbBatchConfig.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/OpenmldbBatchConfig.scala
@@ -128,6 +128,12 @@ class OpenmldbBatchConfig extends Serializable {
   @ConfigOption(name = "openmldb.opt.unsaferow.window", doc = "Enable UnsafeRow optimization for window")
   var enableUnsafeRowOptForWindow = false
 
+  @ConfigOption(name = "openmldb.opt.unsaferow.groupby", doc = "Enable UnsafeRow optimization for groupby")
+  var enableUnsafeRowOptForGroupby = false
+
+  @ConfigOption(name = "openmldb.opt.unsaferow.join", doc = "Enable UnsafeRow optimization for join")
+  var enableUnsafeRowOptForJoin = false
+
   // Switch for disable OpenMLDB
   @ConfigOption(name = "openmldb.disable", doc = "Disable OpenMLDB optimization or not")
   var disableOpenmldb = false

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/RowProjectPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/RowProjectPlan.scala
@@ -71,7 +71,7 @@ object RowProjectPlan {
 
     val openmldbJsdkLibraryPath = ctx.getConf.openmldbJsdkLibraryPath
 
-    val outputDf = if (ctx.getConf.enableUnsafeRowOptimization) { // Use UnsafeRow optimization
+    val outputDf = if (ctx.getConf.enableUnsafeRowOptForProject) { // Use UnsafeRow optimization
 
       val outputInternalRowRdd = inputDf.queryExecution.toRdd.mapPartitions(partitionIter => {
         val tag = projectConfig.moduleTag

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/WindowAggPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/WindowAggPlan.scala
@@ -54,7 +54,7 @@ object WindowAggPlan {
     // Check if we should keep the index column
     val isKeepIndexColumn = SparkInstance.keepIndexColumn(ctx, physicalNode.GetNodeId())
     // Check if use UnsafeRow optimizaiton or not
-    val isUnsafeRowOptimization = ctx.getConf.enableUnsafeRowOptimization
+    val isUnsafeRowOptimization = ctx.getConf.enableUnsafeRowOptForWindow
     // Check if we should keep the index column
     val isWindowSkewOptimization = ctx.getConf.enableWindowSkewOpt
 

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/unsafe/TestUnsafeGroupby.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/unsafe/TestUnsafeGroupby.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 4Paradigm
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com._4paradigm.openmldb.batch.end2end.unsafe
+
+import com._4paradigm.openmldb.batch.SparkTestSuite
+import com._4paradigm.openmldb.batch.api.OpenmldbSession
+import com._4paradigm.openmldb.batch.end2end.DataUtil
+import com._4paradigm.openmldb.batch.utils.SparkUtil
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+
+class TestUnsafeGroupby extends SparkTestSuite {
+
+  override def customizedBefore(): Unit = {
+    val spark = getSparkSession
+    spark.conf.set("spark.openmldb.unsaferow.opt", true)
+  }
+
+  test("Test unsafe groupby") {
+    val spark = getSparkSession
+    val sess = new OpenmldbSession(spark)
+
+    val df = DataUtil.getTestDf(spark)
+    sess.registerTable("t1", df)
+    df.createOrReplaceTempView("t1")
+
+    val sqlText = "SELECT max(id) AS max_id, sum(trans_amount) AS sum_amount FROM t1 GROUP BY name"
+
+    val outputDf = sess.sql(sqlText)
+    val sparksqlOutputDf = sess.sparksql(sqlText)
+    assert(SparkUtil.approximateDfEqual(outputDf.getSparkDf(), sparksqlOutputDf, false))
+  }
+
+  override def customizedAfter(): Unit = {
+    val spark = getSparkSession
+    spark.conf.set("spark.openmldb.unsaferow.opt", false)
+  }
+
+}

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/unsafe/TestUnsafeJoin.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/unsafe/TestUnsafeJoin.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 4Paradigm
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com._4paradigm.openmldb.batch.end2end.unsafe
+
+import com._4paradigm.openmldb.batch.SparkTestSuite
+import com._4paradigm.openmldb.batch.api.OpenmldbSession
+import com._4paradigm.openmldb.batch.end2end.DataUtil
+import com._4paradigm.openmldb.batch.utils.SparkUtil
+
+class TestUnsafeJoin extends SparkTestSuite {
+
+  override def customizedBefore(): Unit = {
+    val spark = getSparkSession
+    spark.conf.set("spark.openmldb.unsaferow.opt", true)
+  }
+
+  test("Test unsafe join") {
+    val spark = getSparkSession
+    val sess = new OpenmldbSession(spark)
+
+    val df = DataUtil.getTestDf(spark)
+    sess.registerTable("t1", df)
+    sess.registerTable("t2", df)
+    df.createOrReplaceTempView("t1")
+    df.createOrReplaceTempView("t2")
+
+    val sqlText = "SELECT t1.id as t1_id, t2.id as t2_id, t1.name FROM t1 LEFT JOIN t2 ON t1.id = t2.id"
+
+    val outputDf = sess.sql(sqlText)
+    val sparksqlOutputDf = sess.sparksql(sqlText)
+    assert(SparkUtil.approximateDfEqual(outputDf.getSparkDf(), sparksqlOutputDf, false))
+  }
+
+  override def customizedAfter(): Unit = {
+    val spark = getSparkSession
+    spark.conf.set("spark.openmldb.unsaferow.opt", false)
+  }
+
+}


### PR DESCRIPTION
* Resolve https://github.com/4paradigm/OpenMLDB/issues/1348 .
* Add new offline configs to enable UnsafeRowOpt for project, window, groupby or join .
* Add UT for groupby with UnsafeRowOpt.
* Add UT for join with UnsafeRowOpt.

Now we can enable UnsafeRowOpt which will use UnsafeRow memory layout when using Spark internal row or previous codec row. This means that GroupbyPlan which does not support internal row as input and use previous codec can work for UnsafeRowOpt.