### PR TITLE
feat: support init global table and recover table when tablet restart 

### DIFF
--- a/src/cmd/sql_cmd_test.cc
+++ b/src/cmd/sql_cmd_test.cc
@@ -592,7 +592,6 @@ TEST_P(DBSDKTest, GlobalVariable) {
                         "set @@global.enable_trace='false';",
                         "set @@global.execute_mode='offline';",
                     });
-
     ExpectResultSetStrEq({{"Variable_name", "Variable_value"}, {"enable_trace", "false"}, {"execute_mode", "offline"}},
                          rs.get());
 }

--- a/src/cmd/sql_cmd_test.cc
+++ b/src/cmd/sql_cmd_test.cc
@@ -579,7 +579,7 @@ TEST_P(DBSDKTest, GlobalVariable) {
     ::hybridse::sdk::Status status;
     auto rs = sr->ExecuteSQL("show global variables", &status);
     // init global variable
-    ExpectResultSetStrEq({{"Variable_name", "Variable_value"}, {"enable_trace", "false"}, "execute_mode", "offline"},
+    ExpectResultSetStrEq({{"Variable_name", "Variable_value"}, {"enable_trace", "false"}, {"execute_mode", "offline"}},
                          rs.get());
     ProcessSQLs(sr, {
                         "set @@global.enable_trace='true';",
@@ -593,7 +593,7 @@ TEST_P(DBSDKTest, GlobalVariable) {
                         "set @@global.enable_trace='false';",
                         "set @@global.execute_mode='offline';",
                     });
-                    
+
     ExpectResultSetStrEq({{"Variable_name", "Variable_value"}, {"enable_trace", "false"}, {"execute_mode", "offline"}},
                          rs.get());
 }

--- a/src/cmd/sql_cmd_test.cc
+++ b/src/cmd/sql_cmd_test.cc
@@ -579,22 +579,38 @@ TEST_P(DBSDKTest, GlobalVariable) {
     ::hybridse::sdk::Status status;
     auto rs = sr->ExecuteSQL("show global variables", &status);
     // init global variable
-    ExpectResultSetStrEq({{"Variable_name", "Variable_value"}, {"enable_trace", "false"}, {"execute_mode", "offline"}},
+    ExpectResultSetStrEq({{"Variable_name", "Variable_value"},
+                          {"enable_trace", "false"},
+                          {"sync_job", "false"},
+                          {"job_timeout", "20000"},
+                          {"execute_mode", "offline"}},
                          rs.get());
     ProcessSQLs(sr, {
                         "set @@global.enable_trace='true';",
+                        "set @@global.sync_job='true';",
+                        "set @@global.job_timeout='30000';",
                         "set @@global.execute_mode='online';",
                     });
     rs = sr->ExecuteSQL("show global variables", &status);
-    ExpectResultSetStrEq({{"Variable_name", "Variable_value"}, {"enable_trace", "true"}, {"execute_mode", "online"}},
+    ExpectResultSetStrEq({{"Variable_name", "Variable_value"},
+                          {"enable_trace", "true"},
+                          {"sync_job", "true"},
+                          {"job_timeout", "30000"},
+                          {"execute_mode", "online"}},
                          rs.get());
 
     ProcessSQLs(sr, {
                         "set @@global.enable_trace='false';",
+                        "set @@global.sync_job='false';",
+                        "set @@global.job_timeout='20000';",
                         "set @@global.execute_mode='offline';",
                     });
 
-    ExpectResultSetStrEq({{"Variable_name", "Variable_value"}, {"enable_trace", "false"}, {"execute_mode", "offline"}},
+    ExpectResultSetStrEq({{"Variable_name", "Variable_value"},
+                          {"enable_trace", "false"},
+                          {"sync_job", "false"},
+                          {"job_timeout", "20000"},
+                          {"execute_mode", "offline"}},
                          rs.get());
 }
 

--- a/src/cmd/sql_cmd_test.cc
+++ b/src/cmd/sql_cmd_test.cc
@@ -594,6 +594,60 @@ TEST_P(DBSDKTest, GlobalVariable) {
                     });
     ExpectResultSetStrEq({{"Variable_name", "Variable_value"}, {"enable_trace", "false"}, {"execute_mode", "offline"}},
                          rs.get());
+    // todo: should support standalone mode.
+    if (cs->IsClusterMode()) {
+        std::vector<::openmldb::nameserver::TableInfo> tables;
+        std::string msg;
+        ASSERT_TRUE(ns_client->ShowTable("", nameserver::INFORMATION_SCHEMA_DB, false, tables, msg));
+        ASSERT_EQ(1, tables.size());
+        tables.clear();
+        ASSERT_TRUE(
+            ns_client->ShowTable(nameserver::GLOBAL_VARIABLES, nameserver::INFORMATION_SCHEMA_DB, false, tables, msg));
+        ASSERT_EQ(1, tables.size());
+        ASSERT_STREQ(nameserver::GLOBAL_VARIABLES, tables[0].name().c_str());
+        tables.clear();
+
+        // init global var table
+        ::hybridse::sdk::Status status;
+        auto rs = sr->ExecuteSQL("show global variables", &status);
+        ASSERT_EQ(2, rs->Size());
+        ASSERT_TRUE(rs->Next());
+        ASSERT_EQ("enable_trace", rs->GetStringUnsafe(0));
+        ASSERT_EQ("false", rs->GetStringUnsafe(1));
+        ASSERT_TRUE(rs->Next());
+        ASSERT_EQ("execute_mode", rs->GetStringUnsafe(0));
+        ASSERT_EQ("offline", rs->GetStringUnsafe(1));
+        // set @@global.xxx = xxx
+        std::string sql = "set @@global.enable_trace='true';";
+        auto res = sr->ExecuteSQL(sql, &status);
+        ASSERT_EQ(0, status.code);
+        sql = "set @@global.execute_mode='online';";
+        res = sr->ExecuteSQL(sql, &status);
+        ASSERT_EQ(0, status.code);
+        rs = sr->ExecuteSQL("show global variables", &status);
+        ASSERT_EQ(2, rs->Size());
+        ASSERT_TRUE(rs->Next());
+        ASSERT_EQ("enable_trace", rs->GetStringUnsafe(0));
+        ASSERT_EQ("true", rs->GetStringUnsafe(1));
+        ASSERT_TRUE(rs->Next());
+        ASSERT_EQ("execute_mode", rs->GetStringUnsafe(0));
+        ASSERT_EQ("online", rs->GetStringUnsafe(1));
+
+        sql = "set GLOBAL enable_trace='false';";
+        res = sr->ExecuteSQL(sql, &status);
+        ASSERT_EQ(0, status.code);
+        sql = "set GLOBAL execute_mode='offline';";
+        res = sr->ExecuteSQL(sql, &status);
+        ASSERT_EQ(0, status.code);
+        rs = sr->ExecuteSQL("show global variables", &status);
+        ASSERT_EQ(2, rs->Size());
+        ASSERT_TRUE(rs->Next());
+        ASSERT_EQ("enable_trace", rs->GetStringUnsafe(0));
+        ASSERT_EQ("false", rs->GetStringUnsafe(1));
+        ASSERT_TRUE(rs->Next());
+        ASSERT_EQ("execute_mode", rs->GetStringUnsafe(0));
+        ASSERT_EQ("offline", rs->GetStringUnsafe(1));
+    }
 }
 
 /* TODO: Only run test in standalone mode

--- a/src/cmd/sql_cmd_test.cc
+++ b/src/cmd/sql_cmd_test.cc
@@ -588,66 +588,14 @@ TEST_P(DBSDKTest, GlobalVariable) {
     rs = sr->ExecuteSQL("show global variables", &status);
     ExpectResultSetStrEq({{"Variable_name", "Variable_value"}, {"enable_trace", "true"}, {"execute_mode", "online"}},
                          rs.get());
+
     ProcessSQLs(sr, {
                         "set @@global.enable_trace='false';",
                         "set @@global.execute_mode='offline';",
                     });
+                    
     ExpectResultSetStrEq({{"Variable_name", "Variable_value"}, {"enable_trace", "false"}, {"execute_mode", "offline"}},
                          rs.get());
-    // todo: should support standalone mode.
-    if (cs->IsClusterMode()) {
-        std::vector<::openmldb::nameserver::TableInfo> tables;
-        std::string msg;
-        ASSERT_TRUE(ns_client->ShowTable("", nameserver::INFORMATION_SCHEMA_DB, false, tables, msg));
-        ASSERT_EQ(1, tables.size());
-        tables.clear();
-        ASSERT_TRUE(
-            ns_client->ShowTable(nameserver::GLOBAL_VARIABLES, nameserver::INFORMATION_SCHEMA_DB, false, tables, msg));
-        ASSERT_EQ(1, tables.size());
-        ASSERT_STREQ(nameserver::GLOBAL_VARIABLES, tables[0].name().c_str());
-        tables.clear();
-
-        // init global var table
-        ::hybridse::sdk::Status status;
-        auto rs = sr->ExecuteSQL("show global variables", &status);
-        ASSERT_EQ(2, rs->Size());
-        ASSERT_TRUE(rs->Next());
-        ASSERT_EQ("enable_trace", rs->GetStringUnsafe(0));
-        ASSERT_EQ("false", rs->GetStringUnsafe(1));
-        ASSERT_TRUE(rs->Next());
-        ASSERT_EQ("execute_mode", rs->GetStringUnsafe(0));
-        ASSERT_EQ("offline", rs->GetStringUnsafe(1));
-        // set @@global.xxx = xxx
-        std::string sql = "set @@global.enable_trace='true';";
-        auto res = sr->ExecuteSQL(sql, &status);
-        ASSERT_EQ(0, status.code);
-        sql = "set @@global.execute_mode='online';";
-        res = sr->ExecuteSQL(sql, &status);
-        ASSERT_EQ(0, status.code);
-        rs = sr->ExecuteSQL("show global variables", &status);
-        ASSERT_EQ(2, rs->Size());
-        ASSERT_TRUE(rs->Next());
-        ASSERT_EQ("enable_trace", rs->GetStringUnsafe(0));
-        ASSERT_EQ("true", rs->GetStringUnsafe(1));
-        ASSERT_TRUE(rs->Next());
-        ASSERT_EQ("execute_mode", rs->GetStringUnsafe(0));
-        ASSERT_EQ("online", rs->GetStringUnsafe(1));
-
-        sql = "set GLOBAL enable_trace='false';";
-        res = sr->ExecuteSQL(sql, &status);
-        ASSERT_EQ(0, status.code);
-        sql = "set GLOBAL execute_mode='offline';";
-        res = sr->ExecuteSQL(sql, &status);
-        ASSERT_EQ(0, status.code);
-        rs = sr->ExecuteSQL("show global variables", &status);
-        ASSERT_EQ(2, rs->Size());
-        ASSERT_TRUE(rs->Next());
-        ASSERT_EQ("enable_trace", rs->GetStringUnsafe(0));
-        ASSERT_EQ("false", rs->GetStringUnsafe(1));
-        ASSERT_TRUE(rs->Next());
-        ASSERT_EQ("execute_mode", rs->GetStringUnsafe(0));
-        ASSERT_EQ("offline", rs->GetStringUnsafe(1));
-    }
 }
 
 /* TODO: Only run test in standalone mode

--- a/src/cmd/sql_cmd_test.cc
+++ b/src/cmd/sql_cmd_test.cc
@@ -578,8 +578,9 @@ TEST_P(DBSDKTest, GlobalVariable) {
 
     ::hybridse::sdk::Status status;
     auto rs = sr->ExecuteSQL("show global variables", &status);
-    ExpectResultSetStrEq({{"Variable_name", "Variable_value"}}, rs.get());
-
+    // init global variable
+    ExpectResultSetStrEq({{"Variable_name", "Variable_value"}, {"enable_trace", "false"}, "execute_mode", "offline"},
+                         rs.get());
     ProcessSQLs(sr, {
                         "set @@global.enable_trace='true';",
                         "set @@global.execute_mode='online';",
@@ -587,7 +588,6 @@ TEST_P(DBSDKTest, GlobalVariable) {
     rs = sr->ExecuteSQL("show global variables", &status);
     ExpectResultSetStrEq({{"Variable_name", "Variable_value"}, {"enable_trace", "true"}, {"execute_mode", "online"}},
                          rs.get());
-
     ProcessSQLs(sr, {
                         "set @@global.enable_trace='false';",
                         "set @@global.execute_mode='offline';",

--- a/src/nameserver/name_server_impl.cc
+++ b/src/nameserver/name_server_impl.cc
@@ -5483,7 +5483,6 @@ void NameServerImpl::OnLocked() {
     if (!Recover()) {
         PDLOG(WARNING, "recover failed");
     }
-    // todo: should support standalone mode
     if (IsClusterMode()) {
         if (tablets_.size() < FLAGS_system_table_replica_num) {
             LOG(FATAL) << "tablet num " << tablets_.size() << " is less then system table replica num "

--- a/src/nameserver/name_server_impl.cc
+++ b/src/nameserver/name_server_impl.cc
@@ -5493,7 +5493,6 @@ void NameServerImpl::OnLocked() {
 
         if (FLAGS_system_table_replica_num > 0 && db_table_info_[INTERNAL_DB].count(JOB_INFO_NAME) == 0) {
             CreateSystemTableOrExit(SystemTableType::kJobInfo);
-
         }
     }
 

--- a/src/nameserver/name_server_impl.cc
+++ b/src/nameserver/name_server_impl.cc
@@ -10321,7 +10321,7 @@ base::Status NameServerImpl::InitGlobalVarTable() {
     std::string table = GLOBAL_VARIABLES;
     std::shared_ptr<TableInfo> table_info;
     if (!GetTableInfo(table, db, &table_info)) {
-        return {ReturnCode::kTableIsNotExist, "table is not exist!"};
+        return {ReturnCode::kTableIsNotExist, "table is not exist"};
     }
     // encode row && dimensions
     std::vector<std::string> rows;

--- a/src/nameserver/name_server_impl.cc
+++ b/src/nameserver/name_server_impl.cc
@@ -10355,12 +10355,12 @@ base::Status NameServerImpl::InitGlobalVarTable() {
                 std::string endpoint = table_info->table_partition(0).partition_meta(meta_idx).endpoint();
                 auto table_ptr = GetTablet(endpoint);
                 if (!table_ptr->client_->Put(tid, pid, cur_ts, row, dimensions)) {
-                    LOG(WARNING) << "fail to make a put request to table. tid " + std::to_string(tid);
-                    return {};
+                    return {ReturnCode::kPutFailed, "fail to make a put request to table"};
                 }
             }
         }
     }
+    return {};
 }
 
 }  // namespace nameserver

--- a/src/nameserver/name_server_impl.cc
+++ b/src/nameserver/name_server_impl.cc
@@ -588,6 +588,12 @@ bool NameServerImpl::Recover() {
             }
         }
         value.clear();
+        if (!zk_client_->GetNodeValue(zk_path_.globalvar_changed_notify_node_, value)) {
+            if (!zk_client_->CreateNode(zk_path_.globalvar_changed_notify_node_, "1")) {
+                PDLOG(WARNING, "create globalvar changed notify node failed");
+                return false;
+            }
+        }
         if (!zk_client_->GetNodeValue(zk_path_.auto_failover_node_, value)) {
             auto_failover_.load(std::memory_order_acquire) ? value = "true" : value = "false";
             if (!zk_client_->CreateNode(zk_path_.auto_failover_node_, value)) {

--- a/src/nameserver/name_server_impl.cc
+++ b/src/nameserver/name_server_impl.cc
@@ -10313,6 +10313,8 @@ base::Status NameServerImpl::InitGlobalVarTable() {
     std::map<std::string, std::string> default_value = {
         {"execute_mode", "offline"},
         {"enable_trace", "false"},
+        {"sync_job", "false"},
+        {"job_timeout", "20000"}
     };
     // get table_info
     std::string db = INFORMATION_SCHEMA_DB;

--- a/src/nameserver/name_server_impl.cc
+++ b/src/nameserver/name_server_impl.cc
@@ -35,6 +35,7 @@
 #include "gflags/gflags.h"
 #include "schema/index_util.h"
 #include "schema/schema_adapter.h"
+#include "codec/row_codec.h"
 
 DECLARE_string(endpoint);
 DECLARE_string(zk_cluster);
@@ -1279,6 +1280,33 @@ void NameServerImpl::RecoverEndpointInternal(const std::string& endpoint, bool n
     for (const auto& kv : db_table_info_) {
         RecoverEndpointDBInternal(endpoint, need_restore, concurrency, kv.second);
     }
+    // recover global variable after tablet restart
+    std::shared_ptr<TableInfo> table_info;
+    if (!GetTableInfo(GLOBAL_VARIABLES, INFORMATION_SCHEMA_DB, &table_info)) {
+        PDLOG(WARNING, "table is not exist!");
+        return;
+    }
+    bool exist_globalvar = false;
+    for (int meta_idx = 0; meta_idx < table_info->table_partition(0).partition_meta_size(); meta_idx++) {
+        if (table_info->table_partition(0).partition_meta(meta_idx).endpoint() == endpoint) {
+            exist_globalvar = true;
+            break;
+        }
+    }
+    if (!exist_globalvar) {
+        NotifyGlobalVarChanged();
+    }
+}
+
+void NameServerImpl::NotifyGlobalVarChanged() {
+    if (!IsClusterMode()) {
+        return;
+    }
+    if (!zk_client_->Increment(zk_path_.globalvar_changed_notify_node_)) {
+        PDLOG(WARNING, "increment failed, node is %s", zk_path_.globalvar_changed_notify_node_);
+        return;
+    }
+    PDLOG(INFO, "notify table changed ok");
 }
 
 void NameServerImpl::ShowTablet(RpcController* controller, const ShowTabletRequest* request,
@@ -1338,6 +1366,7 @@ bool NameServerImpl::Init(const std::string& zk_cluster, const std::string& zk_p
         zk_path_.zone_data_path_ = zk_path + "/cluster";
         zk_path_.auto_failover_node_ = zk_config_path + "/auto_failover";
         zk_path_.table_changed_notify_node_ = zk_table_path + "/notify";
+        zk_path_.globalvar_changed_notify_node_ = zk_path + "/notify/global_variable";
         zone_info_.set_mode(kNORMAL);
         zone_info_.set_zone_name(endpoint + zk_path);
         zone_info_.set_replica_alias("");
@@ -5446,6 +5475,7 @@ void NameServerImpl::OnLocked() {
     if (!Recover()) {
         PDLOG(WARNING, "recover failed");
     }
+    // todo: should support standalone mode
     if (IsClusterMode()) {
         if (tablets_.size() < FLAGS_system_table_replica_num) {
             LOG(FATAL) << "tablet num " << tablets_.size() << " is less then system table replica num "
@@ -5456,6 +5486,7 @@ void NameServerImpl::OnLocked() {
 
         if (FLAGS_system_table_replica_num > 0 && db_table_info_[INTERNAL_DB].count(JOB_INFO_NAME) == 0) {
             CreateSystemTableOrExit(SystemTableType::kJobInfo);
+
         }
     }
 
@@ -5470,6 +5501,7 @@ void NameServerImpl::OnLocked() {
     // TODO(ace): create table if not exists
     if (FLAGS_system_table_replica_num > 0 && db_table_info_[INFORMATION_SCHEMA_DB].count(GLOBAL_VARIABLES) == 0) {
         CreateSystemTableOrExit(SystemTableType::kGlobalVariable);
+        InitGlobalVarTable();
     }
 
     if (FLAGS_system_table_replica_num > 0 && db_table_info_[INFORMATION_SCHEMA_DB].count(DEPLOY_RESPONSE_TIME) == 0) {
@@ -8812,6 +8844,9 @@ void NameServerImpl::DeleteIndex(RpcController* controller, const DeleteIndexReq
 bool NameServerImpl::UpdateZkTableNode(const std::shared_ptr<::openmldb::nameserver::TableInfo>& table_info) {
     if (IsClusterMode() && UpdateZkTableNodeWithoutNotify(table_info.get())) {
         NotifyTableChanged();
+        if (table_info->db() == INFORMATION_SCHEMA_DB && table_info->name() == GLOBAL_VARIABLES) {
+            NotifyGlobalVarChanged();
+        }
         return true;
     }
     return false;
@@ -10266,6 +10301,58 @@ void NameServerImpl::UpdateOfflineTableInfo(::google::protobuf::RpcController* c
         NotifyTableChanged();
     }
     LOG(INFO) << "[" << db_name << "." << table_name << "] update offline table info succeed";
+}
+
+base::Status NameServerImpl::InitGlobalVarTable() {
+    std::map<std::string, std::string> default_value = {
+        {"execute_mode", "offline"},
+        {"enable_trace", "false"},
+    };
+    // get table_info
+    std::string db = INFORMATION_SCHEMA_DB;
+    std::string table = GLOBAL_VARIABLES;
+    std::shared_ptr<TableInfo> table_info;
+    if (!GetTableInfo(table, db, &table_info)) {
+        return {ReturnCode::kTableIsNotExist, "table is not exist!"};
+    }
+    // encode row && dimensions
+    std::vector<std::string> rows;
+    std::vector<std::vector<std::pair<std::string, uint32_t>>> rows_dimensions;
+    for (auto iter = default_value.begin(); iter != default_value.end(); iter++) {
+        std::string row;
+        std::vector<std::string> vec;
+        vec.push_back(iter->first);
+        vec.push_back(iter->second);
+        codec::RowCodec::EncodeRow(vec, table_info->column_desc(), 1, row);
+        rows.push_back(row);
+        std::vector<std::pair<std::string, uint32_t>> dimensions;
+        // only one index in system table
+        dimensions.push_back(std::make_pair(iter->first, 0));
+        rows_dimensions.push_back(dimensions);
+    }
+    // insert value
+    uint32_t tid = table_info->tid();
+    uint32_t pid_num = table_info->table_partition_size();
+    for (int i = 0; i < default_value.size(); i++) {
+        std::string row = rows[i];
+        std::vector<std::pair<std::string, uint32_t>> dimensions = rows_dimensions[i];
+        uint32_t pid = 0;
+        if (pid_num > 0) {
+            pid = (uint32_t)(::openmldb::base::hash64(dimensions[0].first) % pid_num);
+        }
+        // system table only have one partition, so table_partition(0) can be used
+        for (int meta_idx = 0; meta_idx < table_info->table_partition(0).partition_meta_size(); meta_idx++) {
+            if (table_info->table_partition(0).partition_meta(meta_idx).is_leader()) {
+                uint64_t cur_ts = ::baidu::common::timer::get_micros() / 1000;
+                std::string endpoint = table_info->table_partition(0).partition_meta(meta_idx).endpoint();
+                auto table_ptr = GetTablet(endpoint);
+                if (!table_ptr->client_->Put(tid, pid, cur_ts, row, dimensions)) {
+                    LOG(WARNING) << "fail to make a put request to table. tid " + std::to_string(tid);
+                    return {};
+                }
+            }
+        }
+    }
 }
 
 }  // namespace nameserver

--- a/src/nameserver/name_server_impl.h
+++ b/src/nameserver/name_server_impl.h
@@ -353,6 +353,7 @@ class NameServerImpl : public NameServer {
 
     void DropProcedure(RpcController* controller, const api::DropProcedureRequest* request, GeneralResponse* response,
                        Closure* done);
+ 
  private:
     // create the database if not exists, exit on fail
     void CreateDatabaseOrExit(const std::string& db_name);

--- a/src/nameserver/name_server_impl.h
+++ b/src/nameserver/name_server_impl.h
@@ -355,6 +355,8 @@ class NameServerImpl : public NameServer {
                        Closure* done);
  
  private:
+    base::Status InitGlobalVarTable();
+
     // create the database if not exists, exit on fail
     void CreateDatabaseOrExit(const std::string& db_name);
 

--- a/src/nameserver/name_server_impl.h
+++ b/src/nameserver/name_server_impl.h
@@ -352,9 +352,8 @@ class NameServerImpl : public NameServer {
     bool CreateProcedureOnTablet(const api::CreateProcedureRequest& sp_request, std::string& err_msg);  // NOLINT
 
     void DropProcedure(RpcController* controller, const api::DropProcedureRequest* request, GeneralResponse* response,
-                       Closure* done);
- 
- private:
+                       Closure* done); 
+private:
     base::Status InitGlobalVarTable();
 
     // create the database if not exists, exit on fail

--- a/src/nameserver/name_server_impl.h
+++ b/src/nameserver/name_server_impl.h
@@ -352,8 +352,9 @@ class NameServerImpl : public NameServer {
     bool CreateProcedureOnTablet(const api::CreateProcedureRequest& sp_request, std::string& err_msg);  // NOLINT
 
     void DropProcedure(RpcController* controller, const api::DropProcedureRequest* request, GeneralResponse* response,
-                       Closure* done); 
-private:
+                       Closure* done);
+
+ private:
     base::Status InitGlobalVarTable();
 
     // create the database if not exists, exit on fail

--- a/src/nameserver/name_server_impl.h
+++ b/src/nameserver/name_server_impl.h
@@ -114,6 +114,7 @@ struct ZkPath {
     std::string op_index_node_;
     std::string op_data_path_;
     std::string op_sync_path_;
+    std::string globalvar_changed_notify_node_;
 };
 
 class NameServerImplTest;
@@ -352,7 +353,6 @@ class NameServerImpl : public NameServer {
 
     void DropProcedure(RpcController* controller, const api::DropProcedureRequest* request, GeneralResponse* response,
                        Closure* done);
-
  private:
     // create the database if not exists, exit on fail
     void CreateDatabaseOrExit(const std::string& db_name);
@@ -757,6 +757,8 @@ class NameServerImpl : public NameServer {
     base::Status CreateDatabase(const std::string& db_name, bool if_not_exists = false);
 
     uint64_t GetTerm() const;
+
+    void NotifyGlobalVarChanged();
 
  private:
     std::mutex mu_;

--- a/src/sdk/db_sdk.cc
+++ b/src/sdk/db_sdk.cc
@@ -98,7 +98,6 @@ bool ClusterSDK::TriggerNotify() const {
 }
 
 bool ClusterSDK::GlobalVarNotify() const {
-    LOG(INFO) << "Global variable changed trigger notify node";
     return zk_client_->Increment(globalvar_changed_notify_path_);
 }
 

--- a/src/sdk/sql_cluster_router.cc
+++ b/src/sdk/sql_cluster_router.cc
@@ -252,6 +252,7 @@ bool SQLClusterRouter::Init() {
             }
         }
     }
+    // todo: init session variables from systemtable
     session_variables_.emplace("execute_mode", "offline");
     session_variables_.emplace("enable_trace", "false");
     session_variables_.emplace("sync_job", "false");


### PR DESCRIPTION
1. support init global system table when nameserver init
2. support recover system table when tablet restart
3. add global var `sync_job` `job_timeout`