### PR TITLE
fix: 1295 udaf default value for `min_where` and `max_where`

### DIFF
--- a/.github/workflows/hybridse-ci.yml
+++ b/.github/workflows/hybridse-ci.yml
@@ -18,6 +18,7 @@ on:
 env:
   HYBRIDSE_PATH: hybridse
   CTEST_PARALLEL_LEVEL: 2 # parallel test level for ctest (make test)
+  CTEST_OUTPUT_ON_FAILURE: ON
   NPROC: 2 # default Parallel build number for GitHub's Linux runner
 
 jobs:

--- a/cases/function/function/test_udaf_function.yaml
+++ b/cases/function/function/test_udaf_function.yaml
@@ -307,10 +307,11 @@ cases:
         columns : ["id int","c1 string","c2 smallint","c3 int","c4 bigint","c5 float","c6 double","c7 timestamp","c8 date","c9 string","c10 bool"]
         indexs: ["index1:c1:c7"]
         rows:
-          - [1,"aa",1,1,30,1.1,2.1,1590738990000,"2020-05-01","a",true]
-          - [2,"aa",4,4,33,1.4,2.4,1590738991000,"2020-05-03","c",false]
-          - [3,"aa",3,3,32,1.3,2.3,1590738992000,"2020-05-02","b",true]
-          - [4,"aa",NULL,NULL,NULL,NULL,NULL,1590738993000,NULL,NULL,NULL]
+          - [0, "00", 5, 3, 10, 1.0, 4.4, 1590738990000, "2020-05-01", "a", false]
+          - [1, "aa", 1, 1, 30, 1.1, 2.1, 1590738990000, "2020-05-01", "a", true]
+          - [2, "aa", 4, 4, 33, 1.4, 2.4, 1590738991000, "2020-05-03", "c", false]
+          - [3, "aa", 3, 3, 32, 1.3, 2.3, 1590738992000, "2020-05-02", "b", true]
+          - [4, "aa", NULL,NULL,NULL,NULL,NULL,1590738993000,NULL,NULL,NULL]
     sql: |
       SELECT {0}.id, c1, max_where(c2,c2<4) OVER w1 as m2,max_where(c3,c3<4) OVER w1 as m3,max_where(c4,c10) OVER w1 as m4,max_where(c5,c5<=1.3) OVER w1 as m5,max_where(c6,c6<=2.3) OVER w1 as m6 FROM {0} WINDOW
       w1 AS (PARTITION BY {0}.c1 ORDER BY {0}.c7 ROWS BETWEEN 2 PRECEDING AND CURRENT ROW);
@@ -318,6 +319,7 @@ cases:
       order: id
       columns: ["id int","c1 string","m2 smallint","m3 int","m4 bigint","m5 float","m6 double"]
       rows:
+        - [0,"00",NULL,3,NULL,1.0,NULL]
         - [1,"aa",1,1,30,1.1,2.1]
         - [2,"aa",1,1,30,1.1,2.1]
         - [3,"aa",3,3,32,1.3,2.3]
@@ -342,7 +344,7 @@ cases:
       order: id
       columns: ["id int","c1 string","m2 smallint","m3 int","m4 bigint","m5 float","m6 double"]
       rows:
-        - [1,"aa",32767,2147483647,30,1.1,2.1]
+        - [1,"aa",NULL,NULL,30,1.1,2.1]
         - [2,"aa",4,4,30,1.1,2.1]
         - [3,"aa",3,3,30,1.1,2.1]
         - [4,"aa",3,3,32,1.3,2.3]

--- a/hybridse/src/udf/default_udf_library.cc
+++ b/hybridse/src/udf/default_udf_library.cc
@@ -378,8 +378,7 @@ struct MinWhereDef {
     void operator()(UdafRegistryHelper& helper) {  // NOLINT
         helper.templates<T, Tuple<bool, T>, T, bool>()
             .const_init(MakeTuple(true, DataTypeTrait<T>::maximum_value()))
-            .update([](UdfResolveContext* ctx, ExprNode* acc, ExprNode* elem,
-                       ExprNode* cond) {
+            .update([](UdfResolveContext* ctx, ExprNode* acc, ExprNode* elem, ExprNode* cond) {
                 auto nm = ctx->node_manager();
                 if (elem->GetOutputType()->base() == node::kTimestamp) {
                     elem = nm->MakeCastNode(node::kInt64, elem);
@@ -397,10 +396,10 @@ struct MinWhereDef {
             })
             .output([](UdfResolveContext* ctx, ExprNode* acc) {
                 auto nm = ctx->node_manager();
-                auto flag = nm->MakeGetFieldExpr(acc, 0);
-                auto cur_max = nm->MakeGetFieldExpr(acc, 1);
-                return nm->MakeCondExpr(flag, nm->MakeCastNode(DataTypeTrait<T>::to_type_enum(), nm->MakeConstNode()),
-                                        cur_max);
+                auto is_null = nm->MakeGetFieldExpr(acc, 0);
+                auto val = nm->MakeGetFieldExpr(acc, 1);
+                return nm->MakeCondExpr(is_null,
+                                        nm->MakeCastNode(DataTypeTrait<T>::to_type_enum(), nm->MakeConstNode()), val);
             });
     }
 };
@@ -428,10 +427,10 @@ struct MaxWhereDef {
             })
             .output([](UdfResolveContext* ctx, ExprNode* acc) {
                 auto nm = ctx->node_manager();
-                auto flag = nm->MakeGetFieldExpr(acc, 0);
-                auto cur_max = nm->MakeGetFieldExpr(acc, 1);
-                return nm->MakeCondExpr(flag, nm->MakeCastNode(DataTypeTrait<T>::to_type_enum(), nm->MakeConstNode()),
-                                        cur_max);
+                auto is_null = nm->MakeGetFieldExpr(acc, 0);
+                auto val = nm->MakeGetFieldExpr(acc, 1);
+                return nm->MakeCondExpr(is_null,
+                                        nm->MakeCastNode(DataTypeTrait<T>::to_type_enum(), nm->MakeConstNode()), val);
             });
     }
 };

--- a/hybridse/src/udf/udaf_test.cc
+++ b/hybridse/src/udf/udaf_test.cc
@@ -162,7 +162,7 @@ TEST_F(UdafTest, avg_where_test_3) {
         "avg_where", 0.0 / 0, MakeList<int32_t>({}), MakeBoolList({}));
 }
 
-TEST_F(UdafTest, min_where_test) {
+TEST_F(UdafTest, MinWhereTest) {
     CheckUdf<int32_t, ListRef<int32_t>, ListRef<bool>>(
         "min_where", 4, MakeList<int32_t>({4, 5, 6}),
         MakeBoolList({true, false, true}));
@@ -171,8 +171,22 @@ TEST_F(UdafTest, min_where_test) {
         "min_where", 7, MakeList<Nullable<int32_t>>({7, 5, 4, 8}),
         MakeList<Nullable<bool>>({true, false, nullptr, true}));
 
-    CheckUdf<int32_t, ListRef<int32_t>, ListRef<bool>>(
-        "min_where", 2147483647, MakeList<int32_t>({}), MakeBoolList({}));
+    // NULL if no data
+    CheckUdf<Nullable<int32_t>, ListRef<Nullable<int32_t>>, ListRef<Nullable<bool>>>(
+        "min_where", nullptr, MakeList<Nullable<int32_t>>({}), MakeList<Nullable<bool>>({}));
+
+    // NULL if no matches
+    CheckUdf<Nullable<int32_t>, ListRef<Nullable<int32_t>>, ListRef<Nullable<bool>>>(
+        "min_where", nullptr, MakeList<Nullable<int32_t>>({1, 9, 3}), MakeList<Nullable<bool>>({false, false, false}));
+
+    // NULL if only NULL value matched
+    CheckUdf<Nullable<int32_t>, ListRef<Nullable<int32_t>>, ListRef<Nullable<bool>>>(
+        "min_where", nullptr, MakeList<Nullable<int32_t>>({nullptr, 3, nullptr}),
+        MakeList<Nullable<bool>>({true, false, true}));
+
+    // value is NULL => skiped, only pickup not null
+    CheckUdf<Nullable<int32_t>, ListRef<Nullable<int32_t>>, ListRef<Nullable<bool>>>(
+        "min_where", 1, MakeList<Nullable<int32_t>>({1, nullptr, 3}), MakeList<Nullable<bool>>({true, true, true}));
 }
 
 TEST_F(UdafTest, MaxWhereTest) {
@@ -197,7 +211,7 @@ TEST_F(UdafTest, MaxWhereTest) {
     CheckUdf<Nullable<int32_t>, ListRef<Nullable<int32_t>>, ListRef<Nullable<bool>>>(
         "max_where", nullptr, MakeList<Nullable<int32_t>>({nullptr, 3}), MakeList<Nullable<bool>>({true, false}));
 
-    // value is NULL => skiped
+    // value is NULL => skiped, only pickup not null
     CheckUdf<Nullable<int32_t>, ListRef<Nullable<int32_t>>, ListRef<Nullable<bool>>>(
         "max_where", 3, MakeList<Nullable<int32_t>>({1, nullptr, 3}), MakeList<Nullable<bool>>({true, true, true}));
 }

--- a/hybridse/src/udf/udaf_test.cc
+++ b/hybridse/src/udf/udaf_test.cc
@@ -62,7 +62,7 @@ TEST_F(UdafTest, MaxTest) {
     CheckUdafOneParam<Nullable<int32_t>>("max", nullptr, {});
     CheckUdafOneParam<Nullable<int32_t>, Nullable<int32_t>>("max", nullptr, {nullptr});
     CheckUdafOneParam<Nullable<int32_t>, Nullable<int32_t>>("max", nullptr, {nullptr, nullptr});
-    CheckUdafOneParam<Nullable<int64_t>, Nullable<int64_t>>("max", 5, {nullptr, 5, 1});
+    CheckUdafOneParam<Nullable<int64_t>, Nullable<int64_t>>("max", 5, { 5, 1});
     CheckUdafOneParam<Nullable<int64_t>, Nullable<int64_t>>("max", 5, {nullptr, 5, 1});
     CheckUdafOneParam<Nullable<float>, Nullable<float>>("max", 5.0, {nullptr, 5.0, -1.0});
     CheckUdafOneParam<Nullable<double>, Nullable<double>>("max", 5.0, {nullptr, 5.0, -1.0});
@@ -76,7 +76,7 @@ TEST_F(UdafTest, MinTest) {
     CheckUdafOneParam<Nullable<int32_t>>("min", nullptr, {});
     CheckUdafOneParam<Nullable<int32_t>, Nullable<int32_t>>("min", nullptr, {nullptr});
     CheckUdafOneParam<Nullable<int32_t>, Nullable<int32_t>>("min", nullptr, {nullptr, nullptr});
-    CheckUdafOneParam<Nullable<int64_t>, Nullable<int64_t>>("min", 1, {nullptr, 5, 1});
+    CheckUdafOneParam<Nullable<int64_t>, Nullable<int64_t>>("min", 1, {5, 1});
     CheckUdafOneParam<Nullable<int64_t>, Nullable<int64_t>>("min", 1, {nullptr, 5, 1});
     CheckUdafOneParam<Nullable<float>, Nullable<float>>("min", -1.0, {nullptr, 5.0, -1.0});
     CheckUdafOneParam<Nullable<double>, Nullable<double>>("min", -1.0, {nullptr, 5.0, -1.0});

--- a/hybridse/src/udf/udaf_test.cc
+++ b/hybridse/src/udf/udaf_test.cc
@@ -175,17 +175,31 @@ TEST_F(UdafTest, min_where_test) {
         "min_where", 2147483647, MakeList<int32_t>({}), MakeBoolList({}));
 }
 
-TEST_F(UdafTest, max_where_test) {
+TEST_F(UdafTest, MaxWhereTest) {
     CheckUdf<int32_t, ListRef<int32_t>, ListRef<bool>>(
         "max_where", 7, MakeList<int32_t>({7, 5, 6}),
         MakeBoolList({true, false, true}));
 
+    // cond is false or NULL => skiped
     CheckUdf<int32_t, ListRef<Nullable<int32_t>>, ListRef<Nullable<bool>>>(
         "max_where", 1, MakeList<Nullable<int32_t>>({1, 5, 4, 0}),
         MakeList<Nullable<bool>>({true, false, nullptr, true}));
 
-    CheckUdf<int32_t, ListRef<int32_t>, ListRef<bool>>(
-        "max_where", -2147483648, MakeList<int32_t>({}), MakeBoolList({}));
+    // NULL if no data
+    CheckUdf<Nullable<int32_t>, ListRef<Nullable<int32_t>>, ListRef<Nullable<bool>>>(
+        "max_where", nullptr, MakeList<Nullable<int32_t>>({}), MakeList<Nullable<bool>>({}));
+
+    // NULL if no matches
+    CheckUdf<Nullable<int32_t>, ListRef<Nullable<int32_t>>, ListRef<Nullable<bool>>>(
+        "max_where", nullptr, MakeList<Nullable<int32_t>>({1, 9, 3}), MakeList<Nullable<bool>>({false, false, false}));
+
+    // NULL if only NULL value matched
+    CheckUdf<Nullable<int32_t>, ListRef<Nullable<int32_t>>, ListRef<Nullable<bool>>>(
+        "max_where", nullptr, MakeList<Nullable<int32_t>>({nullptr, 3}), MakeList<Nullable<bool>>({true, false}));
+
+    // value is NULL => skiped
+    CheckUdf<Nullable<int32_t>, ListRef<Nullable<int32_t>>, ListRef<Nullable<bool>>>(
+        "max_where", 3, MakeList<Nullable<int32_t>>({1, nullptr, 3}), MakeList<Nullable<bool>>({true, true, true}));
 }
 
 TEST_F(UdafTest, avg_test) {


### PR DESCRIPTION
close #1295 

rules: 
1. if no cols matched, return `NULL`
2. if all cols matched is `NULL`, return `NULL`
