### PR TITLE
feat: select into null exception

### DIFF
--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/SelectIntoPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/SelectIntoPlan.scala
@@ -37,7 +37,7 @@ object SelectIntoPlan {
     logger.info("select into offline storage: format[{}], options[{}], write mode[{}], out path {}", format, options,
       mode, outPath)
     if (input.getDf().isEmpty) {
-      logger.info("select empty, skip save")
+      throw new Exception("select empty, skip save")
     } else {
       input.getDf().write.format(format).options(options).mode(mode).save(outPath)
     }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
If select closure in select into result is empty, we just skip saving, and the job is succeed. But users can't find the output file. It's not intuitive.
We should throw an exception.

close #1459 

* **What is the current behavior?** (You can also link to an open issue here)
throw new Exception("select empty, skip save")


* **What is the new behavior (if this is a feature change)?**

