### PR TITLE
fix: print import rows count after finished

### DIFF
--- a/java/openmldb-import/src/main/java/com/_4paradigm/openmldb/importer/Importer.java
+++ b/java/openmldb-import/src/main/java/com/_4paradigm/openmldb/importer/Importer.java
@@ -209,16 +209,20 @@ public class Importer {
         reader.enableCheckHeader(tableMetaData);
         try {
             CSVRecord record;
+            int lines = 0;
             while ((record = reader.next()) != null) {
+                lines++;
+                // integer gets added at the start of iteration for each line. 
                 Map<Integer, List<Tablet.Dimension>> dims = buildDimensions(record, keyIndexMap, tableMetaData.getPartitionNum());
-
                 // distribute the row to the bulk load generators for each MemTable(tid, pid)
                 for (Integer pid : dims.keySet()) {
                     // Note: NS pid is int
                     // no need to calc dims twice, pass it to BulkLoadGenerator
                     generators.get(pid).feed(new BulkLoadGenerator.FeedItem(dims, tsIdxSet, record));
-                }
+                }    
             }
+            System.out.println(lines);
+            // after while loop is finished, print out number of lines gone through.
         } catch (Exception e) {
             logger.error("feeding failed, {}", e.getMessage());
         }

--- a/java/openmldb-import/src/main/java/com/_4paradigm/openmldb/importer/Importer.java
+++ b/java/openmldb-import/src/main/java/com/_4paradigm/openmldb/importer/Importer.java
@@ -211,7 +211,7 @@ public class Importer {
             CSVRecord record;
             int lines = 0;
             while ((record = reader.next()) != null) {
-                // integer gets added at the start of iteration for each line. 
+                // integer gets added at the start of iteration for each line.
                 lines++;
                 Map<Integer, List<Tablet.Dimension>> dims = buildDimensions(record, keyIndexMap, tableMetaData.getPartitionNum());
                 // distribute the row to the bulk load generators for each MemTable(tid, pid)
@@ -219,7 +219,7 @@ public class Importer {
                     // Note: NS pid is int
                     // no need to calc dims twice, pass it to BulkLoadGenerator
                     generators.get(pid).feed(new BulkLoadGenerator.FeedItem(dims, tsIdxSet, record));
-                }    
+                }
             }
             System.out.println("Total read rows: " + lines);
             // after while loop is finished, print out number of lines gone through.

--- a/java/openmldb-import/src/main/java/com/_4paradigm/openmldb/importer/Importer.java
+++ b/java/openmldb-import/src/main/java/com/_4paradigm/openmldb/importer/Importer.java
@@ -211,8 +211,8 @@ public class Importer {
             CSVRecord record;
             int lines = 0;
             while ((record = reader.next()) != null) {
-                lines++;
                 // integer gets added at the start of iteration for each line. 
+                lines++;
                 Map<Integer, List<Tablet.Dimension>> dims = buildDimensions(record, keyIndexMap, tableMetaData.getPartitionNum());
                 // distribute the row to the bulk load generators for each MemTable(tid, pid)
                 for (Integer pid : dims.keySet()) {
@@ -221,7 +221,7 @@ public class Importer {
                     generators.get(pid).feed(new BulkLoadGenerator.FeedItem(dims, tsIdxSet, record));
                 }    
             }
-            System.out.println(lines);
+            System.out.println("Total read rows: " + lines);
             // after while loop is finished, print out number of lines gone through.
         } catch (Exception e) {
             logger.error("feeding failed, {}", e.getMessage());


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- The commit message follows our guidelines
- Tests for the changes have been added (for bug fixes / features)
- Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

-fix that allows importer to know number of rows read. Resolve #1327


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**




* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
