### PR TITLE
fix: scala coverage report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ coverage-cpp: coverage-configure
 coverage-java: coverage-configure
 	$(CMAKE_PRG) --build $(OPENMLDB_BUILD_DIR) --target cp_native_so -- -j$(NPROC)
 	cd java && ./mvnw --batch-mode prepare-package
+	cd java && ./mvnw --batch-mode clean scoverage:report
 
 coverage-configure:
 	$(MAKE) configure COVERAGE_ENABLE=ON CMAKE_BUILD_TYPE=Debug SQL_JAVASDK_ENABLE=ON TESTING_ENABLE=ON
@@ -167,7 +168,7 @@ thirdpartysrc-clean:
 HYBRIDSE_BUILD_DIR := $(MAKEFILE_DIR)/hybridse/build
 HYBRIDSE_INSTALL_DIR := $(THIRD_PARTY_DIR)/hybridse
 
-.PHONY: hybridse hybridse-build hybridse-test hybridse-configure hybridse-coverage hybridse-coverage-configure hybridse-clean
+.PHONY: hybridse hybridse-build hybridse-test hybridse-configure hybridse-clean
 
 # hybridse* target reserved for those like to compile in the old way
 hybridse: hybridse-build
@@ -183,13 +184,6 @@ hybridse-build: hybridse-configure
 
 hybridse-configure: thirdparty-fast
 	$(CMAKE_PRG) -S hybridse -B $(HYBRIDSE_BUILD_DIR) -DCMAKE_PREFIX_PATH=$(THIRD_PARTY_DIR) -DCMAKE_INSTALL_PREFIX=$(HYBRIDSE_INSTALL_DIR) $(HYBRIDSE_CMAKE_FLAGS) $(CMAKE_EXTRA_FLAGS)
-
-hybridse-coverage: hybridse-coverage-configure
-	$(CMAKE_PRG) --build $(HYBRIDSE_BUILD_DIR) -- -j$(NPROC)
-	$(CMAKE_PRG) --build $(HYBRIDSE_BUILD_DIR) --target coverage -- -j$(NPROC) SQL_CASE_BASE_DIR=$(SQL_CASE_BASE_DIR) YAML_CASE_BASE_DIR=$(SQL_CASE_BASE_DIR)
-
-hybridse-coverage-configure:
-	$(MAKE) hybridse-configure CMAKE_BUILD_TYPE=Debug COVERAGE_ENABLE=ON
 
 hybridse-clean:
 	rm -rf "$(HYBRIDSE_BUILD_DIR)"

--- a/java/openmldb-batch/pom.xml
+++ b/java/openmldb-batch/pom.xml
@@ -96,24 +96,24 @@
 			<version>3.0.0</version>
 			<scope>test</scope>
 		</dependency>
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <version>6.14.3</version>
-            <scope>test</scope>
-        </dependency>
+		<dependency>
+			<groupId>org.testng</groupId>
+			<artifactId>testng</artifactId>
+			<version>6.14.3</version>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.openjdk.jmh</groupId>
 			<artifactId>jmh-core</artifactId>
 			<version>1.19</version>
 			<scope>provided</scope>
 		</dependency>
-        <dependency>
-            <groupId>org.openjdk.jmh</groupId>
-            <artifactId>jmh-generator-annprocess</artifactId>
-            <version>1.19</version>
-            <scope>provided</scope>
-        </dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-generator-annprocess</artifactId>
+			<version>1.19</version>
+			<scope>provided</scope>
+		</dependency>
 
 		<!-- Use for draw graph with graphviz -->
 		<dependency>
@@ -228,11 +228,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.7.0</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -248,38 +243,6 @@
 			<plugin>
 				<groupId>net.alchim31.maven</groupId>
 				<artifactId>scala-maven-plugin</artifactId>
-				<version>3.2.1</version>
-				<configuration>
-					<scalaCompatVersion>${scala.binary.version}</scalaCompatVersion>
-					<scalaVersion>${scala.version}</scalaVersion>
-					<jvmArgs>
-						<jvmArg>-Xms2048m</jvmArg>
-						<jvmArg>-Xmx2048m</jvmArg>
-					</jvmArgs>
-					<args>
-						<arg>-deprecation</arg>
-						<arg>-feature</arg>
-						<arg>-g:vars</arg>
-					</args>
-				</configuration>
-				<executions>
-					<execution>
-						<id>add-source</id>
-						<phase>pre-site</phase>
-						<goals>
-							<goal>add-source</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>scala-compile-first</id>
-						<phase>process-resources</phase>
-						<goals>
-							<goal>add-source</goal>
-							<goal>compile</goal>
-							<goal>testCompile</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.scalatest</groupId>
@@ -409,36 +372,6 @@
 						<goals>
 							<goal>check</goal>
 						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.6</version>
-				<executions>
-					<execution>
-						<id>prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>report</id>
-						<phase>prepare-package</phase>
-						<goals>
-							<goal>report</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>post-unit-test</id>
-						<phase>test</phase>
-						<goals>
-							<goal>report</goal>
-						</goals>
-						<configuration>
-							<dataFile>target/jacoco.exec</dataFile>
-						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/java/openmldb-batchjob/pom.xml
+++ b/java/openmldb-batchjob/pom.xml
@@ -88,10 +88,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
       </plugin>
 
       <plugin>
@@ -115,38 +111,6 @@
         <configuration>
           <!-- <forkMode>never</forkMode> -->
         </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.2.0</version>
-        <executions>
-          <execution>
-            <id>add-source</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>add-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-                <source>src/main/scala</source>
-              </sources>
-            </configuration>
-          </execution>
-          <execution>
-            <id>add-test-source</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>add-test-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-                <source>src/test/scala</source>
-              </sources>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
 
       <!-- Use shade when the dependencies are not in cluster, package from 10k to 31M -->

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -16,10 +16,10 @@
         <module>openmldb-native</module>
         <module>openmldb-common</module>
 
+        <module>openmldb-spark-connector</module>
+        <module>openmldb-batch</module>
         <module>openmldb-batchjob</module>
         <module>openmldb-taskmanager</module>
-        <module>openmldb-batch</module>
-        <module>openmldb-spark-connector</module>
     </modules>
     <description>OpenMLDB is an open-source database that is designed and optimized to enable data integrity and efficiency for machine learning driven applications. In addition to 10x faster ML application landing experience, OpenMLDB provides unified computing and storage engines to reduce the complexity and cost of development and operation.</description>
     <url>https://github.com/4paradigm/OpenMLDB</url>
@@ -106,11 +106,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
             <plugin>
-                <!-- scala's code coverage plugin -->
-                <groupId>org.scoverage</groupId>
-                <artifactId>scoverage-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <!-- bundle git info into jar -->
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
@@ -139,6 +134,11 @@
                 <!-- code coverage reports generator for Java projects -->
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <!-- scala's code coverage plugin -->
+                <groupId>org.scoverage</groupId>
+                <artifactId>scoverage-maven-plugin</artifactId>
             </plugin>
 
         </plugins>
@@ -169,18 +169,18 @@
               <artifactId>jacoco-maven-plugin</artifactId>
               <version>0.8.7</version>
               <executions>
-                <execution>
-                  <goals>
-                    <goal>prepare-agent</goal>
-                  </goals>
-                </execution>
-                <execution>
-                  <id>report</id>
-                  <phase>prepare-package</phase>
-                  <goals>
-                    <goal>report</goal>
-                  </goals>
-                </execution>
+                  <execution>
+                      <goals>
+                          <goal>prepare-agent</goal>
+                      </goals>
+                  </execution>
+                  <execution>
+                      <id>report</id>
+                      <phase>prepare-package</phase>
+                      <goals>
+                          <goal>report</goal>
+                      </goals>
+                  </execution>
               </executions>
             </plugin>
                 <plugin>
@@ -206,7 +206,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.7.0</version>
+                    <version>3.8.1</version>
                     <configuration>
                         <source>1.8</source>
                         <target>1.8</target>
@@ -231,20 +231,20 @@
                     <groupId>org.scoverage</groupId>
                     <artifactId>scoverage-maven-plugin</artifactId>
                     <version>1.4.11</version>
-                    <executions>
-                        <execution>
-                            <id>scoverage-report</id>
-                            <phase>prepare-package</phase>
-                            <goals>
-                                <goal>report</goal> <!-- or integration-check -->
-                            </goals>
-                        </execution>
-                    </executions>
+                    <!-- <executions> -->
+                    <!--     <execution> -->
+                    <!--         <id>scoverage-report</id> -->
+                    <!--         <phase>prepare-package</phase> -->
+                    <!--         <goals> -->
+                    <!--             <goal>report</goal> -->
+                    <!--         </goals> -->
+                    <!--     </execution> -->
+                    <!-- </executions> -->
                 </plugin>
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>4.5.6</version>
                 <configuration>
                     <scalaCompatVersion>${scala.binary.version}</scalaCompatVersion>
                     <scalaVersion>${scala.version}</scalaVersion>
@@ -255,10 +255,17 @@
                     <args>
                         <arg>-deprecation</arg>
                         <arg>-feature</arg>
+                        <arg>-g:vars</arg>
                     </args>
                 </configuration>
                 <executions>
-                    <!-- process mixed compilation of java and scala files -->
+                    <execution>
+                        <id>add-source</id>
+                        <phase>pre-site</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                    </execution>
                     <execution>
                         <id>scala-compile-first</id>
                         <phase>process-resources</phase>


### PR DESCRIPTION
This PR fix or partial fix a few issues related with coverage task in maven, I'm trying to understand the reason and give a little refactor here, but maybe I'm still not fully correctly. So have a extra check ~

1. close #1375, can tell why we break it , so I give a little refactor on `scala-maven-plugin`, reorder the goals used in `scal-maven-plugin`, which mostly based on the example in https://davidb.github.io/scala-maven-plugin/example_java.html


2. resolve (or temporally) #989, the reason is `scoverage` has kind conflict with `maven-scalatest & jacoco` ( see https://github.com/scoverage/scoverage-maven-plugin/issues/61). The PR resolve this by removing `scoverage:report` goal in the default `prepare-package` phase, so in the maven lifecycle `scoverage` won't invoke. Instead, we have to run `mvn scoverage:report` manually in order to get Scala related coverage report. 