### PR TITLE
chore: enhance like predicate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,10 @@ if (MAC_TABLET_ENABLE)
     add_compile_definitions(__mac_tablet__=1)
 endif ()
 
+if (NOT DEFINED CMAKE_PREFIX_PATH)
+    set(CMAKE_PREFIX_PATH ${CMAKE_SOURCE_DIR}/.deps/usr)
+endif()
+
 find_package(OpenSSL REQUIRED)
 find_library(BRPC_LIBRARY brpc)
 find_library(PROTOBUF_LIBRARY protobuf)
@@ -138,10 +142,6 @@ if (COVERAGE_ENABLE)
     include(CodeCoverage)
     APPEND_COVERAGE_COMPILER_FLAGS()
 endif ()
-
-if (NOT DEFINED CMAKE_PREFIX_PATH)
-    set(CMAKE_PREFIX_PATH ${CMAKE_SOURCE_DIR}/.deps/usr)
-endif()
 
 if (DEFINED ENV{CI})
   # suppress useless maven log (e.g download log) on CI environment

--- a/hybridse/src/codegen/expr_ir_builder.cc
+++ b/hybridse/src/codegen/expr_ir_builder.cc
@@ -833,7 +833,7 @@ Status ExprIRBuilder::BuildLikeExprAsUdf(const ::hybridse::node::BinaryExpr* exp
 
     // target node
     const auto target_node = expr->GetChild(0);
-    auto arg_0 = nm->MakeExprIdNode("proxy_arg_1");
+    auto arg_0 = nm->MakeExprIdNode("proxy_arg_0");
     arg_0->SetOutputType(target_node->GetOutputType());
     arg_0->SetNullable(target_node->nullable());
     proxy_args.push_back(arg_0);

--- a/hybridse/src/codegen/expr_ir_builder_test.cc
+++ b/hybridse/src/codegen/expr_ir_builder_test.cc
@@ -987,6 +987,23 @@ TEST_F(ExprIRBuilderTest, TestInExprNotSupport) {
     ExprErrorCheck<bool, codec::StringRef, codec::StringRef>(in_expr);
 }
 
+TEST_F(ExprIRBuilderTest, LikeExpr) {
+    auto assert_like = [&](const udf::Nullable<bool> &ret, const udf::Nullable<codec::StringRef> &lhs,
+                           const udf::Nullable<codec::StringRef> &rhs) {
+        ExprCheck([](node::NodeManager *nm, node::ExprNode *lhs,
+                     node::ExprNode *rhs) { return nm->MakeBinaryExprNode(lhs, rhs, node::FnOperator::kFnOpLike); },
+                  ret, lhs, rhs);
+    };
+
+
+    assert_like(true, "abc", "abc");
+    assert_like(false, "abc", "def");
+    assert_like(true, "abc", "a_c");
+    assert_like(false, "a_c", "abc");
+    assert_like(true, "Mary", "M%");
+    assert_like(false, "Mary", "m%");
+}
+
 }  // namespace codegen
 }  // namespace hybridse
 

--- a/hybridse/src/udf/literal_traits.h
+++ b/hybridse/src/udf/literal_traits.h
@@ -72,6 +72,7 @@ template <>
 struct Nullable<StringRef> {
     Nullable(std::nullptr_t) : data_(""), is_null_(true) {}      // NOLINT
     Nullable(const StringRef& t) : data_(t), is_null_(false) {}  // NOLINT
+    Nullable(const char* buf) : data_(buf), is_null_(false) {}    // NOLINT
     Nullable() : is_null_(false) {}
 
     const StringRef& value() const { return data_; }


### PR DESCRIPTION
- build: resolve compile on darwin by move `CMAKE_PREFIX_PATH` before `find_package`s
- add a explicit constructor for `Nullable<StringRef>(const char*)`, so it is possialb to write `Nullable<StringRef>` as 
 `"abc"` instead `StringRef("abc")`, which may help reduce key strokes
- chore(codegen): fix a arg name for like expr & add a few ExprIR test for LIKE predicate