### PR TITLE
build(maven): reserve jacoco report after execute scoverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,10 +92,11 @@ coverage: coverage-cpp coverage-java
 coverage-cpp: coverage-configure
 	$(CMAKE_PRG) --build $(OPENMLDB_BUILD_DIR) --target coverage -- -j$(NPROC) SQL_CASE_BASE_DIR=$(SQL_CASE_BASE_DIR) YAML_CASE_BASE_DIR=$(SQL_CASE_BASE_DIR)
 
+# scoverage may conflicts with jacoco, so we run it separately
 coverage-java: coverage-configure
 	$(CMAKE_PRG) --build $(OPENMLDB_BUILD_DIR) --target cp_native_so -- -j$(NPROC)
 	cd java && ./mvnw --batch-mode prepare-package
-	cd java && ./mvnw --batch-mode clean scoverage:report
+	cd java && ./mvnw --batch-mode scoverage:report
 
 coverage-configure:
 	$(MAKE) configure COVERAGE_ENABLE=ON CMAKE_BUILD_TYPE=Debug SQL_JAVASDK_ENABLE=ON TESTING_ENABLE=ON

--- a/java/openmldb-batch/pom.xml
+++ b/java/openmldb-batch/pom.xml
@@ -324,7 +324,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-site-plugin</artifactId>
-				<version>3.9.1</version>
 			</plugin>
 
 			<!-- Check Java style -->
@@ -407,7 +406,6 @@
 			<plugin>
 				<groupId>com.github.spotbugs</groupId>
 				<artifactId>spotbugs-maven-plugin</artifactId>
-				<version>4.2.2</version>
 				<configuration>
 					<excludeFilterFile>spotbugs-exclude.xml</excludeFilterFile>
 					<failOnError>true</failOnError>
@@ -415,7 +413,7 @@
 				</configuration>
 				<executions>
 					<execution>
-						<phase>package</phase>
+						<phase>prepare-package</phase>
 						<goals>
 							<goal>check</goal>
 						</goals>
@@ -443,22 +441,5 @@
 		</pluginManagement>
 	</build>
 
-	<reporting>
-		<plugins>
-			<!-- Generate report for jacoco -->
-			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<reportSets>
-					<reportSet>
-						<reports>
-							<report>report</report>
-						</reports>
-					</reportSet>
-				</reportSets>
-			</plugin>
-
-		</plugins>
-	</reporting>
-
+	<!-- use the same reporting in parent pom -->
 </project>

--- a/java/openmldb-batchjob/pom.xml
+++ b/java/openmldb-batchjob/pom.xml
@@ -174,15 +174,6 @@
           <artifactId>maven-deploy-plugin</artifactId>
           <version>2.8.2</version>
         </plugin>
-        <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
-        <plugin>
-          <artifactId>maven-site-plugin</artifactId>
-          <version>3.7.1</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>3.0.0</version>
-        </plugin>
 
       </plugins>
     </pluginManagement>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -68,6 +68,9 @@
         <plugin.violationSeverity>error</plugin.violationSeverity>
         <spotless-maven-plugin.version>2.9.0</spotless-maven-plugin.version>
         <eclipse.jdt.version>4.13.0</eclipse.jdt.version>
+        <scoverage.plugin.version>1.4.11</scoverage.plugin.version>
+        <surefire.plugin.version>3.0.0-M5</surefire.plugin.version>
+        <jacoco.plugin.version>0.8.7</jacoco.plugin.version>
     </properties>
 
     <dependencies>
@@ -167,7 +170,7 @@
             <plugin>
               <groupId>org.jacoco</groupId>
               <artifactId>jacoco-maven-plugin</artifactId>
-              <version>0.8.7</version>
+              <version>${jacoco.plugin.version}</version>
               <executions>
                   <execution>
                       <goals>
@@ -215,9 +218,10 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M5</version>
+                    <version>${surefire.plugin.version}</version>
                     <configuration>
                       <reuseForks>false</reuseForks>
+                      <!-- forkCount > 0 and argLine required to work well with jacoco -->
                       <forkCount>1</forkCount>
                       <argLine>@{argLine} -Xmx4G</argLine>
                     </configuration>
@@ -230,16 +234,7 @@
                 <plugin>
                     <groupId>org.scoverage</groupId>
                     <artifactId>scoverage-maven-plugin</artifactId>
-                    <version>1.4.11</version>
-                    <!-- <executions> -->
-                    <!--     <execution> -->
-                    <!--         <id>scoverage-report</id> -->
-                    <!--         <phase>prepare-package</phase> -->
-                    <!--         <goals> -->
-                    <!--             <goal>report</goal> -->
-                    <!--         </goals> -->
-                    <!--     </execution> -->
-                    <!-- </executions> -->
+                    <version>${scoverage.plugin.version}</version>
                 </plugin>
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
@@ -397,10 +392,15 @@
                     <injectAllReactorProjects>true</injectAllReactorProjects>
                   </configuration>
                 </plugin>
+                <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.9.1</version>
+                    <version>3.11.0</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-project-info-reports-plugin</artifactId>
+                    <version>3.2.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -427,7 +427,40 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.2.2</version>
+                <version>4.5.3.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-report-plugin</artifactId>
+                <version>${surefire.plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.plugin.version}</version>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>report</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+            <plugin>
+                <groupId>org.scoverage</groupId>
+                <artifactId>scoverage-maven-plugin</artifactId>
+                <version>${scoverage.plugin.version}</version>
+                <configuration>
+                    <!-- additionally generate aggregated SCoverage report for root module -->
+                    <aggregate>true</aggregate>
+                </configuration>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>report</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
             </plugin>
         </plugins>
     </reporting>


### PR DESCRIPTION
- the PR bring the jacoco coverage report back in #1390 
- make a little refactor over site lifecycle 
- as for now, `scoverage:report`  won't run in the default maven lifecycle, closing #989