### PR TITLE
fix: move CMAKE_PREFIX_PATH def to the top

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,10 @@ set(OPENMLDB_VERSION_MAJOR 0)
 set(OPENMLDB_VERSION_MINOR 5)
 set(OPENMLDB_VERSION_BUG 0)
 
+if (NOT DEFINED CMAKE_PREFIX_PATH)
+    set(CMAKE_PREFIX_PATH ${CMAKE_SOURCE_DIR}/.deps/usr)
+endif()
+
 function(get_commitid CODE_DIR COMMIT_ID)
     find_package(Git REQUIRED)
     execute_process(
@@ -138,10 +142,6 @@ if (COVERAGE_ENABLE)
     include(CodeCoverage)
     APPEND_COVERAGE_COMPILER_FLAGS()
 endif ()
-
-if (NOT DEFINED CMAKE_PREFIX_PATH)
-    set(CMAKE_PREFIX_PATH ${CMAKE_SOURCE_DIR}/.deps/usr)
-endif()
 
 if (DEFINED ENV{CI})
   # suppress useless maven log (e.g download log) on CI environment


### PR DESCRIPTION

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix



* **What is the current behavior?** (You can also link to an open issue here)
If run `cmake` directly, some libraries cannot be found, because `CMAKE_PREFIX_PATH` is set after `find_package`/`find_library`


