### PR TITLE
feat: support reading spark conf file from cli

### DIFF
--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/OpenmldbBatchConfig.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/OpenmldbBatchConfig.scala
@@ -135,9 +135,9 @@ class OpenmldbBatchConfig extends Serializable {
   @ConfigOption(name = "openmldb.opt.join.spark_expr", doc = "Enable join with original Spark expression")
   var enableJoinWithSparkExpr = true
 
-  // Switch for disable OpenMLDB
-  @ConfigOption(name = "openmldb.disable", doc = "Disable OpenMLDB optimization or not")
-  var disableOpenmldb = false
+  // Use SparkSQL
+  @ConfigOption(name = "openmldb.sparksql", doc = "Enable SparkSQL instead of using OpenMLDB execution engine")
+  var enableSparksql = false
 
   // OpenMLDB Java SDK dynamic library path, notice that this should not be set hybridse jsdk so
   @ConfigOption(name = "openmldb.jsdk.library.path", doc = "The path of OpenMLDB Java SDK core file path")

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/api/OpenmldbSession.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/api/OpenmldbSession.scala
@@ -158,7 +158,7 @@ class OpenmldbSession {
    * @return
    */
   def openmldbSql(sqlText: String): OpenmldbDataframe = {
-    if (config.disableOpenmldb) {
+    if (config.enableSparksql) {
       return OpenmldbDataframe(this, sparksql(sqlText))
     }
 

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/TestOpenmldbBatchConfig.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/TestOpenmldbBatchConfig.scala
@@ -45,16 +45,16 @@ class TestOpenmldbBatchConfig extends FunSuite {
     assert(config.print)
   }
 
-  test("Test openmldb.disable") {
+  test("Test config of openmldb.sparksql") {
     val dict = Map(
-      "openmldb.disable" -> true
+      "openmldb.sparksql" -> true
     )
     val config = OpenmldbBatchConfig.fromDict(dict)
-    assert(config.disableOpenmldb)
+    assert(config.enableSparksql)
 
     val spark = SparkSession.builder()
       .master("local")
-      .config("openmldb.disable", true)
+      .config("openmldb.sparksql", true)
       .getOrCreate()
     val sess = new OpenmldbSession(spark)
 

--- a/java/openmldb-taskmanager/src/main/scala/com/_4paradigm/openmldb/taskmanager/spark/SparkJobManager.scala
+++ b/java/openmldb-taskmanager/src/main/scala/com/_4paradigm/openmldb/taskmanager/spark/SparkJobManager.scala
@@ -21,8 +21,11 @@ import com._4paradigm.openmldb.taskmanager.config.TaskManagerConfig
 import com._4paradigm.openmldb.taskmanager.dao.JobInfo
 import com._4paradigm.openmldb.taskmanager.yarn.YarnClientUtil
 import org.apache.spark.launcher.SparkLauncher
+import org.slf4j.LoggerFactory
 
 object SparkJobManager {
+
+  private val logger = LoggerFactory.getLogger(this.getClass)
 
   /**
    * Create the SparkLauncher object with pre-set parameters like yarn-cluster.
@@ -106,7 +109,9 @@ object SparkJobManager {
     if (TaskManagerConfig.OFFLINE_DATA_PREFIX.nonEmpty) {
       launcher.setConf("spark.openmldb.offline.data.prefix", TaskManagerConfig.OFFLINE_DATA_PREFIX)
     }
+
     for ((k, v) <- sparkConf) {
+      logger.info("Get Spark config key: " + k + ", value: " + v)
       launcher.setConf(k, v)
     }
 

--- a/release/conf/spark_conf.ini
+++ b/release/conf/spark_conf.ini
@@ -1,0 +1,2 @@
+[Spark]
+spark.yarn.maxAppAttempts=1

--- a/src/client/taskmanager_client.cc
+++ b/src/client/taskmanager_client.cc
@@ -97,7 +97,9 @@ namespace openmldb::client {
 
     request.set_sql(sql);
     request.set_default_db(default_db);
-    // TODO(tobe): Set map of config
+    for (auto it=config.begin(); it!=config.end(); ++it) {
+        (*request.mutable_conf())[it->first] = it->second;
+    }
 
     bool ok = client_.SendRequest(&::openmldb::taskmanager::TaskManagerServer_Stub::RunBatchSql, &request,
                                   &response, FLAGS_request_timeout_ms, 1);
@@ -121,8 +123,10 @@ namespace openmldb::client {
 
     request.set_sql(sql);
     request.set_default_db(default_db);
-    // TODO: Set map of config
     request.set_sync_job(sync_job);
+    for (auto it=config.begin(); it!=config.end(); ++it) {
+        (*request.mutable_conf())[it->first] = it->second;
+    }
 
     bool ok = client_.SendRequest(&::openmldb::taskmanager::TaskManagerServer_Stub::RunBatchAndShow, &request,
                                   &response, request_timeout_ms_, 1);
@@ -149,6 +153,9 @@ namespace openmldb::client {
     request.set_sql(sql);
     request.set_default_db(default_db);
     request.set_sync_job(sync_job);
+    for (auto it=config.begin(); it!=config.end(); ++it) {
+        (*request.mutable_conf())[it->first] = it->second;
+    }
 
     bool ok = client_.SendRequest(&::openmldb::taskmanager::TaskManagerServer_Stub::ImportOnlineData, &request,
                                   &response, request_timeout_ms_, 1);
@@ -175,6 +182,9 @@ namespace openmldb::client {
     request.set_sql(sql);
     request.set_default_db(default_db);
     request.set_sync_job(sync_job);
+    for (auto it=config.begin(); it!=config.end(); ++it) {
+        (*request.mutable_conf())[it->first] = it->second;
+    }
 
     bool ok = client_.SendRequest(&::openmldb::taskmanager::TaskManagerServer_Stub::ImportOfflineData, &request,
                                   &response, request_timeout_ms_, 1);
@@ -201,6 +211,9 @@ namespace openmldb::client {
     request.set_sql(sql);
     request.set_default_db(default_db);
     request.set_sync_job(sync_job);
+    for (auto it=config.begin(); it!=config.end(); ++it) {
+        (*request.mutable_conf())[it->first] = it->second;
+    }
 
     bool ok = client_.SendRequest(&::openmldb::taskmanager::TaskManagerServer_Stub::ExportOfflineData, &request,
                                   &response, request_timeout_ms_, 1);

--- a/src/client/taskmanager_client.cc
+++ b/src/client/taskmanager_client.cc
@@ -97,7 +97,7 @@ namespace openmldb::client {
 
     request.set_sql(sql);
     request.set_default_db(default_db);
-    for (auto it=config.begin(); it!=config.end(); ++it) {
+    for (auto it=config.begin(); it != config.end(); ++it) {
         (*request.mutable_conf())[it->first] = it->second;
     }
 
@@ -124,7 +124,7 @@ namespace openmldb::client {
     request.set_sql(sql);
     request.set_default_db(default_db);
     request.set_sync_job(sync_job);
-    for (auto it=config.begin(); it!=config.end(); ++it) {
+    for (auto it=config.begin(); it != config.end(); ++it) {
         (*request.mutable_conf())[it->first] = it->second;
     }
 
@@ -153,7 +153,7 @@ namespace openmldb::client {
     request.set_sql(sql);
     request.set_default_db(default_db);
     request.set_sync_job(sync_job);
-    for (auto it=config.begin(); it!=config.end(); ++it) {
+    for (auto it=config.begin(); it != config.end(); ++it) {
         (*request.mutable_conf())[it->first] = it->second;
     }
 
@@ -182,7 +182,7 @@ namespace openmldb::client {
     request.set_sql(sql);
     request.set_default_db(default_db);
     request.set_sync_job(sync_job);
-    for (auto it=config.begin(); it!=config.end(); ++it) {
+    for (auto it=config.begin(); it != config.end(); ++it) {
         (*request.mutable_conf())[it->first] = it->second;
     }
 
@@ -211,7 +211,7 @@ namespace openmldb::client {
     request.set_sql(sql);
     request.set_default_db(default_db);
     request.set_sync_job(sync_job);
-    for (auto it=config.begin(); it!=config.end(); ++it) {
+    for (auto it=config.begin(); it != config.end(); ++it) {
         (*request.mutable_conf())[it->first] = it->second;
     }
 

--- a/src/sdk/sql_cluster_router.h
+++ b/src/sdk/sql_cluster_router.h
@@ -296,7 +296,7 @@ class SQLClusterRouter : public SQLRouter {
 
     std::vector<::hybridse::vm::AggrTableInfo> GetAggrTables() override;
 
-    void ReadSparkConfFromFile(std::string conf_file, std::map<std::string, std::string>& config);
+    void ReadSparkConfFromFile(std::string conf_file, std::map<std::string, std::string>* config);
 
  private:
     void GetTables(::hybridse::vm::PhysicalOpNode* node, std::set<std::string>* tables);

--- a/src/sdk/sql_cluster_router.h
+++ b/src/sdk/sql_cluster_router.h
@@ -296,6 +296,8 @@ class SQLClusterRouter : public SQLRouter {
 
     std::vector<::hybridse::vm::AggrTableInfo> GetAggrTables() override;
 
+    void ReadSparkConfFromFile(std::string conf_file, std::map<std::string, std::string>& config);
+
  private:
     void GetTables(::hybridse::vm::PhysicalOpNode* node, std::set<std::string>* tables);
 


### PR DESCRIPTION
* Rename the config of using SparkSQL
* Support reading spark conf file in CLI with gflag parameter
* Pass map of config for TaskManager APIs
* Add template of spark_conf.ini

Now we can create the spark config file in client side and submit offline jobs with these configuration.

```
./bin/openmldb --zk_cluster=127.0.0.1:2181 --zk_root_path=/openmldb --role=sql_client --spark_conf=../release/conf/spark_conf.ini
```