### PR TITLE
fix: autoLoad format

### DIFF
--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/SparkPlanner.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/SparkPlanner.scala
@@ -16,26 +16,20 @@
 
 package com._4paradigm.openmldb.batch
 
-import com._4paradigm.hybridse.HybridSeLibrary
 import com._4paradigm.hybridse.`type`.TypeOuterClass.Database
 import com._4paradigm.hybridse.node.JoinType
 import com._4paradigm.hybridse.sdk.{SqlEngine, UnsupportedHybridSeException}
-import com._4paradigm.hybridse.vm.{CoreAPI, Engine, PhysicalConstProjectNode, PhysicalDataProviderNode,
-  PhysicalGroupAggrerationNode, PhysicalGroupNode, PhysicalJoinNode, PhysicalLimitNode, PhysicalLoadDataNode,
-  PhysicalOpNode, PhysicalOpType, PhysicalProjectNode, PhysicalRenameNode, PhysicalSelectIntoNode,
-  PhysicalSimpleProjectNode, PhysicalSortNode, PhysicalTableProjectNode, PhysicalWindowAggrerationNode, ProjectType}
+import com._4paradigm.hybridse.vm.{CoreAPI, Engine, PhysicalConstProjectNode, PhysicalDataProviderNode, PhysicalGroupAggrerationNode, PhysicalGroupNode, PhysicalJoinNode, PhysicalLimitNode, PhysicalLoadDataNode, PhysicalOpNode, PhysicalOpType, PhysicalProjectNode, PhysicalRenameNode, PhysicalSelectIntoNode, PhysicalSimpleProjectNode, PhysicalSortNode, PhysicalTableProjectNode, PhysicalWindowAggrerationNode, ProjectType}
 import com._4paradigm.openmldb.batch.api.OpenmldbSession
-import com._4paradigm.openmldb.batch.nodes.{ConstProjectPlan, DataProviderPlan, GroupByAggregationPlan, GroupByPlan,
-  JoinPlan, LimitPlan, LoadDataPlan, RenamePlan, RowProjectPlan, SelectIntoPlan, SimpleProjectPlan, SortByPlan,
-  WindowAggPlan}
+import com._4paradigm.openmldb.batch.nodes.{ConstProjectPlan, DataProviderPlan, GroupByAggregationPlan, GroupByPlan, JoinPlan, LimitPlan, LoadDataPlan, RenamePlan, RowProjectPlan, SelectIntoPlan, SimpleProjectPlan, SortByPlan, WindowAggPlan}
 import com._4paradigm.openmldb.batch.utils.{GraphvizUtil, HybridseUtil, NodeIndexInfo, NodeIndexType}
 import com._4paradigm.openmldb.sdk.impl.SqlClusterExecutor
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.slf4j.LoggerFactory
 
-import scala.collection.mutable
 import scala.collection.JavaConversions.seqAsJavaList
+import scala.collection.mutable
 
 class SparkPlanner(session: SparkSession, config: OpenmldbBatchConfig, sparkAppName: String) {
 

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/SparkPlanner.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/SparkPlanner.scala
@@ -19,9 +19,14 @@ package com._4paradigm.openmldb.batch
 import com._4paradigm.hybridse.`type`.TypeOuterClass.Database
 import com._4paradigm.hybridse.node.JoinType
 import com._4paradigm.hybridse.sdk.{SqlEngine, UnsupportedHybridSeException}
-import com._4paradigm.hybridse.vm.{CoreAPI, Engine, PhysicalConstProjectNode, PhysicalDataProviderNode, PhysicalGroupAggrerationNode, PhysicalGroupNode, PhysicalJoinNode, PhysicalLimitNode, PhysicalLoadDataNode, PhysicalOpNode, PhysicalOpType, PhysicalProjectNode, PhysicalRenameNode, PhysicalSelectIntoNode, PhysicalSimpleProjectNode, PhysicalSortNode, PhysicalTableProjectNode, PhysicalWindowAggrerationNode, ProjectType}
+import com._4paradigm.hybridse.vm.{CoreAPI, Engine, PhysicalConstProjectNode, PhysicalDataProviderNode,
+  PhysicalGroupAggrerationNode, PhysicalGroupNode, PhysicalJoinNode, PhysicalLimitNode, PhysicalLoadDataNode,
+  PhysicalOpNode, PhysicalOpType, PhysicalProjectNode, PhysicalRenameNode, PhysicalSelectIntoNode,
+  PhysicalSimpleProjectNode, PhysicalSortNode, PhysicalTableProjectNode, PhysicalWindowAggrerationNode, ProjectType}
 import com._4paradigm.openmldb.batch.api.OpenmldbSession
-import com._4paradigm.openmldb.batch.nodes.{ConstProjectPlan, DataProviderPlan, GroupByAggregationPlan, GroupByPlan, JoinPlan, LimitPlan, LoadDataPlan, RenamePlan, RowProjectPlan, SelectIntoPlan, SimpleProjectPlan, SortByPlan, WindowAggPlan}
+import com._4paradigm.openmldb.batch.nodes.{ConstProjectPlan, DataProviderPlan, GroupByAggregationPlan, GroupByPlan,
+  JoinPlan, LimitPlan, LoadDataPlan, RenamePlan, RowProjectPlan, SelectIntoPlan, SimpleProjectPlan, SortByPlan,
+  WindowAggPlan}
 import com._4paradigm.openmldb.batch.utils.{GraphvizUtil, HybridseUtil, NodeIndexInfo, NodeIndexType}
 import com._4paradigm.openmldb.sdk.impl.SqlClusterExecutor
 import org.apache.hadoop.fs.{FileSystem, Path}

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/LoadDataPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/LoadDataPlan.scala
@@ -98,10 +98,12 @@ object LoadDataPlan {
     }
     // csv should auto detect the timestamp format
 
+    logger.info(s"set file format: $format")
+    reader.format(format)
     // use string to read, then infer the format by the first non-null value of the ts column
     val longTsCols = parseLongTsCols(reader, readSchema, tsCols, file)
-    logger.info(s"read schema: $readSchema")
-    var df = reader.schema(readSchema).format(format).load(file)
+    logger.info(s"read schema: $readSchema, file $file")
+    var df = reader.schema(readSchema).load(file)
     if (longTsCols.nonEmpty) {
       // convert long type to timestamp type
       for (tsCol <- longTsCols) {

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/TestLoadDataPlan.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/TestLoadDataPlan.scala
@@ -85,14 +85,14 @@ class TestLoadDataPlan extends SparkTestSuite with Matchers {
     cols.add(col)
 
     val testFile = "file://" + getClass.getResource("/load_data_test_src/sql_timestamp.csv").getPath
-    val df = autoLoad( getSparkSession.read.option("header", "true").option("nullValue", "null"),
+    val df = autoLoad(getSparkSession.read.option("header", "true").option("nullValue", "null"),
       testFile, "csv", cols)
     df.show()
     val l = df.select("ts").rdd.map(r => r(0)).collect.toList
     l.toString() should equal("List(null, 1970-01-01 00:00:00.0, null, null, 2022-02-01 09:00:00.0)")
 
     val testFile2 = "file://" + getClass.getResource("/load_data_test_src/long_timestamp.csv").getPath
-    val df2 = autoLoad( getSparkSession.read.option("header", "true").option("nullValue", "null"),
+    val df2 = autoLoad(getSparkSession.read.option("header", "true").option("nullValue", "null"),
       testFile2, "csv", cols)
     df2.show()
     val l2 = df2.select("ts").rdd.map(r => r(0)).collect.toList
@@ -102,7 +102,7 @@ class TestLoadDataPlan extends SparkTestSuite with Matchers {
     val testFile3 = "file://" + getClass.getResource("/load_data_test_src/timestamp.parquet").getPath
     // the format setting in arg1 won't work, autoLoad will use arg2 format to load file
     val df3 = autoLoad(getSparkSession.read.option("header", "true").option("nullValue", "null").format("csv"),
-      testFile3,"parquet", cols)
+      testFile3, "parquet", cols)
     df3.show()
     val l3 = df3.select("ts").rdd.map(r => r(0)).collect.toList
     l3.toString() should equal("List(null, 1970-01-01 08:00:00.0, 2022-02-01 17:00:00.0)")

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/TestLoadDataPlan.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/TestLoadDataPlan.scala
@@ -85,14 +85,14 @@ class TestLoadDataPlan extends SparkTestSuite with Matchers {
     cols.add(col)
 
     val testFile = "file://" + getClass.getResource("/load_data_test_src/sql_timestamp.csv").getPath
-    val df = autoLoad( getSparkSession.read.format("csv").option("header", "true").option("nullValue", "null"),
+    val df = autoLoad( getSparkSession.read.option("header", "true").option("nullValue", "null"),
       testFile, "csv", cols)
     df.show()
     val l = df.select("ts").rdd.map(r => r(0)).collect.toList
     l.toString() should equal("List(null, 1970-01-01 00:00:00.0, null, null, 2022-02-01 09:00:00.0)")
 
     val testFile2 = "file://" + getClass.getResource("/load_data_test_src/long_timestamp.csv").getPath
-    val df2 = autoLoad( getSparkSession.read.format("csv").option("header", "true").option("nullValue", "null"),
+    val df2 = autoLoad( getSparkSession.read.option("header", "true").option("nullValue", "null"),
       testFile2, "csv", cols)
     df2.show()
     val l2 = df2.select("ts").rdd.map(r => r(0)).collect.toList
@@ -100,9 +100,12 @@ class TestLoadDataPlan extends SparkTestSuite with Matchers {
 
     // won't try to parse timestamp format when loading parquet
     val testFile3 = "file://" + getClass.getResource("/load_data_test_src/timestamp.parquet").getPath
-    val df3 = autoLoad(getSparkSession.read.format("parquet").option("header", "true").option("nullValue", "null"),
+    // the format setting in arg1 won't work, autoLoad will use arg2 format to load file
+    val df3 = autoLoad(getSparkSession.read.option("header", "true").option("nullValue", "null").format("csv"),
       testFile3,"parquet", cols)
     df3.show()
+    val l3 = df3.select("ts").rdd.map(r => r(0)).collect.toList
+    l3.toString() should equal("List(null, 1970-01-01 08:00:00.0, 2022-02-01 17:00:00.0)")
   }
 
   ignore("Test Load to Openmldb Offline Storage") {


### PR DESCRIPTION
`autoLoad` should use the arg `format`, not the reader's default format.
fix ut.