### PR TITLE
fix(#1410): log error and return at the end of switch statement in `ShadowCopy` function

### DIFF
--- a/hybridse/src/node/expr_node.cc
+++ b/hybridse/src/node/expr_node.cc
@@ -918,6 +918,10 @@ ConstNode* ConstNode::ShadowCopy(NodeManager* nm) const {
             LOG(WARNING) << "Fail to copy primary expr of type " << node::DataTypeName(GetDataType());
             return nm->MakeConstNode(GetDataType());
         }
+        
+        default:
+            LOG(ERROR) << "Unsupported Data type";
+            return nullptr;
     }
 }
 

--- a/hybridse/src/node/expr_node.cc
+++ b/hybridse/src/node/expr_node.cc
@@ -918,9 +918,9 @@ ConstNode* ConstNode::ShadowCopy(NodeManager* nm) const {
             LOG(WARNING) << "Fail to copy primary expr of type " << node::DataTypeName(GetDataType());
             return nm->MakeConstNode(GetDataType());
         }
-        
+
         default:
-            LOG(ERROR) << "Unsupported Data type";
+            LOG(ERROR) << "Unsupported Data type " << node::DataTypeName(GetDataType());
             return nullptr;
     }
 }

--- a/hybridse/src/node/expr_node.cc
+++ b/hybridse/src/node/expr_node.cc
@@ -918,9 +918,6 @@ ConstNode* ConstNode::ShadowCopy(NodeManager* nm) const {
             LOG(WARNING) << "Fail to copy primary expr of type " << node::DataTypeName(GetDataType());
             return nm->MakeConstNode(GetDataType());
         }
-
-        default: {
-        }
     }
     LOG(ERROR) << "Unsupported Data type " << node::DataTypeName(GetDataType());
     return nullptr;

--- a/hybridse/src/node/expr_node.cc
+++ b/hybridse/src/node/expr_node.cc
@@ -919,10 +919,11 @@ ConstNode* ConstNode::ShadowCopy(NodeManager* nm) const {
             return nm->MakeConstNode(GetDataType());
         }
 
-        default:
-            LOG(ERROR) << "Unsupported Data type " << node::DataTypeName(GetDataType());
-            return nullptr;
+        default: {
+        }
     }
+    LOG(ERROR) << "Unsupported Data type " << node::DataTypeName(GetDataType());
+    return nullptr;
 }
 
 ColumnRefNode* ColumnRefNode::ShadowCopy(NodeManager* nm) const {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- The commit message follows our guidelines
- Tests for the changes have been added (for bug fixes / features)
- Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

https://github.com/4paradigm/OpenMLDB/issues/1410

* **What is the new behavior (if this is a feature change)?**

Add default to the switch statement in ShadowCopy function. Log error message 'Unsupported Data type' and return nullptr.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:
