### PR TITLE
fix: fix message when icu package not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,7 +206,7 @@ list(
 
 find_package(ICU COMPONENTS i18n io uc data)
 if (NOT ICU_FOUND)
-    message(STATUS "ICU package Not Found")
+    message(STATUS "ICU find_package failed, try to use `find_library()` to find")
     find_library(ICU_I18N icui18n)
     find_library(ICU_IO icuio)
     find_library(ICU_UC icuuc)


### PR DESCRIPTION
Fixed the message when icu package not found.

Issue: https://github.com/4paradigm/OpenMLDB/issues/1648

Solution:

![solution](https://user-images.githubusercontent.com/98892946/163873252-0f421620-cc1c-4d05-91cd-daae513e3568.png)


