### PR TITLE
refactor: correct spelling of oepnmldb_type to openmldb_type

### DIFF
--- a/src/schema/schema_adapter.cc
+++ b/src/schema/schema_adapter.cc
@@ -176,37 +176,37 @@ bool SchemaAdapter::ConvertType(hybridse::node::DataType hybridse_type, openmldb
     return true;
 }
 
-bool SchemaAdapter::ConvertType(hybridse::type::Type hybridse_type, openmldb::type::DataType* oepnmldb_type) {
-    if (oepnmldb_type == nullptr) {
+bool SchemaAdapter::ConvertType(hybridse::type::Type hybridse_type, openmldb::type::DataType* openmldb_type) {
+    if (openmldb_type == nullptr) {
         return false;
     }
     switch (hybridse_type) {
         case hybridse::type::kBool:
-            *oepnmldb_type = openmldb::type::kBool;
+            *openmldb_type = openmldb::type::kBool;
             break;
         case hybridse::type::kInt16:
-            *oepnmldb_type = openmldb::type::kSmallInt;
+            *openmldb_type = openmldb::type::kSmallInt;
             break;
         case hybridse::type::kInt32:
-            *oepnmldb_type = openmldb::type::kInt;
+            *openmldb_type = openmldb::type::kInt;
             break;
         case hybridse::type::kInt64:
-            *oepnmldb_type = openmldb::type::kBigInt;
+            *openmldb_type = openmldb::type::kBigInt;
             break;
         case hybridse::type::kFloat:
-            *oepnmldb_type = openmldb::type::kFloat;
+            *openmldb_type = openmldb::type::kFloat;
             break;
         case hybridse::type::kDouble:
-            *oepnmldb_type = openmldb::type::kDouble;
+            *openmldb_type = openmldb::type::kDouble;
             break;
         case hybridse::type::kDate:
-            *oepnmldb_type = openmldb::type::kDate;
+            *openmldb_type = openmldb::type::kDate;
             break;
         case hybridse::type::kTimestamp:
-            *oepnmldb_type = openmldb::type::kTimestamp;
+            *openmldb_type = openmldb::type::kTimestamp;
             break;
         case hybridse::type::kVarchar:
-            *oepnmldb_type = openmldb::type::kVarchar;
+            *openmldb_type = openmldb::type::kVarchar;
             break;
         default:
             LOG(WARNING) << "unsupported type" << hybridse_type;
@@ -215,11 +215,11 @@ bool SchemaAdapter::ConvertType(hybridse::type::Type hybridse_type, openmldb::ty
     return true;
 }
 
-bool SchemaAdapter::ConvertType(openmldb::type::DataType oepnmldb_type, hybridse::type::Type* hybridse_type) {
+bool SchemaAdapter::ConvertType(openmldb::type::DataType openmldb_type, hybridse::type::Type* hybridse_type) {
     if (hybridse_type == nullptr) {
         return false;
     }
-    switch (oepnmldb_type) {
+    switch (openmldb_type) {
         case openmldb::type::kBool:
             *hybridse_type = hybridse::type::kBool;
             break;
@@ -249,7 +249,7 @@ bool SchemaAdapter::ConvertType(openmldb::type::DataType oepnmldb_type, hybridse
             *hybridse_type = hybridse::type::kVarchar;
             break;
         default:
-            LOG(WARNING) << "unsupported type: " << openmldb::type::DataType_Name(oepnmldb_type);
+            LOG(WARNING) << "unsupported type: " << openmldb::type::DataType_Name(openmldb_type);
             return false;
     }
     return true;

--- a/src/schema/schema_adapter.h
+++ b/src/schema/schema_adapter.h
@@ -46,9 +46,9 @@ class SchemaAdapter {
 
     static bool ConvertType(hybridse::node::DataType hybridse_type, openmldb::type::DataType* type);
 
-    static bool ConvertType(hybridse::type::Type hybridse_type, openmldb::type::DataType* oepnmldb_type);
+    static bool ConvertType(hybridse::type::Type hybridse_type, openmldb::type::DataType* openmldb_type);
 
-    static bool ConvertType(openmldb::type::DataType oepnmldb_type, hybridse::type::Type* hybridse_type);
+    static bool ConvertType(openmldb::type::DataType openmldb_type, hybridse::type::Type* hybridse_type);
 
     static bool ConvertType(hybridse::sdk::DataType type, hybridse::type::Type *cased_type);
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Renaming variable name `oepnmldb_type` to `openmldb_type` in the following files:

 `src/schema/schema_adapter.h`
 `src/schema/schema_adapter.cc`

* **What is the current behavior?** (You can also link to an open issue here)

Issue: https://github.com/4paradigm/OpenMLDB/issues/1499

* **What is the new behavior (if this is a feature change)?**

N/A.

* **Does this PR introduce a breaking change?**

No.
