### PR TITLE
ci: refactor workflow

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1,3 +1,4 @@
+# OpenMLDB core cpp jobs
 name: cicd
 
 on:
@@ -19,6 +20,7 @@ on:
       - image/
       - release/
       - tools/
+      - "*.md"
   workflow_dispatch:
 
 env:
@@ -28,7 +30,7 @@ env:
   HYBRIDSE_TESTING_ENABLE: OFF # turn off hybridse's test code
 
 jobs:
-  build_and_cpp_ut:
+  cpp:
     runs-on: self-hosted
     if: github.repository == '4paradigm/OpenMLDB'
     container:
@@ -116,266 +118,9 @@ jobs:
           path: openmldb-*.tar.gz
           name: release-artifacts
 
-  java-sdk:
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/4paradigm/hybridsql:0.4.1
-    env:
-      SQL_JAVASDK_ENABLE: ON
-      OPENMLDB_BUILD_TARGET: 'cp_native_so openmldb'
-      MAVEN_OPTS: -Duser.home=/github/home
-      SPARK_HOME: /tmp/spark/
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/setup-java@v2
-        with:
-          distribution: 'adopt'
-          java-version: '8'
-          server-id: ossrh
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_TOKEN
-          gpg-passphrase: GPG_PASSPHRASE # env variable for GPG private key passphrase
-
-      - name: Import GPG key
-        id: import_gpg
-        if: github.event_name == 'push'
-        uses: crazy-max/ghaction-import-gpg@v4
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-
-      - name: Cache local Maven repository
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('java/**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
-      - name: prepare release
-        if: github.event_name == 'push'
-        run: |
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          VERSION=${VERSION#v}
-          ./java/prepare_release.sh "$VERSION"
-
-      - name: build jsdk
-        run: |
-          make build
-
-      - name: upload linux library
-        if: github.event_name == 'push'
-        uses: actions/upload-artifact@v2
-        with:
-          name: shared-library-${{ github.sha }}
-          path: |
-            java/openmldb-native/src/main/resources/libsql_jsdk.so
-            java/hybridse-native/src/main/resources/libhybridse_jsdk_core.so
-
-      - name: start services
-        run: |
-          sh steps/ut_zookeeper.sh start
-          sh steps/download_openmldb_spark.sh $SPARK_HOME
-          cd onebox && sh start_onebox.sh && cd - || exit
-
-      - name: run java modules smoke test
-        working-directory: java
-        run: |
-          ./mvnw --batch-mode test
-
-      - name: upload java ut results
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: linux-ut-result-java-${{ github.sha }}
-          path: |
-            java/*/target/**/TEST-*.xml
-
-      - name: deploy
-        if: github.event_name == 'push'
-        working-directory: java
-        run: |
-          ./mvnw --batch-mode deploy -DskipTests=true -Dscalatest.skip=true
-        env:
-          MAVEN_OPTS: -Duser.home=/github/home
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_TOKEN: ${{ secrets.OSSRH_TOKEN }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-
-      - name: stop services
-        run: |
-          cd onebox && sh stop_all.sh && cd - || exit
-          sh steps/ut_zookeeper.sh stop
-
-
-  java-sdk-mac:
-    # mac job for java sdk. steps are almost same with job 'java-sdk'
-    # except mvn deploy won't target all modules, just hybridse-native & openmldb-native
-    # the job only run on tag push or manual workflow dispatch due to no test runs
-    runs-on: macos-latest
-    needs:
-      - java-sdk
-    if: github.event_name == 'push'
-    env:
-      SQL_JAVASDK_ENABLE: ON
-      OPENMLDB_BUILD_TARGET: 'cp_native_so openmldb'
-      NPROC: 3
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Cache local Maven repository
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('java/**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
-      - name: Cache thirdparty
-        uses: actions/cache@v2
-        with:
-          path: |
-            .deps/
-            thirdsrc
-          key: ${{ runner.os }}-thirdparty-${{ hashFiles('third-party/**/CMakeLists.txt', 'third-party/**/*.cmake', 'third-party/**/*.sh') }}
-
-      - name: prepare release
-        if: github.event_name == 'push'
-        run: |
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          VERSION=${VERSION#v}
-          VARIANT_TYPE=macos ./java/prepare_release.sh "$VERSION"
-
-      - uses: actions/setup-java@v2
-        with:
-          distribution: 'adopt'
-          java-version: '8'
-          server-id: ossrh
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_TOKEN
-          gpg-passphrase: GPG_PASSPHRASE # env variable for GPG private key passphrase
-
-      - name: Import GPG key
-        id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v4
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-
-      - name: build jsdk
-        run: |
-          make build
-
-      # Need: ut_zookeeper & start_onebox adopted for macOS
-      # - name: run java modules smoke test
-      #   run: |
-      #     sh steps/ut_zookeeper.sh start
-      #     cd onebox && sh start_onebox.sh && cd - || exit
-      #     cd java
-      #     mvn test
-      #     cd -
-      #     cd onebox && sh stop_all.sh && cd - || exit
-      #     sh steps/ut_zookeeper.sh stop
-
-      # - name: upload java ut results
-      #   if: always()
-      #   uses: actions/upload-artifact@v2
-      #   with:
-      #     name: linux-ut-result-java-${{ github.sha }}
-      #     path: |
-      #       java/openmldb-jdbc/target/**/TEST-*.xml
-
-      - name: mvn deploy
-        working-directory: java
-        run: |
-          # by convention only native submodule has variant release
-          # so it is a bit tricky to compile and deploy that
-          # firstly run `maven install` install things locally
-          # then selectly `mvn deploy` for hybridse-native & openmldb-native
-          ./mvnw --batch-mode clean install -DskipTests=true -Dscalatest.skip=true
-          ./mvnw --batch-mode -pl hybridse-native,openmldb-native deploy
-        env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_TOKEN: ${{ secrets.OSSRH_TOKEN }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-
-      - name: download shared libraries
-        uses: actions/download-artifact@v2
-        with:
-          name: shared-library-${{ github.sha }}
-          path: java
-
-      - name: prepare deploy allinone
-        run: |
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          VERSION=${VERSION#v}
-          VARIANT_TYPE=allinone ./java/prepare_release.sh "$VERSION"
-
-      - name: mvn deploy allinone
-        working-directory: java
-        run: |
-          # by convention only native submodule has variant release
-          # so it is a bit tricky to compile and deploy that
-          # firstly run `maven install` install things locally
-          # then selectly `mvn deploy` for hybridse-native & openmldb-native
-          ./mvnw --batch-mode clean install -DskipTests=true -Dscalatest.skip=true
-          ./mvnw --batch-mode -pl hybridse-native,openmldb-native deploy
-        env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_TOKEN: ${{ secrets.OSSRH_TOKEN }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-
-  python-sdk:
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/4paradigm/hybridsql:0.4.1
-    env:
-      SQL_PYSDK_ENABLE: ON
-      OPENMLDB_BUILD_TARGET: 'cp_python_sdk_so openmldb'
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: prepare release
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: |
-            VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-            VERSION=${VERSION#v}
-            bash steps/prepare_release.sh "$VERSION"
-
-      - name: build pysdk and sqlalchemy
-        run: |
-          make build
-
-      - name: prepare python deps
-        run: |
-          python3 -m easy_install pip
-          pip install setuptools wheel twine
-          yum install -y net-tools
-
-      - name: test sqlalchemy
-        run: |
-          bash steps/test_python.sh
-
-      - name: upload python ut results
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: linux-ut-result-python-${{ github.sha }}
-          path: |
-            python/openmldb/test/pytest.xml
-
-      - name: upload to pypi
-        if: >
-          github.repository == '4paradigm/OpenMLDB' && startsWith(github.ref, 'refs/tags/v')
-        run: |
-          cp python/dist/openmldb*.whl .
-          twine upload openmldb-*.whl
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-
   publish-test-results:
     runs-on: ubuntu-latest
-    needs: [ "build_and_cpp_ut", "java-sdk", "python-sdk" ]
+    needs: [ "cpp" ]
 
     # the action will only run on 4paradigm/OpenMLDB's context, not for fork repo or dependabot
     if: >
@@ -396,7 +141,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     # if test failed, shouldn't release
-    needs: [ "build_and_cpp_ut", "java-sdk", "python-sdk" ]
+    needs: [ "cpp" ]
     if: >
       success() && startsWith(github.ref, 'refs/tags/v')
     steps:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,6 +10,7 @@ on:
       - release/
       - image/
       - tools/
+      - "*.md"
   pull_request:
     paths-ignore:
       - docs/
@@ -17,6 +18,7 @@ on:
       - release/
       - image/
       - tools/
+      - "*.md"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/hybridsql-docker.yml
+++ b/.github/workflows/hybridsql-docker.yml
@@ -1,3 +1,4 @@
+# This workflow make compile docker image for OpenMLDB
 name: HybridSQL Docker
 
 on:
@@ -11,7 +12,7 @@ on:
       - docker/**/*.sh
 
     tags:
-      - docker-*
+      - v*
 
   # Run tests for any PRs.
   pull_request:
@@ -52,7 +53,7 @@ jobs:
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
 
           # Strip "docker" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^docker-//')
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
 
           # Use Docker `latest` tag convention
           [ "$VERSION" == "main" ] && VERSION=latest

--- a/.github/workflows/publish-sdk-test-result-from-fork.yml
+++ b/.github/workflows/publish-sdk-test-result-from-fork.yml
@@ -1,0 +1,61 @@
+name: publish-test-result-from-fork
+
+on:
+  # the action will only run on dependabot/fork pull request
+  workflow_run:
+    workflows: ["SDK"]
+    types:
+      - completed
+
+jobs:
+  test-results:
+    name: Test Results
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.conclusion != 'skipped' && (
+         github.event.sender.login == 'dependabot[bot]' ||
+         github.event.workflow_run.head_repository.full_name != github.repository
+      )
+    steps:
+      - name: Download Artifacts
+        uses: actions/github-script@v3
+        with:
+          script: |
+            var fs = require('fs');
+            var path = require('path');
+            var artifacts_path = path.join('${{github.workspace}}', 'artifacts')
+            fs.mkdirSync(artifacts_path, { recursive: true })
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{ github.event.workflow_run.id }},
+            });
+            for (const artifact of artifacts.data.artifacts) {
+               var download = await github.actions.downloadArtifact({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  artifact_id: artifact.id,
+                  archive_format: 'zip',
+               });
+               var artifact_path = path.join(artifacts_path, `${artifact.name}.zip`)
+               fs.writeFileSync(artifact_path, Buffer.from(download.data));
+               console.log(`Downloaded ${artifact_path}`);
+            }
+      - name: Extract Artifacts
+        run: |
+          for file in artifacts/*.zip
+          do
+            if [ -f "$file" ]
+            then
+              dir="${file/%.zip/}"
+              mkdir -p "$dir"
+              unzip -d "$dir" "$file"
+            fi
+          done
+      - name: Publish SDK UT Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          files: artifacts/linux-ut-result-*/**/*.xml
+          check_name: SDK Test Report
+          comment_title: SDK Test Report

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -1,0 +1,290 @@
+# This workflow runs SDK related jobs for OpenMLDB
+name: SDK
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - docs/
+      - demo/
+      - image/
+      - release/
+      - tools/
+      - "*.md"
+    tags:
+      - v*
+  pull_request:
+    paths-ignore:
+      - docs/
+      - demo/
+      - image/
+      - release/
+      - tools/
+      - "*.md"
+  workflow_dispatch:
+
+env:
+  GIT_SUBMODULE_STRATEGY: recursive
+  NPROC: 2 # default Parallel build number for GitHub's Linux runner
+  EXAMPLES_ENABLE: OFF # turn off hybridse's example code
+  HYBRIDSE_TESTING_ENABLE: OFF # turn off hybridse's test code
+
+jobs:
+  java-sdk:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/4paradigm/hybridsql:0.4.1
+    env:
+      SQL_JAVASDK_ENABLE: ON
+      OPENMLDB_BUILD_TARGET: 'cp_native_so openmldb'
+      MAVEN_OPTS: -Duser.home=/github/home
+      SPARK_HOME: /tmp/spark/
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '8'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_TOKEN
+          gpg-passphrase: GPG_PASSPHRASE # env variable for GPG private key passphrase
+
+      - name: Import GPG key
+        id: import_gpg
+        if: github.event_name == 'push'
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('java/**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: prepare release
+        if: github.event_name == 'push'
+        run: |
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          VERSION=${VERSION#v}
+          ./java/prepare_release.sh "$VERSION"
+
+      - name: build jsdk
+        run: |
+          make build
+
+      - name: upload linux library
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@v2
+        with:
+          name: shared-library-${{ github.sha }}
+          path: |
+            java/openmldb-native/src/main/resources/libsql_jsdk.so
+            java/hybridse-native/src/main/resources/libhybridse_jsdk_core.so
+
+      - name: start services
+        run: |
+          sh steps/ut_zookeeper.sh start
+          sh steps/download_openmldb_spark.sh $SPARK_HOME
+          cd onebox && sh start_onebox.sh && cd - || exit
+
+      - name: run java modules smoke test
+        working-directory: java
+        run: |
+          ./mvnw --batch-mode test
+
+      - name: upload java ut results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: linux-ut-result-java-${{ github.sha }}
+          path: |
+            java/*/target/**/TEST-*.xml
+
+      - name: deploy
+        if: github.event_name == 'push'
+        working-directory: java
+        run: |
+          ./mvnw --batch-mode deploy -DskipTests=true -Dscalatest.skip=true
+        env:
+          MAVEN_OPTS: -Duser.home=/github/home
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: stop services
+        run: |
+          cd onebox && sh stop_all.sh && cd - || exit
+          sh steps/ut_zookeeper.sh stop
+
+
+  java-sdk-mac:
+    # mac job for java sdk. steps are almost same with job 'java-sdk'
+    # except mvn deploy won't target all modules, just hybridse-native & openmldb-native
+    # the job only run on tag push or manual workflow dispatch due to no test runs
+    runs-on: macos-latest
+    needs:
+      - java-sdk
+    if: github.event_name == 'push'
+    env:
+      SQL_JAVASDK_ENABLE: ON
+      OPENMLDB_BUILD_TARGET: 'cp_native_so openmldb'
+      NPROC: 3
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('java/**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Cache thirdparty
+        uses: actions/cache@v2
+        with:
+          path: |
+            .deps/
+            thirdsrc
+          key: ${{ runner.os }}-thirdparty-${{ hashFiles('third-party/**/CMakeLists.txt', 'third-party/**/*.cmake', 'third-party/**/*.sh') }}
+
+      - name: prepare release
+        if: github.event_name == 'push'
+        run: |
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          VERSION=${VERSION#v}
+          VARIANT_TYPE=macos ./java/prepare_release.sh "$VERSION"
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '8'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_TOKEN
+          gpg-passphrase: GPG_PASSPHRASE # env variable for GPG private key passphrase
+
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+
+      - name: build jsdk
+        run: |
+          make build
+
+      - name: mvn deploy
+        working-directory: java
+        run: |
+          # by convention only native submodule has variant release
+          # so it is a bit tricky to compile and deploy that
+          # firstly run `maven install` install things locally
+          # then selectly `mvn deploy` for hybridse-native & openmldb-native
+          ./mvnw --batch-mode clean install -DskipTests=true -Dscalatest.skip=true
+          ./mvnw --batch-mode -pl hybridse-native,openmldb-native deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: download shared libraries
+        uses: actions/download-artifact@v2
+        with:
+          name: shared-library-${{ github.sha }}
+          path: java
+
+      - name: prepare deploy allinone
+        run: |
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          VERSION=${VERSION#v}
+          VARIANT_TYPE=allinone ./java/prepare_release.sh "$VERSION"
+
+      - name: mvn deploy allinone
+        working-directory: java
+        run: |
+          # by convention only native submodule has variant release
+          # so it is a bit tricky to compile and deploy that
+          # firstly run `maven install` install things locally
+          # then selectly `mvn deploy` for hybridse-native & openmldb-native
+          ./mvnw --batch-mode clean install -DskipTests=true -Dscalatest.skip=true
+          ./mvnw --batch-mode -pl hybridse-native,openmldb-native deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+  python-sdk:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/4paradigm/hybridsql:0.4.1
+    env:
+      SQL_PYSDK_ENABLE: ON
+      OPENMLDB_BUILD_TARGET: 'cp_python_sdk_so openmldb'
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: prepare release
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+            VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+            VERSION=${VERSION#v}
+            bash steps/prepare_release.sh "$VERSION"
+
+      - name: build pysdk and sqlalchemy
+        run: |
+          make build
+
+      - name: prepare python deps
+        run: |
+          python3 -m easy_install pip
+          pip install setuptools wheel twine
+          yum install -y net-tools
+
+      - name: test sqlalchemy
+        run: |
+          bash steps/test_python.sh
+
+      - name: upload python ut results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: linux-ut-result-python-${{ github.sha }}
+          path: |
+            python/openmldb/test/pytest.xml
+
+      - name: upload to pypi
+        if: >
+          github.repository == '4paradigm/OpenMLDB' && startsWith(github.ref, 'refs/tags/v')
+        run: |
+          cp python/dist/openmldb*.whl .
+          twine upload openmldb-*.whl
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+
+  publish-test-results:
+    runs-on: ubuntu-latest
+    needs: [ "java-sdk", "python-sdk" ]
+
+    # the action will only run on 4paradigm/OpenMLDB's context, not for fork repo or dependabot
+    if: >
+      always() && github.event_name == 'push' || (
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.sender.login != 'dependabot[bot]' )
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+
+      - name: Publish Linux UT Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          files: linux-ut-result-*/**/*.xml
+          check_name: SDK Test Report
+          comment_title: SDK Test Report


### PR DESCRIPTION
close #1292, likely avoid failed SDK jobs that will fail the cpp relase job

In detail:
- separate cpp jobs and SDK jobs ( java & python)
