### PR TITLE
feat(hybridsql): upgrade bundled thirdparty into 0.5.0.b2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@
 FROM centos:7
 
 ARG ZETASQL_VERSION=0.2.10
-ARG THIRDPARTY_VERSION=0.5.0.b1
+ARG THIRDPARTY_VERSION=0.5.0.b2
 ARG TARGETARCH
 
 LABEL org.opencontainers.image.source https://github.com/4paradigm/OpenMLDB


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Upgrade thirdparty version in compile image.
It should update `hybridsql:latest` image on merge, I will update workflow and cmakelists afterwards (will use hybridsql:latest on main branch)

* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**

