### PR TITLE
fix: 1554 lag correctness

### DIFF
--- a/cases/function/function/test_udaf_function.yaml
+++ b/cases/function/function/test_udaf_function.yaml
@@ -2395,8 +2395,6 @@ cases:
     desc: |
       correctness for at/lag when offset out-of-range rows_range window frame bound, together with other window function.
       refer https://github.com/4paradigm/OpenMLDB/issues/1554
-    # FIXME(ace): request/cluster run do not meet the expects
-    mode: request-unsupport,cluster-unsupport
     inputs:
       - columns: [ "id int","ts timestamp","group1 string","val1 int" ]
         indexs: [ "index1:group1:ts" ]

--- a/cases/function/function/test_udaf_function.yaml
+++ b/cases/function/function/test_udaf_function.yaml
@@ -1918,8 +1918,6 @@ cases:
   - id: 46
     desc: window lag functions
     sqlDialect: ["HybridSQL"]
-    # FIXME(ace): cluster & batch-request mode
-    mode: cluster-unsupport, batch-request-unsupport
     inputs:
       -
         columns : ["id int","pk bigint","c1 string","c2 int","c3 bigint","c4 float",
@@ -2304,8 +2302,6 @@ cases:
         - [4,"aa",1,1,30,1.1,2.1,1590738990000,"2020-05-01","a"]
   - id: 56
     desc: window at functions, at is synonym to lag
-    # FIXME(ace): cluster & batch-request mode
-    mode: cluster-unsupport, batch-request-unsupport
     sqlDialect: ["HybridSQL"]
     inputs:
       -

--- a/cases/function/function/test_udaf_function.yaml
+++ b/cases/function/function/test_udaf_function.yaml
@@ -2353,7 +2353,7 @@ cases:
 
   - id: 57
     desc: |
-      correctness for at/lag when offset out-of-range window frame bound.
+      correctness for at/lag when offset out-of-range rows_range window frame bound.
       keynote, lag returns value evaluated at the row that is offset rows before the current row within the partition.
       refer https://github.com/4paradigm/OpenMLDB/issues/1554
     inputs:
@@ -2393,7 +2393,7 @@ cases:
 
   - id: 58
     desc: |
-      correctness for at/lag when offset out-of-range window frame bound, together with other window function.
+      correctness for at/lag when offset out-of-range rows_range window frame bound, together with other window function.
       refer https://github.com/4paradigm/OpenMLDB/issues/1554
     # FIXME(ace): request/cluster run do not meet the expects
     mode: request-unsupport,cluster-unsupport
@@ -2407,9 +2407,9 @@ cases:
           3, 1612130402000, g1, 3
           4, 1612130403000, g1, 4
           5, 1612130404000, g1, 5
-          6, 1612130404000, g2, 4
-          7, 1612130405000, g2, 3
-          8, 1612130406000, g2, 2
+          6, 1612130405000, g2, 4
+          7, 1612130406000, g2, 3
+          8, 1612130407000, g2, 2
     sql: |
       select
       `id`,
@@ -2419,6 +2419,85 @@ cases:
       first_value(val1) over w1 as agg3
       from `t1` WINDOW
         w1 as (partition by `group1` order by `ts` rows_range between 2s preceding and 1s preceding MAXSIZE 10);
+    expect:
+      columns: ["id int", "val1 int", "agg1 int", "agg2 int", "agg3 int"]
+      order: id
+      data: |
+        1, 1, 1, NULL, NULL
+        2, 2, 2, NULL, 1
+        3, 3, 3, NULL, 2
+        4, 4, 4, 1,    3
+        5, 5, 5, 2,    4
+        6, 4, 4, NULL, NULL
+        7, 3, 3, NULL, 4
+        8, 2, 2, NULL, 3
+
+  - id: 59
+    desc: |
+      correctness for at/lag when offset out-of-range window frame bound.
+      keynote, lag returns value evaluated at the row that is offset rows before the current row within the partition.
+      refer https://github.com/4paradigm/OpenMLDB/issues/1554
+    inputs:
+      - columns: [ "id int","ts timestamp","group1 string","val1 int" ]
+        indexs: [ "index1:group1:ts" ]
+        name: t1
+        data: |
+          1, 1612130400000, g1, 1
+          2, 1612130401000, g1, 2
+          3, 1612130402000, g1, 3
+          4, 1612130403000, g1, 4
+          5, 1612130404000, g1, 5
+          6, 1612130405000, g2, 4
+          7, 1612130406000, g2, 3
+          8, 1612130407000, g2, 2
+    sql: |
+      select
+      `id`,
+      `val1`,
+      lag(val1, 0) over w1 as agg1,
+      lag(val1, 1) over w1 as agg2,
+      lag(val1, 3) over w1 as agg3
+      from `t1` WINDOW
+        w1 as (partition by `group1` order by `ts` rows between 2 preceding and 1 preceding);
+    expect:
+      columns: ["id int", "val1 int", "agg1 int", "agg2 int", "agg3 int"]
+      order: id
+      data: |
+        1, 1, 1, NULL, NULL
+        2, 2, 2, 1,    NULL
+        3, 3, 3, 2,    NULL
+        4, 4, 4, 3,    1
+        5, 5, 5, 4,    2
+        6, 4, 4, NULL, NULL
+        7, 3, 3, 4,    NULL
+        8, 2, 2, 3,    NULL
+
+  - id: 60
+    desc: |
+      correctness for at/lag when offset out-of-range rows window frame bound
+      refer https://github.com/4paradigm/OpenMLDB/issues/1554
+    inputs:
+      - columns: [ "id int","ts timestamp","group1 string","val1 int" ]
+        indexs: [ "index1:group1:ts" ]
+        name: t1
+        data: |
+          1, 1612130400000, g1, 1
+          2, 1612130401000, g1, 2
+          3, 1612130402000, g1, 3
+          4, 1612130403000, g1, 4
+          5, 1612130404000, g1, 5
+          6, 1612130405000, g2, 4
+          7, 1612130406000, g2, 3
+          8, 1612130407000, g2, 2
+    sql: |
+      select
+      `id`,
+      `val1`,
+      lag(val1, 0) over w1 as agg1,
+      lag(val1, 3) over w1 as agg2,
+      first_value(val1) over w1 as agg3
+      from `t1` WINDOW
+        w1 as (partition by `group1` order by `ts` rows between 2 preceding and 1 preceding);
     expect:
       columns: ["id int", "val1 int", "agg1 int", "agg2 int", "agg3 int"]
       order: id

--- a/cases/function/function/test_udaf_function.yaml
+++ b/cases/function/function/test_udaf_function.yaml
@@ -1918,6 +1918,8 @@ cases:
   - id: 46
     desc: window lag functions
     sqlDialect: ["HybridSQL"]
+    # FIXME(ace): cluster & batch-request mode
+    mode: cluster-unsupport, batch-request-unsupport
     inputs:
       -
         columns : ["id int","pk bigint","c1 string","c2 int","c3 bigint","c4 float",
@@ -1946,26 +1948,25 @@ cases:
           lag(c7, 0) OVER w1 as m13,
           lag(c7, 2) OVER w1 as m14,
           lag(c8, 0) OVER w1 as m15,
-          lag(c8, 2) OVER w1 as m16,
-          lag(pk, -1) OVER w1 as m17
+          lag(c8, 2) OVER w1 as m16
       FROM {0} WINDOW
       w1 AS (PARTITION BY {0}.pk ORDER BY {0}.c6 ROWS BETWEEN 2 PRECEDING AND CURRENT ROW);
     expect:
       order: id
       columns: ["id int","m1 string", "m2 string", "m3 int", "m4 int", "m5 bigint", "m6 bigint",
                 "m7 float", "m8 float", "m9 double", "m10 double",
-                "m11 timestamp", "m12 timestamp", "m13 date", "m14 date", "m15 bool", "m16 bool", "m17 bigint"]
+                "m11 timestamp", "m12 timestamp", "m13 date", "m14 date", "m15 bool", "m16 bool"]
       rows:
         - [1, "a", NULL, 1, NULL, 30, NULL, 1.1, NULL, 2.1, NULL,
-           1590738990000, NULL, "2020-05-01", NULL, true, NULL, NULL]
+           1590738990000, NULL, "2020-05-01", NULL, true, NULL]
         - [2, "c", NULL, 4, NULL, 33, NULL, 1.4, NULL, 2.4, NULL,
-           1590738991000, NULL, "2020-05-03", NULL, false, NULL, NULL]
+           1590738991000, NULL, "2020-05-03", NULL, false, NULL]
         - [3, "b", "a", 3, 1, 32, 30, 1.3, 1.1, 2.3, 2.1,
-           1590738992000, 1590738990000, "2020-05-02", "2020-05-01", true, true, NULL]
+           1590738992000, 1590738990000, "2020-05-02", "2020-05-01", true, true]
         - [4, NULL, "c", NULL, 4, NULL, 33, NULL, 1.4, NULL, 2.4,
-           1590738993000, 1590738991000, NULL, "2020-05-03", NULL, false, NULL]
+           1590738993000, 1590738991000, NULL, "2020-05-03", NULL, false]
         - [5, "d", "b", 5, 3, 35, 32, 1.5, 1.3, 2.5, 2.3,
-           1590738994000, 1590738992000, "2020-05-04", "2020-05-02", false, true, NULL]
+           1590738994000, 1590738992000, "2020-05-04", "2020-05-02", false, true]
 
   - id: 47
     desc: count where value equals first value
@@ -2303,6 +2304,8 @@ cases:
         - [4,"aa",1,1,30,1.1,2.1,1590738990000,"2020-05-01","a"]
   - id: 56
     desc: window at functions, at is synonym to lag
+    # FIXME(ace): cluster & batch-request mode
+    mode: cluster-unsupport, batch-request-unsupport
     sqlDialect: ["HybridSQL"]
     inputs:
       -
@@ -2310,11 +2313,11 @@ cases:
                    "c5 double","c6 timestamp","c7 date","c8 bool"]
         indexs: ["index1:pk:c6"]
         rows:
-          - [1, 1, "a", 1, 30, 1.1, 2.1, 1590738990000, "2020-05-01", true]
-          - [2, 1, "c", 4, 33, 1.4, 2.4, 1590738991000, "2020-05-03", false]
-          - [3, 1, "b", 3, 32, 1.3, 2.3, 1590738992000, "2020-05-02", true,]
+          - [1, 1, "a",  1,    30,   1.1,  2.1,  1590738990000, "2020-05-01", true]
+          - [2, 1, "c",  4,    33,   1.4,  2.4,  1590738991000, "2020-05-03", false]
+          - [3, 1, "b",  3,    32,   1.3,  2.3,  1590738992000, "2020-05-02", true,]
           - [4, 1, NULL, NULL, NULL, NULL, NULL, 1590738993000, NULL, NULL]
-          - [5, 1, "d", 5, 35, 1.5, 2.5, 1590738994000, "2020-05-04", false]
+          - [5, 1, "d",  5,    35,   1.5,  2.5,  1590738994000, "2020-05-04", false]
     sql: |
       SELECT {0}.id,
           at(c1, 0) OVER w1 as m1,
@@ -2332,24 +2335,103 @@ cases:
           at(c7, 0) OVER w1 as m13,
           at(c7, 2) OVER w1 as m14,
           at(c8, 0) OVER w1 as m15,
-          at(c8, 2) OVER w1 as m16,
-          at(pk, -1) OVER w1 as m17
+          at(c8, 2) OVER w1 as m16
       FROM {0} WINDOW
       w1 AS (PARTITION BY {0}.pk ORDER BY {0}.c6 ROWS BETWEEN 2 PRECEDING AND CURRENT ROW);
     expect:
       order: id
       columns: ["id int","m1 string", "m2 string", "m3 int", "m4 int", "m5 bigint", "m6 bigint",
                 "m7 float", "m8 float", "m9 double", "m10 double",
-                "m11 timestamp", "m12 timestamp", "m13 date", "m14 date", "m15 bool", "m16 bool", "m17 bigint"]
+                "m11 timestamp", "m12 timestamp", "m13 date", "m14 date", "m15 bool", "m16 bool"]
       rows:
         - [1, "a", NULL, 1, NULL, 30, NULL, 1.1, NULL, 2.1, NULL,
-           1590738990000, NULL, "2020-05-01", NULL, true, NULL, NULL]
+           1590738990000, NULL, "2020-05-01", NULL, true, NULL]
         - [2, "c", NULL, 4, NULL, 33, NULL, 1.4, NULL, 2.4, NULL,
-           1590738991000, NULL, "2020-05-03", NULL, false, NULL, NULL]
+           1590738991000, NULL, "2020-05-03", NULL, false, NULL]
         - [3, "b", "a", 3, 1, 32, 30, 1.3, 1.1, 2.3, 2.1,
-           1590738992000, 1590738990000, "2020-05-02", "2020-05-01", true, true, NULL]
+           1590738992000, 1590738990000, "2020-05-02", "2020-05-01", true, true]
         - [4, NULL, "c", NULL, 4, NULL, 33, NULL, 1.4, NULL, 2.4,
-           1590738993000, 1590738991000, NULL, "2020-05-03", NULL, false, NULL]
+           1590738993000, 1590738991000, NULL, "2020-05-03", NULL, false]
         - [5, "d", "b", 5, 3, 35, 32, 1.5, 1.3, 2.5, 2.3,
-           1590738994000, 1590738992000, "2020-05-04", "2020-05-02", false, true, NULL]
+           1590738994000, 1590738992000, "2020-05-04", "2020-05-02", false, true]
 
+  - id: 57
+    desc: |
+      correctness for at/lag when offset out-of-range window frame bound.
+      keynote, lag returns value evaluated at the row that is offset rows before the current row within the partition.
+      refer https://github.com/4paradigm/OpenMLDB/issues/1554
+    inputs:
+      - columns: [ "id int","ts timestamp","group1 string","val1 int" ]
+        indexs: [ "index1:group1:ts" ]
+        name: t1
+        data: |
+          1, 1612130400000, g1, 1
+          2, 1612130401000, g1, 2
+          3, 1612130402000, g1, 3
+          4, 1612130403000, g1, 4
+          5, 1612130404000, g1, 5
+          6, 1612130404000, g2, 4
+          7, 1612130405000, g2, 3
+          8, 1612130406000, g2, 2
+    sql: |
+      select
+      `id`,
+      `val1`,
+      lag(val1, 0) over w1 as agg1,
+      lag(val1, 1) over w1 as agg2,
+      lag(val1, 3) over w1 as agg3
+      from `t1` WINDOW
+        w1 as (partition by `group1` order by `ts` rows_range between 2s preceding and 1s preceding MAXSIZE 10);
+    expect:
+      columns: ["id int", "val1 int", "agg1 int", "agg2 int", "agg3 int"]
+      order: id
+      data: |
+        1, 1, 1, NULL, NULL
+        2, 2, 2, 1,    NULL
+        3, 3, 3, 2,    NULL
+        4, 4, 4, 3,    1
+        5, 5, 5, 4,    2
+        6, 4, 4, NULL, NULL
+        7, 3, 3, 4,    NULL
+        8, 2, 2, 3,    NULL
+
+  - id: 58
+    desc: |
+      correctness for at/lag when offset out-of-range window frame bound, together with other window function.
+      refer https://github.com/4paradigm/OpenMLDB/issues/1554
+    # FIXME(ace): request/cluster run do not meet the expects
+    mode: request-unsupport,cluster-unsupport
+    inputs:
+      - columns: [ "id int","ts timestamp","group1 string","val1 int" ]
+        indexs: [ "index1:group1:ts" ]
+        name: t1
+        data: |
+          1, 1612130400000, g1, 1
+          2, 1612130401000, g1, 2
+          3, 1612130402000, g1, 3
+          4, 1612130403000, g1, 4
+          5, 1612130404000, g1, 5
+          6, 1612130404000, g2, 4
+          7, 1612130405000, g2, 3
+          8, 1612130406000, g2, 2
+    sql: |
+      select
+      `id`,
+      `val1`,
+      lag(val1, 0) over w1 as agg1,
+      lag(val1, 3) over w1 as agg2,
+      first_value(val1) over w1 as agg3
+      from `t1` WINDOW
+        w1 as (partition by `group1` order by `ts` rows_range between 2s preceding and 1s preceding MAXSIZE 10);
+    expect:
+      columns: ["id int", "val1 int", "agg1 int", "agg2 int", "agg3 int"]
+      order: id
+      data: |
+        1, 1, 1, NULL, NULL
+        2, 2, 2, NULL, 1
+        3, 3, 3, NULL, 2
+        4, 4, 4, 1,    3
+        5, 5, 5, 2,    4
+        6, 4, 4, NULL, NULL
+        7, 3, 3, NULL, 4
+        8, 2, 2, NULL, 3

--- a/hybridse/CMakeLists.txt
+++ b/hybridse/CMakeLists.txt
@@ -203,6 +203,7 @@ list(
         absl::synchronization
         absl::time
         absl::status
+        absl::statusor
 )
 
 find_package(ICU COMPONENTS i18n io uc data)

--- a/hybridse/include/codec/list_iterator_codec.h
+++ b/hybridse/include/codec/list_iterator_codec.h
@@ -49,7 +49,7 @@ template <class V, class R>
 class WrapListImpl : public ListV<V> {
  public:
     WrapListImpl() : ListV<V>() {}
-    ~WrapListImpl() {}
+    ~WrapListImpl() override {}
     virtual const V GetFieldUnsafe(const R &row) const = 0;
     virtual void GetField(const R &row, V *, bool *) const = 0;
     virtual const bool IsNull(const R &row) const = 0;
@@ -67,7 +67,7 @@ class ColumnImpl : public WrapListImpl<V, Row> {
           col_idx_(col_idx),
           offset_(offset) {}
 
-    ~ColumnImpl() {}
+    ~ColumnImpl() override {}
 
     const V GetFieldUnsafe(const Row &row) const override {
         V value;

--- a/hybridse/include/node/node_manager.h
+++ b/hybridse/include/node/node_manager.h
@@ -57,7 +57,7 @@ class NodeManager {
     PlanNode *MakeMultiPlanNode(const PlanType &type);
     PlanNode *MakeMergeNode(int column_size);
     WindowPlanNode *MakeWindowPlanNode(int w_id);
-    ProjectListNode *MakeProjectListPlanNode(const WindowPlanNode *w,
+    ProjectListNode *MakeProjectListPlanNode(WindowPlanNode *w,
                                              const bool need_agg);
     FilterPlanNode *MakeFilterPlanNode(PlanNode *node,
                                        const ExprNode *condition);

--- a/hybridse/include/node/node_manager.h
+++ b/hybridse/include/node/node_manager.h
@@ -57,8 +57,7 @@ class NodeManager {
     PlanNode *MakeMultiPlanNode(const PlanType &type);
     PlanNode *MakeMergeNode(int column_size);
     WindowPlanNode *MakeWindowPlanNode(int w_id);
-    ProjectListNode *MakeProjectListPlanNode(WindowPlanNode *w,
-                                             const bool need_agg);
+    ProjectListNode *MakeProjectListPlanNode(const WindowPlanNode *w, const bool need_agg);
     FilterPlanNode *MakeFilterPlanNode(PlanNode *node,
                                        const ExprNode *condition);
 
@@ -128,7 +127,7 @@ class NodeManager {
                                const WindowDefNode *w2);
     OrderExpression* MakeOrderExpression(const ExprNode* expr, const bool is_asc);
     OrderByNode *MakeOrderByNode(const ExprListNode *order_expressions);
-    SqlNode *MakeFrameExtent(SqlNode *start, SqlNode *end);
+    FrameExtent *MakeFrameExtent(SqlNode *start, SqlNode *end);
     SqlNode *MakeFrameBound(BoundType bound_type);
     SqlNode *MakeFrameBound(BoundType bound_type, ExprNode *offset);
     SqlNode *MakeFrameBound(BoundType bound_type, int64_t offset);

--- a/hybridse/include/node/plan_node.h
+++ b/hybridse/include/node/plan_node.h
@@ -23,7 +23,6 @@
 #include <utility>
 #include <vector>
 
-#include "glog/logging.h"
 #include "node/node_enum.h"
 #include "node/sql_node.h"
 
@@ -298,7 +297,7 @@ class ProjectListNode : public LeafPlanNode {
           w_ptr_(nullptr),
           having_condition_(nullptr),
           projects_({}) {}
-    ProjectListNode(WindowPlanNode *w_ptr, const bool has_agg)
+    ProjectListNode(const WindowPlanNode *w_ptr, const bool has_agg)
         : LeafPlanNode(kProjectList),
           has_row_project_(false),
           has_agg_project_(has_agg),
@@ -320,8 +319,7 @@ class ProjectListNode : public LeafPlanNode {
         }
     }
 
-    WindowPlanNode *GetW() const { return w_ptr_; }
-    void SetW(WindowPlanNode* window) { w_ptr_ = window; }
+    const WindowPlanNode *GetW() const { return w_ptr_; }
     const ExprNode* GetHavingCondition() const { return having_condition_;}
     void SetHavingCondition(const node::ExprNode* having_condition) {
         this->having_condition_ = having_condition;
@@ -339,7 +337,7 @@ class ProjectListNode : public LeafPlanNode {
  private:
     bool has_row_project_;
     bool has_agg_project_;
-    WindowPlanNode *w_ptr_;
+    const WindowPlanNode *w_ptr_;
     const ExprNode* having_condition_;
     PlanNodeList projects_;
 };

--- a/hybridse/include/node/plan_node.h
+++ b/hybridse/include/node/plan_node.h
@@ -17,14 +17,16 @@
 #ifndef HYBRIDSE_INCLUDE_NODE_PLAN_NODE_H_
 #define HYBRIDSE_INCLUDE_NODE_PLAN_NODE_H_
 
-#include <glog/logging.h>
 #include <list>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
+
+#include "glog/logging.h"
 #include "node/node_enum.h"
 #include "node/sql_node.h"
+
 namespace hybridse {
 namespace node {
 
@@ -232,7 +234,7 @@ class ProjectNode : public LeafPlanNode {
     node::ExprNode *GetExpression() const { return expression_; }
     void SetExpression(node::ExprNode *expr) { expression_ = expr; }
     node::FrameNode *frame() const { return frame_; }
-    void set_frame(node::FrameNode *frame) { frame_ = frame; }
+    void set_frame(FrameNode* frame) { frame_ = frame; }
     virtual bool Equals(const PlanNode *node) const;
     const bool IsAgg() const { return is_aggregation_; }
 
@@ -248,10 +250,10 @@ class WindowPlanNode : public LeafPlanNode {
  public:
     explicit WindowPlanNode(int id)
         : LeafPlanNode(kPlanTypeWindow),
-          id(id),
+          id_(id),
           exclude_current_time_(false),
           instance_not_in_window_(false),
-          name(""),
+          name_(""),
           keys_(nullptr),
           orders_(nullptr) {}
     ~WindowPlanNode() {}
@@ -264,9 +266,10 @@ class WindowPlanNode : public LeafPlanNode {
     const OrderByNode *GetOrders() const { return orders_; }
     void SetKeys(ExprListNode *keys) { keys_ = keys; }
     void SetOrders(OrderByNode *orders) { orders_ = orders; }
-    const std::string &GetName() const { return name; }
-    void SetName(const std::string &name) { WindowPlanNode::name = name; }
-    const int GetId() const { return id; }
+    const std::string &GetName() const { return name_; }
+    void SetName(const std::string &name) { name_ = name; }
+    int GetId() const { return id_; }
+    void SetId(int id) { id_ = id; }
     void AddUnionTable(PlanNode *node) { return union_tables_.push_back(node); }
     const PlanNodeList &union_tables() const { return union_tables_; }
     const bool instance_not_in_window() const { return instance_not_in_window_; }
@@ -276,10 +279,10 @@ class WindowPlanNode : public LeafPlanNode {
     virtual bool Equals(const PlanNode *node) const;
 
  private:
-    int id;
+    int id_;
     bool exclude_current_time_;
     bool instance_not_in_window_;
-    std::string name;
+    std::string name_;
     FrameNode *frame_node_;
     ExprListNode *keys_;
     OrderByNode *orders_;
@@ -294,47 +297,51 @@ class ProjectListNode : public LeafPlanNode {
           has_agg_project_(false),
           w_ptr_(nullptr),
           having_condition_(nullptr),
-          projects({}) {}
-    ProjectListNode(const WindowPlanNode *w_ptr, const bool has_agg)
+          projects_({}) {}
+    ProjectListNode(WindowPlanNode *w_ptr, const bool has_agg)
         : LeafPlanNode(kProjectList),
           has_row_project_(false),
           has_agg_project_(has_agg),
           w_ptr_(w_ptr),
           having_condition_(nullptr),
-          projects({}) {}
+          projects_({}) {}
     ~ProjectListNode() {}
+
     void Print(std::ostream &output, const std::string &org_tab) const;
 
-    const PlanNodeList &GetProjects() const { return projects; }
+    const PlanNodeList &GetProjects() const { return projects_; }
+
     void AddProject(ProjectNode *project) {
-        projects.push_back(project);
+        projects_.push_back(project);
         if (project->IsAgg()) {
             has_agg_project_ = true;
         } else {
             has_row_project_ = true;
         }
     }
-    const WindowPlanNode *GetW() const { return w_ptr_; }
+
+    WindowPlanNode *GetW() const { return w_ptr_; }
+    void SetW(WindowPlanNode* window) { w_ptr_ = window; }
     const ExprNode* GetHavingCondition() const { return having_condition_;}
     void SetHavingCondition(const node::ExprNode* having_condition) {
         this->having_condition_ = having_condition;
     }
-    const bool HasRowProject() const { return has_row_project_; }
-    const bool HasAggProject() const { return has_agg_project_; }
-    const bool IsWindowProject() const { return nullptr != w_ptr_; }
+    bool HasRowProject() const { return has_row_project_; }
+    bool HasAggProject() const { return has_agg_project_; }
+    bool IsWindowProject() const { return nullptr != w_ptr_; }
     virtual bool Equals(const PlanNode *node) const;
 
     static bool MergeProjectList(node::ProjectListNode *project_list1, node::ProjectListNode *project_list2,
                                  node::ProjectListNode *merged_project);
-    bool has_row_project_;
-    bool has_agg_project_;
-    const WindowPlanNode *w_ptr_;
 
     bool IsSimpleProjectList();
 
  private:
+    bool has_row_project_;
+    bool has_agg_project_;
+    WindowPlanNode *w_ptr_;
     const ExprNode* having_condition_;
-    PlanNodeList projects;
+    PlanNodeList projects_;
 };
 
 class ProjectPlanNode : public UnaryPlanNode {

--- a/hybridse/include/node/sql_node.h
+++ b/hybridse/include/node/sql_node.h
@@ -1230,6 +1230,7 @@ class FrameNode : public SqlNode {
     void SetFrameRows(FrameExtent* ext) { frame_rows_ = ext; }
 
     int64_t frame_maxsize() const { return frame_maxsize_; }
+    void set_frame_maxsize(int64_t s) { frame_maxsize_ = s; }
     int64_t GetHistoryRangeStart() const {
         if (nullptr == frame_rows_ && nullptr == frame_range_) {
             return INT64_MIN;
@@ -1359,9 +1360,6 @@ class WindowDefNode : public SqlNode {
     SqlNodeList *union_tables() const { return union_tables_; }
     void set_union_tables(SqlNodeList *union_table) { union_tables_ = union_table; }
 
-    bool PermitWindowMerge() const { return permit_window_merge_; }
-    void SetPermitWindowMerge(bool permit) { permit_window_merge_ = permit; }
-
     const bool instance_not_in_window() const { return instance_not_in_window_; }
     void set_instance_not_in_window(bool instance_not_in_window) { instance_not_in_window_ = instance_not_in_window; }
     const bool exclude_current_time() const { return exclude_current_time_; }
@@ -1381,10 +1379,6 @@ class WindowDefNode : public SqlNode {
     SqlNodeList *union_tables_; /* union other table in window */
     ExprListNode *partitions_;  /* PARTITION BY expression list */
     OrderByNode *orders_;       /* ORDER BY (list of SortBy) */
-
-    // whether allow two window merged into single
-    // one can explicitly set this to false to disable window merge over this window
-    bool permit_window_merge_ = true;
 };
 
 class AllNode : public ExprNode {
@@ -2773,8 +2767,13 @@ bool SqlListEquals(const SqlNodeList *left, const SqlNodeList *right);
 bool ExprEquals(const ExprNode *left, const ExprNode *right);
 bool FnDefEquals(const FnDefNode *left, const FnDefNode *right);
 bool TypeEquals(const TypeNode *left, const TypeNode *right);
+
+// retrieve the `WindowDefNode` for the `ExprNode`, which is either from
+//  `ExprNode` itself inside if it is an anonymous window e.g `fn() over (window)`
+//  or find in `windows` map by window name
 bool WindowOfExpression(const std::map<std::string, const WindowDefNode *>& windows, ExprNode *node_ptr,
                         const WindowDefNode **output);
+
 bool IsAggregationExpression(const udf::UdfLibrary* lib, const node::ExprNode* node_ptr);
 void ColumnOfExpression(const ExprNode *node_ptr,
                         std::vector<const node::ExprNode *> *columns);  // NOLINT

--- a/hybridse/include/node/sql_node.h
+++ b/hybridse/include/node/sql_node.h
@@ -454,7 +454,7 @@ class SqlNodeList : public SqlNode {
     const bool IsEmpty() const { return list_.empty(); }
     const int GetSize() const { return list_.size(); }
     const std::vector<SqlNode *> &GetList() const { return list_; }
-    void Print(std::ostream &output, const std::string &tab) const;
+    void Print(std::ostream &output, const std::string &tab) const override;
     virtual bool Equals(const SqlNodeList *that) const;
 
  private:

--- a/hybridse/src/node/node_manager.cc
+++ b/hybridse/src/node/node_manager.cc
@@ -239,7 +239,7 @@ SqlNode *NodeManager::MakeFrameBound(BoundType bound_type, int64_t offset) {
     FrameBound *node_ptr = new FrameBound(bound_type, offset, false);
     return RegisterNode(node_ptr);
 }
-SqlNode *NodeManager::MakeFrameExtent(SqlNode *start, SqlNode *end) {
+FrameExtent *NodeManager::MakeFrameExtent(SqlNode *start, SqlNode *end) {
     FrameExtent *node_ptr = new FrameExtent(dynamic_cast<FrameBound *>(start), dynamic_cast<FrameBound *>(end));
     return RegisterNode(node_ptr);
 }
@@ -566,7 +566,7 @@ WindowPlanNode *NodeManager::MakeWindowPlanNode(int w_id) {
     return node_ptr;
 }
 
-ProjectListNode *NodeManager::MakeProjectListPlanNode(WindowPlanNode *w_ptr, const bool need_agg) {
+ProjectListNode *NodeManager::MakeProjectListPlanNode(const WindowPlanNode *w_ptr, const bool need_agg) {
     ProjectListNode *node_ptr = new ProjectListNode(w_ptr, need_agg);
     RegisterNode(node_ptr);
     return node_ptr;

--- a/hybridse/src/node/node_manager.cc
+++ b/hybridse/src/node/node_manager.cc
@@ -566,7 +566,7 @@ WindowPlanNode *NodeManager::MakeWindowPlanNode(int w_id) {
     return node_ptr;
 }
 
-ProjectListNode *NodeManager::MakeProjectListPlanNode(const WindowPlanNode *w_ptr, const bool need_agg) {
+ProjectListNode *NodeManager::MakeProjectListPlanNode(WindowPlanNode *w_ptr, const bool need_agg) {
     ProjectListNode *node_ptr = new ProjectListNode(w_ptr, need_agg);
     RegisterNode(node_ptr);
     return node_ptr;

--- a/hybridse/src/node/plan_node.cc
+++ b/hybridse/src/node/plan_node.cc
@@ -279,18 +279,15 @@ void ProjectListNode::Print(std::ostream &output,
     PlanNode::Print(output, org_tab);
     if (nullptr == w_ptr_) {
         output << "\n";
-        PrintPlanVector(output, org_tab + INDENT, projects,
-                        "projects on table ", nullptr == this->having_condition_);
+        PrintPlanVector(output, org_tab + INDENT, projects_, "projects on table ", nullptr == this->having_condition_);
         if (nullptr != this->having_condition_) {
-            PrintSqlNode(output, org_tab + INDENT, having_condition_,
-                            "having condition: ", true);
+            PrintSqlNode(output, org_tab + INDENT, having_condition_, "having condition: ", true);
         }
     } else {
         output << "\n";
         PrintPlanNode(output, org_tab + INDENT, (w_ptr_), "", false);
         output << "\n";
-        PrintPlanVector(output, org_tab + INDENT, projects,
-                        "projects on window ", true);
+        PrintPlanVector(output, org_tab + INDENT, projects_, "projects on window ", true);
     }
 }
 
@@ -347,7 +344,7 @@ bool ProjectListNode::Equals(const PlanNode *node) const {
         return false;
     }
     const ProjectListNode *that = dynamic_cast<const ProjectListNode *>(node);
-    if (this->projects.size() != that->projects.size()) {
+    if (this->projects_.size() != that->projects_.size()) {
         return false;
     }
 
@@ -355,17 +352,17 @@ bool ProjectListNode::Equals(const PlanNode *node) const {
            this->has_agg_project_ == that->has_agg_project_ &&
            node::ExprEquals(this->having_condition_, that->having_condition_) &&
            node::PlanEquals(this->w_ptr_, that->w_ptr_) &&
-           PlanListEquals(this->projects, that->projects) &&
+           PlanListEquals(this->projects_, that->projects_) &&
            LeafPlanNode::Equals(node);
 }
 bool ProjectListNode::IsSimpleProjectList() {
     if (has_agg_project_) {
         return false;
     }
-    if (projects.empty()) {
+    if (projects_.empty()) {
         return false;
     }
-    for (auto item : projects) {
+    for (auto item : projects_) {
         auto expr = dynamic_cast<ProjectNode *>(item)->GetExpression();
         if (!node::ExprIsSimple(expr)) {
             return false;
@@ -530,7 +527,7 @@ void WindowPlanNode::Print(std::ostream &output,
                            const std::string &org_tab) const {
     PlanNode::Print(output, org_tab);
     output << "\n";
-    PrintValue(output, org_tab, name, "window_name", true);
+    PrintValue(output, org_tab, name_, "window_name", true);
 }
 bool WindowPlanNode::Equals(const PlanNode *node) const {
     if (nullptr == node) {
@@ -545,7 +542,7 @@ bool WindowPlanNode::Equals(const PlanNode *node) const {
         return false;
     }
     const WindowPlanNode *that = dynamic_cast<const WindowPlanNode *>(node);
-    return this->name == that->name &&
+    return this->name_ == that->name_ &&
            this->instance_not_in_window() == that->instance_not_in_window() &&
            this->exclude_current_time() == that->exclude_current_time() &&
            SqlEquals(this->frame_node_, that->frame_node_) &&

--- a/hybridse/src/passes/expression/merge_aggregations_test.cc
+++ b/hybridse/src/passes/expression/merge_aggregations_test.cc
@@ -81,8 +81,8 @@ TEST_F(MergeAggregationsTest, Test) {
                        .rfind("merged_window_agg") == 0;
     };
 
-    ASSERT_EQ(merge_cases.size() + non_merge_cases.size(),
-              output->GetChildNum());
+    ASSERT_EQ(merge_cases.size() + non_merge_cases.size(), output->GetChildNum());
+
     for (size_t i = 0; i < non_merge_cases.size(); ++i) {
         auto expr = output->GetChild(i);
         ASSERT_TRUE(!is_opt(expr))

--- a/hybridse/src/passes/expression/window_iter_analysis_test.cc
+++ b/hybridse/src/passes/expression/window_iter_analysis_test.cc
@@ -36,7 +36,6 @@ TEST_F(WindowIterAnalysisTest, Test) {
         {"sum(col_0 + sum(col_1)) over w1", 2},
         {"sum(col_0 + sum(col_1 + sum(col_2))) over w1", 3},
         {"lag(col_0, 1) over w1", 1},
-        {"lag(col_0, min(col_0)) over w1", 1},
         {"count(fz_window_split(cast(col_0 as string), \",\")) over w1 ", 1},
     };
 

--- a/hybridse/src/plan/planner.cc
+++ b/hybridse/src/plan/planner.cc
@@ -254,11 +254,9 @@ base::Status Planner::CreateSelectQueryPlan(const node::SelectQueryNode *root, P
     // add MergeNode if multi ProjectionLists exist
     PlanNodeList project_list_vec(w_id);
     for (auto &v : merged_project_list_map) {
-        if (v.second->GetW() == nullptr) {
-            project_list_vec[0] = v.second;
-        } else {
-            project_list_vec[v.second->GetW()->GetId()] = v.second;
-        }
+        node::ProjectListNode *project_list = v.second;
+        int pos = nullptr == project_list->GetW() ? 0 : project_list->GetW()->GetId();
+        project_list_vec[pos] = project_list;
     }
 
     // merge simple project with 1st window project

--- a/hybridse/src/plan/planner.cc
+++ b/hybridse/src/plan/planner.cc
@@ -1182,7 +1182,7 @@ absl::StatusOr<node::WindowDefNode *> Planner::ConstructWindowForLag(const node:
     }
 
     auto *const_node = dynamic_cast<node::ConstNode *>(offset_expr);
-    int64_t offset = const_node->GetAsInt32();
+    int64_t offset = const_node->GetAsInt64();
 
     auto *rows_frame_ext =
         node_manager_->MakeFrameExtent(node_manager_->MakeFrameBound(node::BoundType::kPreceding, offset),

--- a/hybridse/src/plan/planner.cc
+++ b/hybridse/src/plan/planner.cc
@@ -1154,6 +1154,12 @@ std::map<const node::WindowDefNode *, node::ProjectListNode *> Planner::FilterWi
             continue;
         }
 
+        if (kv.first->GetFrame() == nullptr || !kv.first->GetFrame()->IsPureHistoryFrame()) {
+            // only split project list if the window is pure history
+            splited_map.emplace(kv.first, kv.second);
+            continue;
+        }
+
         node::ProjectListNode* window_bound_relative_projects = nullptr;
         node::ProjectListNode* window_bound_non_relative_projects = nullptr;
         SplitProjectList(

--- a/hybridse/src/plan/planner.h
+++ b/hybridse/src/plan/planner.h
@@ -86,9 +86,23 @@ class Planner {
 
     std::string MakeTableName(const PlanNode *node) const;
     base::Status MergeProjectMap(const std::map<const node::WindowDefNode *, node::ProjectListNode *> &map,
-                                 std::map<const node::WindowDefNode *, node::ProjectListNode *> *output);
+                                 std::map<const node::WindowDefNode *, node::ProjectListNode *> *output, int* win_id);
 
  private:
+    // iterate the {in} map and make a new map from that, but sperate projects into two ProjectListNode if there are any
+    // lag/at in the project list list
+    // it is used to sperate project list nodes which is at/lag/lead call expr, see #1554
+    std::map<const node::WindowDefNode *, node::ProjectListNode *> FilterWindowFrameBoundNonRelativeProjects(
+        const std::map<const node::WindowDefNode *, node::ProjectListNode *> &in, int* win_id);
+
+    // split the give ProjectListNode {in} into two ProjectListNode with the given {condition},
+    // true results into {trues}, false results into {falses}
+    void SplitProjectList(const node::ProjectListNode *in, std::function<bool(const node::ProjectNode *)> predicate,
+                          node::ProjectListNode **trues, node::ProjectListNode **falses) const;
+
+    // create a copy (shallow) of {in} where it's frame is [unbound preceding, current row]
+    node::WindowDefNode* CreateWindowUnboundPrecedingAndCurrent(const node::WindowDefNode* in) const;
+
     const std::unordered_map<std::string, std::string>* extra_options_ = nullptr;
     std::set<std::string> long_windows_;
 };

--- a/hybridse/src/plan/planner.h
+++ b/hybridse/src/plan/planner.h
@@ -102,7 +102,7 @@ class Planner {
     //  - frame_start = max(offset, in.frame_start)
     //  - frame_end = current row
     absl::StatusOr<node::WindowDefNode *> ConstructWindowForLag(const node::WindowDefNode *in,
-                                                             const node::CallExprNode *call) const;
+                                                                const node::CallExprNode *call) const;
 
  private:
     const std::unordered_map<std::string, std::string>* extra_options_ = nullptr;

--- a/hybridse/src/plan/planner.h
+++ b/hybridse/src/plan/planner.h
@@ -22,6 +22,8 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+
+#include "absl/status/statusor.h"
 #include "base/fe_status.h"
 #include "gflags/gflags.h"
 #include "glog/logging.h"
@@ -54,10 +56,8 @@ class Planner {
     static int GetPlanTreeLimitCount(node::PlanNode *node);
 
  protected:
-    const bool is_batch_mode_;
-    const bool is_cluster_optimized_;
-    const bool enable_window_maxsize_merged_;
-    const bool enable_batch_window_parallelization_;
+    // expand pure history window to current history window.
+    // currently only apply to rows window
     bool ExpandCurrentHistoryWindow(std::vector<const node::WindowDefNode *> *windows);
     bool IsTable(node::PlanNode *node, node::PlanNode **output);
     base::Status ValidateRequestTable(node::PlanNode *node, std::vector<node::PlanNode *> &request_tables);  // NOLINT
@@ -74,7 +74,10 @@ class Planner {
     base::Status CreateExplainPlan(const SqlNode *root, node::PlanNode **output);
     base::Status CreateCreateIndexPlan(const SqlNode *root, node::PlanNode **output);
     base::Status CreateFuncDefPlan(const SqlNode *root, node::PlanNode **output);
-    base::Status CreateWindowPlanNode(const node::WindowDefNode *w_ptr, node::WindowPlanNode *plan_node);
+
+    // fill-in the `WindowPlanNode` from the `WindowDefNode`
+    base::Status FillInWindowPlanNode(const node::WindowDefNode *w_ptr, node::WindowPlanNode *plan_node);
+
     base::Status CreateDeployPlanNode(const node::DeployNode *root, node::PlanNode **output);
     base::Status CreateLoadDataPlanNode(const node::LoadDataNode *root, node::PlanNode **output);
     base::Status CreateSelectIntoPlanNode(const node::SelectIntoNode *root, node::PlanNode **output);
@@ -82,27 +85,26 @@ class Planner {
     base::Status CreateCreateFunctionPlanNode(const node::CreateFunctionNode *root, node::PlanNode **output);
     base::Status CreateCreateProcedurePlan(const node::SqlNode *root, const PlanNodeList &inner_plan_node_list,
                                            node::PlanNode **output);
-    node::NodeManager *node_manager_;
-
     std::string MakeTableName(const PlanNode *node) const;
     base::Status MergeProjectMap(const std::map<const node::WindowDefNode *, node::ProjectListNode *> &map,
-                                 std::map<const node::WindowDefNode *, node::ProjectListNode *> *output, int* win_id);
+                                 std::map<const node::WindowDefNode *, node::ProjectListNode *> *output);
+
+ protected:
+    const bool is_batch_mode_;
+    const bool is_cluster_optimized_;
+    const bool enable_window_maxsize_merged_;
+    const bool enable_batch_window_parallelization_;
+    node::NodeManager *node_manager_;
 
  private:
-    // iterate the {in} map and make a new map from that, but sperate projects into two ProjectListNode if there are any
-    // lag/at in the project list list
-    // it is used to sperate project list nodes which is at/lag/lead call expr, see #1554
-    std::map<const node::WindowDefNode *, node::ProjectListNode *> FilterWindowFrameBoundNonRelativeProjects(
-        const std::map<const node::WindowDefNode *, node::ProjectListNode *> &in, int* win_id);
+    // get the `WindowDefNode` for `lag(col, offset)` function
+    //  output a rows window, where
+    //  - frame_start = max(offset, in.frame_start)
+    //  - frame_end = current row
+    absl::StatusOr<node::WindowDefNode *> ConstructWindowForLag(const node::WindowDefNode *in,
+                                                             const node::CallExprNode *call) const;
 
-    // split the give ProjectListNode {in} into two ProjectListNode with the given {condition},
-    // true results into {trues}, false results into {falses}
-    void SplitProjectList(const node::ProjectListNode *in, std::function<bool(const node::ProjectNode *)> predicate,
-                          node::ProjectListNode **trues, node::ProjectListNode **falses) const;
-
-    // create a copy (shallow) of {in} where it's frame is [unbound preceding, current row]
-    node::WindowDefNode* CreateWindowUnboundPrecedingAndCurrent(const node::WindowDefNode* in) const;
-
+ private:
     const std::unordered_map<std::string, std::string>* extra_options_ = nullptr;
     std::set<std::string> long_windows_;
 };

--- a/hybridse/src/planv2/plan_api.cc
+++ b/hybridse/src/planv2/plan_api.cc
@@ -43,7 +43,7 @@ bool PlanAPI::CreatePlanTreeFromScript(const std::string &sql, PlanNodeList &pla
         status.code = common::kSyntaxError;
         return false;
     }
-    DLOG(INFO) << "\n" << parser_output->script()->DebugString();
+    DLOG(INFO) << "AST Node:\n" << parser_output->script()->DebugString();
     const zetasql::ASTScript *script = parser_output->script();
     auto planner_ptr = std::make_unique<SimplePlannerV2>(node_manager, is_batch_mode, is_cluster,
                                                          enable_batch_window_parallelization, extra_options);

--- a/hybridse/src/planv2/planner_v2.cc
+++ b/hybridse/src/planv2/planner_v2.cc
@@ -37,10 +37,15 @@ base::Status SimplePlannerV2::CreateASTScriptPlan(const zetasql::ASTScript *scri
         return status;
     }
     node::SqlNodeList *resolved_trees;
-    CHECK_STATUS(ConvertASTScript(script, node_manager_, &resolved_trees))
+    CHECK_STATUS(ConvertASTScript(script, node_manager_, &resolved_trees));
     CHECK_TRUE(nullptr != resolved_trees && resolved_trees->GetSize() > 0, common::kPlanError,
-               "fail to create plan, sql trees is null or empty")
-    CHECK_STATUS(CreatePlanTree(resolved_trees->GetList(), plan_trees))
+               "fail to create plan, sql trees is null or empty");
+    DLOG(INFO) << "parsed SqlNode:\n" << resolved_trees->GetTreeString();
+    CHECK_STATUS(CreatePlanTree(resolved_trees->GetList(), plan_trees));
+    DLOG(INFO) << "PlanNode:\n";
+    for (decltype(plan_trees.size()) i = 0; i < plan_trees.size(); ++i) {
+        DLOG(INFO) << i << "=>" << plan_trees[i]->GetTreeString();
+    }
     return base::Status::OK();
 }
 }  // namespace plan

--- a/hybridse/src/planv2/planner_v2_test.cc
+++ b/hybridse/src/planv2/planner_v2_test.cc
@@ -1912,6 +1912,10 @@ TEST_F(PlannerV2ErrorTest, NonSupportSQL) {
 
     expect_converted(R"sql(select 'mike' like 'm%' escape '2c';)sql",
         common::kUnsupportSql, "escape value is not string or string size >= 2");
+
+    expect_converted(R"sql(SELECT lag(COL2, lag(col1, 1)) over w1 from t1
+                                 WINDOW w1 AS (PARTITION BY col1 ORDER BY col5 ROWS BETWEEN 3 PRECEDING AND CURRENT ROW);)sql",
+                     common::kUnsupportSql, "INVALID_ARGUMENT: offset can only be constant");
 }
 
 TEST_F(PlannerV2ErrorTest, NonSupportOnlineServingSQL) {

--- a/hybridse/src/planv2/planner_v2_test.cc
+++ b/hybridse/src/planv2/planner_v2_test.cc
@@ -331,25 +331,20 @@ TEST_F(PlannerV2Test, MultiProjectListPlanPostTest) {
     node::PlanNodeList trees;
     base::Status status;
     const std::string sql =
-        "SELECT sum(col1) OVER w1 as w1_col1_sum, "
-        "sum(col3) OVER w2 as w2_col3_sum, "
-        "sum(col4) OVER w2 as w2_col4_sum, "
-        "col1, "
-        "sum(col3) OVER w1 as w1_col3_sum, "
-        "col2, "
-        "sum(col1) OVER w2 as w2_col1_sum, "
-        "lag(col1, 0) OVER w2 as w2_col1_at_0, "
-        "lag(col1, 1) OVER w2 as w2_col1_at_1 "
-        "FROM t1 "
-        "WINDOW "
-        "w1 AS (PARTITION BY col2 ORDER BY `TS` ROWS_RANGE BETWEEN 1d "
-        "PRECEDING AND "
-        "1s PRECEDING), "
-        "w2 AS (PARTITION BY col3 ORDER BY `TS` ROWS_RANGE BETWEEN 2d "
-        "PRECEDING AND "
-        "1s PRECEDING) "
-        "limit 10;";
-    std::cout << sql << std::endl;
+        R"sql(SELECT
+        sum(col1) OVER w1 as w1_col1_sum,
+        sum(col3) OVER w2 as w2_col3_sum,
+        sum(col4) OVER w2 as w2_col4_sum,
+        col1,
+        sum(col3) OVER w1 as w1_col3_sum,
+        col2,
+        sum(col1) OVER w2 as w2_col1_sum,
+        lag(col1, 0) OVER w2 as w2_col1_at_0,
+        lag(col1, 1) OVER w2 as w2_col1_at_1
+        FROM t1 WINDOW
+        w1 AS (PARTITION BY col2 ORDER BY `TS` ROWS_RANGE BETWEEN 1d PRECEDING AND 1s PRECEDING),
+        w2 AS (PARTITION BY col3 ORDER BY `TS` ROWS_RANGE BETWEEN 2d PRECEDING AND 1s PRECEDING) limit 10;)sql";
+
     node::PlanNodeList plan_trees;
     ASSERT_TRUE(plan::PlanAPI::CreatePlanTreeFromScript(sql, plan_trees, manager_, status));
     ASSERT_EQ(1u, plan_trees.size());
@@ -357,24 +352,24 @@ TEST_F(PlannerV2Test, MultiProjectListPlanPostTest) {
     PlanNode *plan_ptr = plan_trees[0];
     ASSERT_TRUE(NULL != plan_ptr);
 
-    std::cout << *plan_ptr << std::endl;
     // validate select plan
     ASSERT_EQ(node::kPlanTypeQuery, plan_ptr->GetType());
     plan_ptr = plan_ptr->GetChildren()[0];
 
     // validate limit node
     ASSERT_EQ(node::kPlanTypeLimit, plan_ptr->GetType());
-    node::LimitPlanNode *limit_ptr = (node::LimitPlanNode *)plan_ptr;
+    node::LimitPlanNode *limit_ptr = dynamic_cast<node::LimitPlanNode *>(plan_ptr);
 
     // validate project list based on current row
     ASSERT_EQ(10, limit_ptr->GetLimitCnt());
     ASSERT_EQ(node::kPlanTypeProject, limit_ptr->GetChildren().at(0)->GetType());
 
-    node::ProjectPlanNode *project_plan_node = (node::ProjectPlanNode *)limit_ptr->GetChildren().at(0);
+    node::ProjectPlanNode *project_plan_node = dynamic_cast<node::ProjectPlanNode *>(limit_ptr->GetChildren().at(0));
     plan_ptr = project_plan_node;
-    ASSERT_EQ(2u, project_plan_node->project_list_vec_.size());
 
-    const std::vector<std::pair<uint32_t, uint32_t>> pos_mapping = project_plan_node->pos_mapping_;
+    ASSERT_EQ(3u, project_plan_node->project_list_vec_.size());
+
+    const std::vector<std::pair<uint32_t, uint32_t>>& pos_mapping = project_plan_node->pos_mapping_;
     ASSERT_EQ(9u, pos_mapping.size());
     ASSERT_EQ(std::make_pair(0u, 0u), pos_mapping[0]);
     ASSERT_EQ(std::make_pair(1u, 0u), pos_mapping[1]);
@@ -383,8 +378,8 @@ TEST_F(PlannerV2Test, MultiProjectListPlanPostTest) {
     ASSERT_EQ(std::make_pair(0u, 2u), pos_mapping[4]);
     ASSERT_EQ(std::make_pair(0u, 3u), pos_mapping[5]);
     ASSERT_EQ(std::make_pair(1u, 2u), pos_mapping[6]);
-    ASSERT_EQ(std::make_pair(1u, 3u), pos_mapping[7]);
-    ASSERT_EQ(std::make_pair(1u, 4u), pos_mapping[8]);
+    ASSERT_EQ(std::make_pair(2u, 0u), pos_mapping[7]);
+    ASSERT_EQ(std::make_pair(2u, 1u), pos_mapping[8]);
 
     // validate projection 0: window agg over w1 [-1d, -1s]
     {
@@ -424,7 +419,7 @@ TEST_F(PlannerV2Test, MultiProjectListPlanPostTest) {
         node::ProjectListNode *project_list =
             dynamic_cast<node::ProjectListNode *>(project_plan_node->project_list_vec_.at(1));
 
-        ASSERT_EQ(5u, project_list->GetProjects().size());
+        ASSERT_EQ(3u, project_list->GetProjects().size());
         ASSERT_TRUE(nullptr != project_list->GetW());
         ASSERT_EQ(-2 * 86400000, project_list->GetW()->GetStartOffset());
         ASSERT_EQ(-1000, project_list->GetW()->GetEndOffset());
@@ -446,15 +441,26 @@ TEST_F(PlannerV2Test, MultiProjectListPlanPostTest) {
             node::ProjectNode *project = dynamic_cast<node::ProjectNode *>(project_list->GetProjects()[2]);
             ASSERT_EQ(6u, project->GetPos());
         }
+    }
+    {
+        // validate projection 3: lag agg over w2
+        node::ProjectListNode *project_list =
+            dynamic_cast<node::ProjectListNode *>(project_plan_node->project_list_vec_.at(2));
+        ASSERT_EQ(2u, project_list->GetProjects().size());
+        ASSERT_TRUE(nullptr != project_list->GetW());
+        ASSERT_EQ(INT64_MIN, project_list->GetW()->GetStartOffset());
+        ASSERT_EQ(0, project_list->GetW()->GetEndOffset());
+        ASSERT_EQ("(col3)", node::ExprString(project_list->GetW()->GetKeys()));
+        ASSERT_TRUE(project_list->HasAggProject());
 
         // validate w2_col1_at_0 pos 7
         {
-            node::ProjectNode *project = dynamic_cast<node::ProjectNode *>(project_list->GetProjects()[3]);
+            node::ProjectNode *project = dynamic_cast<node::ProjectNode *>(project_list->GetProjects()[0]);
             ASSERT_EQ(7u, project->GetPos());
         }
         // validate w2_col1_at_1 pos 8
         {
-            node::ProjectNode *project = dynamic_cast<node::ProjectNode *>(project_list->GetProjects()[4]);
+            node::ProjectNode *project = dynamic_cast<node::ProjectNode *>(project_list->GetProjects()[1]);
             ASSERT_EQ(8u, project->GetPos());
         }
     }
@@ -464,6 +470,7 @@ TEST_F(PlannerV2Test, MultiProjectListPlanPostTest) {
     node::TablePlanNode *relation_node = reinterpret_cast<node::TablePlanNode *>(plan_ptr);
     ASSERT_EQ("t1", relation_node->table_);
 }
+
 TEST_F(PlannerV2Test, LastJoinPlanTest) {
     node::NodePointVector list;
     node::PlanNodeList trees;

--- a/hybridse/src/udf/default_defs/window_functions_def.cc
+++ b/hybridse/src/udf/default_defs/window_functions_def.cc
@@ -39,7 +39,7 @@ void AtList(::hybridse::codec::ListRef<V>* list_ref, int64_t pos, V* v,
         *v = V(DataTypeTrait<V>::zero_value());
         return;
     }
-    auto list = (codec::ListV<V>*)(list_ref->list);
+    auto list = reinterpret_cast<codec::ListV<V>*>(list_ref->list);
     auto column = dynamic_cast<codec::WrapListImpl<V, codec::Row>*>(list);
     if (column != nullptr) {
         auto row = column->root()->At(pos);
@@ -95,22 +95,29 @@ template <typename V>
 void RegisterBaseListAt(UdfLibrary* lib) {
     lib->RegisterExternal("at")
         .doc(R"(
-            @brief Returns the value of expression from the offset-th row of the ordered partition.
+            @brief Returns value evaluated at the row that is offset rows before the current row within the partition. Offset is evaluated with respect to the current row
 
-            @param offset The number of rows forward from the current row from which to obtain the value.
+            @param offset The number of rows forwarded from the current row, must not negative
 
             Example:
 
-            |value|
-            |--|
-            |0|
-            |1|
-            |2|
-            |3|
-            |4|
+            |c1|c2|
+            |--|--|
+            |0 | 1|
+            |1 | 1|
+            |2 | 2|
+            |3 | 2|
+            |4 | 2|
             @code{.sql}
-                SELECT at(value, 3) OVER w;
-                -- output 3
+                SELECT at(c1, 1) as co OVER w from t1 window (order by c1 partition by c2);
+                -- output
+                -- | co |
+                -- |----|
+                -- |NULL|
+                -- |0   |
+                -- |NULL|
+                -- |2   |
+                -- |3   |
             @endcode
         )")
         .args<codec::ListRef<V>, int64_t>(reinterpret_cast<void*>(AtList<V>))


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

close #1554 

for those where `lag` function exists in sql, e.g
```sql
select id, sum(col) over w1, lag(col, 0) over w1 from t1 window w1 as (....)
```

the logic plan is constructed,  previous:

```
Query
  ProjectPlan
    project_vec
      -ProjectList 1
        - id
        - sum(col)
        - lag(col, 0)
````

after the PR:

add a restriction to `lag`'s offset: it must be constant

the `lag` project node will splited into seperate project list if:
- `lag` over a `rows_range` window

new window is a `ROWS` type window:
- without `max_size`
- window start = offset
- window end = current row

This is a internal split that happens before window merge, so mergable window can still merged based on original logic