### PR TITLE
fix: execute udf function on string field will core dump if length greater than 2048

### DIFF
--- a/hybridse/src/codegen/udf_ir_builder_test.cc
+++ b/hybridse/src/codegen/udf_ir_builder_test.cc
@@ -631,6 +631,19 @@ TEST_F(UdfIRBuilderTest, lower_lcase) {
     CheckUdf<Nullable<StringRef>, Nullable<StringRef>>("lower", StringRef(""), StringRef(""));
     CheckUdf<Nullable<StringRef>, Nullable<StringRef>>("lcase", nullptr, nullptr);
     CheckUdf<Nullable<StringRef>, Nullable<StringRef>>("lower", nullptr, nullptr);
+    char* buf1 = (char*)malloc(2 * 1024 * 1024 + 1);
+    char* buf2 = (char*)malloc(2 * 1024 * 1024 - 1);
+    char* buf3 = (char*)malloc(2 * 1024 * 1024 - 1);
+    memset(buf1, 'A', 2 * 1024 * 1024 + 1);
+    memset(buf2, 'A', 2 * 1024 * 1024 - 1);
+    memset(buf3, 'a', 2 * 1024 * 1024 - 1);
+    StringRef large_str = StringRef(2 * 1024 * 1024 - 1, buf2);
+    StringRef large_str1 = StringRef(2 * 1024 * 1024 - 1, buf3);
+    CheckUdf<Nullable<StringRef>, Nullable<StringRef>>("lower", nullptr, StringRef(2 * 1024 * 1024 + 1, buf1));
+    CheckUdf<Nullable<StringRef>, Nullable<StringRef>>("lower", large_str1, large_str);
+    delete buf1;
+    delete buf2;
+    delete buf3;
 }
 
 TEST_F(UdfIRBuilderTest, concat_str_udf_test) {

--- a/hybridse/src/codegen/udf_ir_builder_test.cc
+++ b/hybridse/src/codegen/udf_ir_builder_test.cc
@@ -631,9 +631,9 @@ TEST_F(UdfIRBuilderTest, lower_lcase) {
     CheckUdf<Nullable<StringRef>, Nullable<StringRef>>("lower", StringRef(""), StringRef(""));
     CheckUdf<Nullable<StringRef>, Nullable<StringRef>>("lcase", nullptr, nullptr);
     CheckUdf<Nullable<StringRef>, Nullable<StringRef>>("lower", nullptr, nullptr);
-    char* buf1 = (char*)malloc(2 * 1024 * 1024 + 1);
-    char* buf2 = (char*)malloc(2 * 1024 * 1024 - 1);
-    char* buf3 = (char*)malloc(2 * 1024 * 1024 - 1);
+    char* buf1 = reinterpret_cast<char*>(malloc(2 * 1024 * 1024 + 1));
+    char* buf2 = reinterpret_cast<char*>(malloc(2 * 1024 * 1024 - 1));
+    char* buf3 = reinterpret_cast<char*>(malloc(2 * 1024 * 1024 - 1));
     memset(buf1, 'A', 2 * 1024 * 1024 + 1);
     memset(buf2, 'A', 2 * 1024 * 1024 - 1);
     memset(buf3, 'a', 2 * 1024 * 1024 - 1);

--- a/hybridse/src/udf/containers.h
+++ b/hybridse/src/udf/containers.h
@@ -112,6 +112,11 @@ class TopKContainer {
         }
         // allocate string buffer
         char* buffer = udf::v1::AllocManagedStringBuf(str_len);
+        if (buffer == nullptr) {
+            output->size_ = 0;
+            output->data_ = "";
+            return;
+        }
         // fill string buffer
         char* cur = buffer;
         uint32_t remain_space = str_len;
@@ -243,6 +248,11 @@ class BoundedGroupByDict {
 
         // allocate string buffer
         char* buffer = udf::v1::AllocManagedStringBuf(str_len);
+        if (buffer == nullptr) {
+            output->size_ = 0;
+            output->data_ = "";
+            return;
+        }
 
         // fill string buffer
         char* cur = buffer;

--- a/hybridse/src/udf/default_defs/feature_zero_def.cc
+++ b/hybridse/src/udf/default_defs/feature_zero_def.cc
@@ -360,6 +360,11 @@ struct FZStringOpsDef {
             }
         }
         char* buf = v1::AllocManagedStringBuf(bytes + 1);
+        if (buf == nullptr) {
+            output->size_ = 0;
+            output->data_ = "";
+            return;
+        }
         buf[bytes] = 0;
 
         size_t offset = 0;
@@ -518,6 +523,11 @@ struct FZTopNFrequency {
 
         // allocate string buffer
         char* buffer = udf::v1::AllocManagedStringBuf(str_len);
+        if (buffer == nullptr) {
+            output->size_ = 0;
+            output->data_ = "";
+            return;
+        }
 
         // fill string buffer
         char* cur = buffer;

--- a/hybridse/src/udf/udf.cc
+++ b/hybridse/src/udf/udf.cc
@@ -49,7 +49,7 @@ using hybridse::codec::StringRef;
 // TODO(chenjing): 时区统一配置
 constexpr int32_t TZ = 8;
 constexpr time_t TZ_OFFSET = TZ * 3600000;
-constexpr int MAX_ALLOC_SIZE = 2 * 1024 * 1024; // 2M
+constexpr int MAX_ALLOC_SIZE = 2 * 1024 * 1024;  // 2M
 bthread_key_t B_THREAD_LOCAL_MEM_POOL_KEY;
 
 int32_t dayofyear(int64_t ts) {


### PR DESCRIPTION
expand `MAX_ALLOC_SIZE` to 2M