### PR TITLE
fix: rename class in Python SDK for 0.4.4 features

### DIFF
--- a/python/openmldb/dbapi/dbapi.py
+++ b/python/openmldb/dbapi/dbapi.py
@@ -462,7 +462,7 @@ class Connection(object):
         self._zk = zk
         self._zkPath = zkPath
         options = sdk_module.OpenmldbSdkOptions(zk, zkPath)
-        sdk = sdk_module.OpenmldbSdk(options)
+        sdk = sdk_module.OpenMLDBSdk(options)
         ok = sdk.init()
         if not ok:
             raise Exception("init openmldb sdk erred")

--- a/python/openmldb/sdk/sdk.py
+++ b/python/openmldb/sdk/sdk.py
@@ -31,7 +31,7 @@ class OpenmldbSdkOptions(object):
         self.zk_path = zk_path
         self.session_timeout = session_timeout
 
-class OpenmldbSdk(object):
+class OpenMLDBSdk(object):
     def __init__(self, options):
         self.options = options
         self.sdk = None


### PR DESCRIPTION
This is a bug fix for [PR](https://github.com/4paradigm/OpenMLDB/pull/1535) naming rules will be refractor in the future. 