### PR TITLE
feat: support init global table and support recover table when tablet restart

### DIFF
--- a/src/cmd/sql_cmd_test.cc
+++ b/src/cmd/sql_cmd_test.cc
@@ -595,7 +595,7 @@ TEST_P(DBSDKTest, GlobalVariable) {
     sr = cli->sr;
     auto ns_client = cs->GetNsClient();
 
-    // todo: should support standalone mode
+    // todo: should support standalone mode.
     if (cs->IsClusterMode()) {
         std::vector<::openmldb::nameserver::TableInfo> tables;
         std::string msg;

--- a/src/cmd/sql_cmd_test.cc
+++ b/src/cmd/sql_cmd_test.cc
@@ -607,7 +607,17 @@ TEST_P(DBSDKTest, GlobalVariable) {
         ASSERT_STREQ(nameserver::GLOBAL_VARIABLES, tables[0].name().c_str());
         tables.clear();
 
+        // init global table
         ::hybridse::sdk::Status status;
+        auto res = sr->ExecuteSQL(nameserver::INFORMATION_SCHEMA_DB,
+                                "select * from GLOBAL_VARIABLES where Variable_name = 'enable_trace';", &status);
+        ASSERT_TRUE(res);
+        ASSERT_EQ("true", res->GetRowString());
+        res = sr->ExecuteSQL(nameserver::INFORMATION_SCHEMA_DB,
+                                "select * from GLOBAL_VARIABLES where Variable_name = 'execute_mode';", &status);
+        ASSERT_TRUE(res);
+        ASSERT_EQ("online", res->GetRowString());
+
         std::string sql = "set @@global.enable_trace='true';";
         auto res = sr->ExecuteSQL(sql, &status);
         ASSERT_EQ(0, status.code);

--- a/src/cmd/sql_cmd_test.cc
+++ b/src/cmd/sql_cmd_test.cc
@@ -595,7 +595,7 @@ TEST_P(DBSDKTest, GlobalVariable) {
     sr = cli->sr;
     auto ns_client = cs->GetNsClient();
 
-    // todo: should support standalone mode.
+    // todo: should support standalone mode
     if (cs->IsClusterMode()) {
         std::vector<::openmldb::nameserver::TableInfo> tables;
         std::string msg;

--- a/src/nameserver/name_server_impl.h
+++ b/src/nameserver/name_server_impl.h
@@ -355,6 +355,7 @@ class NameServerImpl : public NameServer {
 
     base::Status CreateSystemTable(const std::string& table_name, SystemTableType table_type);
 
+    base::Status InitGlobalVarTable();
  private:
     // Recover all memory status, the steps
     // 1.recover table meta from zookeeper

--- a/src/nameserver/name_server_impl.h
+++ b/src/nameserver/name_server_impl.h
@@ -114,6 +114,7 @@ struct ZkPath {
     std::string op_index_node_;
     std::string op_data_path_;
     std::string op_sync_path_;
+    std::string globalvar_changed_notify_node_;
 };
 
 class NameServerImplTest;
@@ -753,6 +754,7 @@ class NameServerImpl : public NameServer {
 
     uint64_t GetTerm() const;
 
+    void NotifyGlobalVarChanged();
  private:
     std::mutex mu_;
     Tablets tablets_;

--- a/src/sdk/db_sdk.cc
+++ b/src/sdk/db_sdk.cc
@@ -98,7 +98,6 @@ bool ClusterSDK::TriggerNotify() const {
 }
 
 bool ClusterSDK::GlobalVarNotify() const {
-    LOG(INFO) << "Global variable changed trigger notify node";
     return zk_client_->Increment(globalvar_changed_notify_path_);
 }
 

--- a/src/sdk/sql_cluster_router.cc
+++ b/src/sdk/sql_cluster_router.cc
@@ -1624,7 +1624,11 @@ std::shared_ptr<hybridse::sdk::ResultSet> SQLClusterRouter::HandleSQLCmd(const h
             std::string table = openmldb::nameserver::GLOBAL_VARIABLES;
             std::string sql = "select * from " + table;
             ::hybridse::sdk::Status status;
+<<<<<<< HEAD
             auto rs = ExecuteSQLParameterized(db, sql, std::shared_ptr<openmldb::sdk::SQLRequestRow>(), &status);
+=======
+            auto rs = ExecuteSQLParameterized(db_, sql, std::shared_ptr<openmldb::sdk::SQLRequestRow>(), &status);
+>>>>>>> 0785d407e (update show global variables)
             if (status.code != 0) {
                 std::cout << "ERROR: " << status.msg << std::endl;
                 return {};

--- a/src/sdk/sql_cluster_router.cc
+++ b/src/sdk/sql_cluster_router.cc
@@ -252,30 +252,9 @@ bool SQLClusterRouter::Init() {
             }
         }
     }
-    // init session variables from systemtable
-    // todo: should support standalone mode
-    if (cluster_sdk_->IsClusterMode()) {
-        hybridse::sdk::Status status;
-        std::string db = openmldb::nameserver::INFORMATION_SCHEMA_DB;
-        std::string table = openmldb::nameserver::GLOBAL_VARIABLES;
-        std::string sql = "select * from " + table;
-        auto rs = ExecuteSQLParameterized(db, sql, std::shared_ptr<openmldb::sdk::SQLRequestRow>(), &status);
-        if (status.code != 0) {
-            LOG(ERROR) << "init session variables from system table failed: " << status.msg;
-        }
-        std::string key;
-        std::string value;
-        while (rs->Next()) {
-            key = rs->GetStringUnsafe(0);
-            value = rs->GetStringUnsafe(1);
-            if (key == "execute_mode" || key == "enable_trace") {
-                session_variables_.emplace(key, value);
-            }
-        }
-    } else {
-        session_variables_.emplace("execute_mode", "offline");
-        session_variables_.emplace("enable_trace", "false");
-    }
+    // todo: init session variables from systemtable
+    session_variables_.emplace("execute_mode", "offline");
+    session_variables_.emplace("enable_trace", "false");
     return true;
 }
 

--- a/src/sdk/sql_cluster_test.cc
+++ b/src/sdk/sql_cluster_test.cc
@@ -901,19 +901,6 @@ TEST_F(SQLClusterTest, GetPreAggrTable) {
         ASSERT_TRUE(found);
     }
 }
-
-TEST_F(SQLClusterTest, SessionVariables) {
-    SQLRouterOptions sql_opt;
-    sql_opt.zk_cluster = mc_->GetZkCluster();
-    sql_opt.zk_path = mc_->GetZkPath();
-    auto router = NewClusterSQLRouter(sql_opt);
-    auto cluster_router = std::dynamic_pointer_cast<SQLClusterRouter>(router);
-    ASSERT_TRUE(cluster_router != nullptr);
-    // session variables get default value from system table
-    ASSERT_FALSE(cluster_router->IsOnlineMode());
-    ASSERT_FALSE(cluster_router->IsEnableTrace());
-}
-
 }  // namespace sdk
 }  // namespace openmldb
 

--- a/src/sdk/sql_cluster_test.cc
+++ b/src/sdk/sql_cluster_test.cc
@@ -902,6 +902,18 @@ TEST_F(SQLClusterTest, GetPreAggrTable) {
     }
 }
 
+TEST_F(SQLClusterTest, SessionVariables) {
+    SQLRouterOptions sql_opt;
+    sql_opt.zk_cluster = mc_->GetZkCluster();
+    sql_opt.zk_path = mc_->GetZkPath();
+    auto router = NewClusterSQLRouter(sql_opt);
+    auto cluster_router = std::dynamic_pointer_cast<SQLClusterRouter>(router);
+    ASSERT_TRUE(cluster_router != nullptr);
+    // session variables get default value from system table
+    ASSERT_FALSE(cluster_router->IsOnlineMode());
+    ASSERT_FALSE(cluster_router->IsEnableTrace());
+}
+
 }  // namespace sdk
 }  // namespace openmldb
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
1. support init global system table when nameserver init
2. support recover system table when tablet restart
3. add ut
