### PR TITLE
fix: 1356 combine index query

### DIFF
--- a/cases/query/simple_query.yaml
+++ b/cases/query/simple_query.yaml
@@ -633,3 +633,82 @@ cases:
       columns: ["col2:bool"]
       rows:
         - [true]
+
+  - id: combined_index_query_1
+    # #1356
+    desc: combined index query order
+    mode: request-unsupport, batch-request-unsupport
+    inputs:
+      - columns: ["a string", "b string", "c string"]
+        name: t1
+        indexs: ["idx:b|a"]
+        data: |
+          aaa, bbb, ccc
+    sql: |
+      select * from t1 where a = 'aaa' and b = 'bbb'
+    expect:
+      columns: ["a string", "b string", "c string"]
+      data: |
+        aaa, bbb, ccc
+  - id: combined_index_query_2
+    desc: combined index query order, filter with same order
+    mode: request-unsupport, batch-request-unsupport
+    inputs:
+      - columns: ["a string", "b string", "c string"]
+        name: t1
+        indexs: ["idx:b|a"]
+        data: |
+          aaa, bbb, ccc
+    sql: |
+      select * from t1 where b = 'bbb' and a = 'aaa';
+    expect:
+      columns: ["a string", "b string", "c string"]
+      data: |
+        aaa, bbb, ccc
+  - id: combined_index_query_3
+    desc: combined index query order, fail to optimize because only one of index key matches
+    mode: request-unsupport, batch-request-unsupport
+    inputs:
+      - columns: ["a string", "b string", "c string"]
+        name: t1
+        indexs: ["idx:b|a"]
+        data: |
+          aaa, bbb, ccc
+    sql: |
+      select * from t1 where a = 'aaa' and c = 'ccc'
+    expect:
+      columns: ["a string", "b string", "c string"]
+      data: |
+        aaa, bbb, ccc
+  - id: combined_index_query_4
+    desc: combined index query order, fail to optimize because only one of index key matches
+    mode: request-unsupport, batch-request-unsupport
+    inputs:
+      - columns: ["a string", "b string", "c string"]
+        name: t1
+        indexs: ["idx:b|a"]
+        data: |
+          aaa, bbb, ccc
+    sql: |
+      select * from t1 where a = 'aaa'
+    expect:
+      columns: ["a string", "b string", "c string"]
+      data: |
+        aaa, bbb, ccc
+
+  - id: combined_index_query_5
+    desc: |
+      combined index query order, optimized three key index
+    mode: request-unsupport, batch-request-unsupport
+    inputs:
+      - columns: ["a string", "b string", "c string"]
+        name: t1
+        indexs: ["idx:b|a|c"]
+        data: |
+          aaa, bbb, ccc
+    sql: |
+      select * from t1 where a = 'aaa' and c = 'ccc' and b = 'bbb';
+    expect:
+      columns: ["a string", "b string", "c string"]
+      data: |
+        aaa, bbb, ccc

--- a/hybridse/src/passes/physical/group_and_sort_optimized.cc
+++ b/hybridse/src/passes/physical/group_and_sort_optimized.cc
@@ -316,14 +316,8 @@ bool GroupAndSortOptimized::KeysOptimized(const SchemasContext* root_schemas_ctx
                 }
             }
 
-            // remove those in expr list that are null
-            auto it = new_index_keys->children_.begin();
-            while (it != new_index_keys->children_.end()) {
-                if (*it == nullptr) {
-                    it = new_index_keys->children_.erase(it);
-                } else {
-                    it++;
-                }
+            for (auto expr : new_index_keys->children_) {
+                DCHECK(expr != nullptr);
             }
 
             if (right_key != nullptr) {

--- a/hybridse/src/passes/physical/group_and_sort_optimized.cc
+++ b/hybridse/src/passes/physical/group_and_sort_optimized.cc
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 #include "passes/physical/group_and_sort_optimized.h"
+#include <absl/strings/string_view.h>
 
+#include <algorithm>
 #include <map>
 #include <memory>
 #include <set>
@@ -265,12 +267,10 @@ bool GroupAndSortOptimized::KeysOptimized(const SchemasContext* root_schemas_ctx
             const node::ExprListNode* right_partition =
                 right_key == nullptr ? left_key->keys() : right_key->keys();
 
-            size_t key_num = right_partition->GetChildNum();
-            std::vector<bool> bitmap(key_num, false);
-            node::ExprListNode order_values;
-
+            IndexBitMap bitmap((std::vector<std::optional<ColIndexInfo>>(right_partition->GetChildNum())));
             PhysicalPartitionProviderNode* partition_op = nullptr;
             std::string index_name;
+
             if (DataProviderType::kProviderTypeTable == scan_op->provider_type_) {
                 // Apply key columns and order column optimization with all indexes binding to scan_op->table_handler_
                 // Return false if fail to find an appropriate index
@@ -296,14 +296,17 @@ bool GroupAndSortOptimized::KeysOptimized(const SchemasContext* root_schemas_ctx
                 }
             }
 
-
             auto new_left_keys = node_manager_->MakeExprList();
             auto new_right_keys = node_manager_->MakeExprList();
             auto new_index_keys = node_manager_->MakeExprList();
-            for (size_t i = 0; i < bitmap.size(); ++i) {
+
+            new_index_keys->children_.resize(bitmap.refered_index_key_count);
+            for (size_t i = 0; i < bitmap.bitmap.size(); ++i) {
                 auto left = left_key->keys()->GetChild(i);
-                if (bitmap[i]) {
-                    new_index_keys->AddChild(left);
+                if (bitmap.bitmap[i].has_value()) {
+                    // reorder index keys to the index definition order, for the runner to correctly filter rows if
+                    // condtion keys has different order to index keys
+                    new_index_keys->SetChild(bitmap.bitmap[i].value().index, left);
                 } else {
                     new_left_keys->AddChild(left);
                     if (right_key != nullptr) {
@@ -312,6 +315,17 @@ bool GroupAndSortOptimized::KeysOptimized(const SchemasContext* root_schemas_ctx
                     }
                 }
             }
+
+            // remove those in expr list that are null
+            auto it = new_index_keys->children_.begin();
+            while (it != new_index_keys->children_.end()) {
+                if (*it == nullptr) {
+                    it = new_index_keys->children_.erase(it);
+                } else {
+                    it++;
+                }
+            }
+
             if (right_key != nullptr) {
                 right_key->set_keys(new_right_keys);
             }
@@ -461,19 +475,12 @@ bool GroupAndSortOptimized::SortOptimized(
     return false;
 }
 
-bool GroupAndSortOptimized::TransformGroupExpr(
-    const SchemasContext* root_schemas_ctx, const node::ExprListNode* groups,
-    std::shared_ptr<TableHandler> table_handler, std::string* index_name,
-    std::vector<bool>* output_bitmap) {
-    return TransformKeysAndOrderExpr(root_schemas_ctx, groups, nullptr,
-                                     table_handler, index_name, output_bitmap);
-}
 bool GroupAndSortOptimized::TransformKeysAndOrderExpr(const SchemasContext* root_schemas_ctx,
                                                       const node::ExprListNode* groups,
                                                       const node::OrderByNode* order,
                                                       std::shared_ptr<TableHandler> table_handler,
                                                       std::string* index_name,
-                                                      std::vector<bool>* output_bitmap) {
+                                                      IndexBitMap* output_bitmap) {
     if (nullptr == groups || nullptr == output_bitmap || nullptr == index_name) {
         DLOG(WARNING) << "fail to transform keys expr : key expr or output "
                          "or index_name ptr is null";
@@ -527,30 +534,33 @@ bool GroupAndSortOptimized::TransformKeysAndOrderExpr(const SchemasContext* root
         return false;
     }
 
-    std::vector<bool> match_bitmap;
-    std::vector<bool> state_bitmap(columns.size(), true);
+    IndexBitMap match_bitmap;
+    // internal structure for MatchBestIndex, initially turn every bit true
+    IndexBitMap state_bitmap(std::vector<std::optional<ColIndexInfo>>(columns.size(), std::make_optional(0)));
     if (!MatchBestIndex(columns, order_columns, table_handler, &state_bitmap, index_name, &match_bitmap)) {
         return false;
     }
-    if (match_bitmap.size() != columns.size()) {
+    if (match_bitmap.bitmap.size() != columns.size()) {
         return false;
     }
     for (size_t i = 0; i < columns.size(); ++i) {
-        if (match_bitmap[i]) {
+        if (match_bitmap.bitmap[i].has_value()) {
             size_t origin_idx = result_bitmap_mapping[i];
-            (*output_bitmap)[origin_idx] = true;
+            output_bitmap->bitmap.at(origin_idx) = match_bitmap.bitmap[i].value();
         }
     }
+    output_bitmap->refered_index_key_count = match_bitmap.refered_index_key_count;
     return true;
 }
 
 // When *index_name is empty, return true if we can find the best index for key columns and order column
 // When *index_name isn't empty, return true if the given index_name match key columns and order column
-bool GroupAndSortOptimized::MatchBestIndex(
-    const std::vector<std::string>& columns,
-    const std::vector<std::string>& order_columns,
-    std::shared_ptr<TableHandler> table_handler, std::vector<bool>* bitmap_ptr,
-    std::string* index_name, std::vector<bool>* index_bitmap) {
+bool GroupAndSortOptimized::MatchBestIndex(const std::vector<std::string>& columns,
+                                           const std::vector<std::string>& order_columns,
+                                           std::shared_ptr<TableHandler> table_handler,
+                                           IndexBitMap* bitmap_ptr,
+                                           std::string* index_name,
+                                           IndexBitMap* index_bitmap) {
     if (nullptr == bitmap_ptr || nullptr == index_name) {
         LOG(WARNING)
             << "fail to match best index: bitmap or index_name ptr is null";
@@ -561,19 +571,11 @@ bool GroupAndSortOptimized::MatchBestIndex(
         LOG(WARNING) << "fail to match best index: table is null";
         return false;
     }
-    auto& index_hint = table_handler->GetIndex();
-    auto schema = table_handler->GetSchema();
+    const auto& index_hint = table_handler->GetIndex();
+    auto* schema = table_handler->GetSchema();
     if (nullptr == schema) {
         LOG(WARNING) << "fail to match best index: table schema null";
         return false;
-    }
-
-    std::set<std::string> column_set;
-    auto& bitmap = *bitmap_ptr;
-    for (size_t i = 0; i < columns.size(); ++i) {
-        if (bitmap[i]) {
-            column_set.insert(columns[i]);
-        }
     }
 
     if (order_columns.size() > 1) {
@@ -599,27 +601,55 @@ bool GroupAndSortOptimized::MatchBestIndex(
                 continue;
             }
         }
-        std::set<std::string> keys;
-        for (auto key_iter = index.keys.cbegin(); key_iter != index.keys.cend();
-             key_iter++) {
-            keys.insert(key_iter->name);
+
+        // key column name -> (idx of index definition, whether hitted by one of columns)
+        std::unordered_map<absl::string_view, std::pair<uint32_t, bool>> key_name_idx_map;
+        for (uint32_t i = 0; i < index.keys.size(); ++i) {
+            key_name_idx_map[index.keys[i].name] = std::make_pair(i, false);
         }
-        if (column_set == keys) {
+
+        // flag whether all the true bitted columns matches key in the same index
+        bool exact_match_all = true;
+        // construct a copy of IndexBitMap for matching
+        IndexBitMap matching = *bitmap_ptr;
+        for (size_t i = 0; i < columns.size(); ++i) {
+            if (matching.bitmap[i].has_value()) {
+                auto it = key_name_idx_map.find(columns[i]);
+                if (it == key_name_idx_map.end()) {
+                    exact_match_all = false;
+                    break;
+                }
+                it->second.second = true;
+                // reset to the correct index of matched Index definition
+                matching.bitmap[i].emplace(it->second.first);
+            }
+        }
+        for (auto & kv : key_name_idx_map) {
+            exact_match_all &= kv.second.second;
+        }
+
+        if (exact_match_all) {
+            // index absolute match
+            matching.refered_index_key_count = index.keys.size();
             *index_name = index.name;
-            *index_bitmap = bitmap;
+            *index_bitmap = matching;
             return true;
         }
     }
 
+    // try match best index
     std::string best_index_name;
-    std::vector<bool> best_index_bitmap;
+    IndexBitMap best_index_bitmap;
 
     bool succ = false;
-    for (size_t i = 0; i < bitmap.size(); ++i) {
-        if (bitmap[i]) {
-            bitmap[i] = false;
+    for (size_t i = 0; i < bitmap_ptr->bitmap.size(); ++i) {
+        // find solutions recursively by flip one of the hitted bit
+        // then choose the best one among those
+        if (bitmap_ptr->bitmap[i].has_value()) {
+            auto val = bitmap_ptr->bitmap[i].value();
+            bitmap_ptr->bitmap[i] = {};
             std::string name;
-            std::vector<bool> sub_best_bitmap;
+            IndexBitMap sub_best_bitmap;
             if (MatchBestIndex(columns, order_columns, table_handler,
                                bitmap_ptr, &name, &sub_best_bitmap)) {
                 succ = true;
@@ -630,12 +660,13 @@ bool GroupAndSortOptimized::MatchBestIndex(
                     auto org_index = index_hint.at(best_index_name);
                     auto new_index = index_hint.at(name);
                     if (org_index.keys.size() < new_index.keys.size()) {
+                        // override with better index
                         best_index_name = name;
                         best_index_bitmap = sub_best_bitmap;
                     }
                 }
             }
-            bitmap[i] = true;
+            bitmap_ptr->bitmap[i] = val;
         }
     }
     *index_name = best_index_name;

--- a/hybridse/src/passes/physical/group_and_sort_optimized.cc
+++ b/hybridse/src/passes/physical/group_and_sort_optimized.cc
@@ -14,14 +14,17 @@
  * limitations under the License.
  */
 #include "passes/physical/group_and_sort_optimized.h"
-#include <absl/strings/string_view.h>
 
 #include <algorithm>
 #include <map>
 #include <memory>
 #include <set>
 #include <string>
+#include <unordered_map>
+#include <utility>
 #include <vector>
+
+#include "absl/strings/string_view.h"
 #include "vm/physical_op.h"
 
 namespace hybridse {

--- a/hybridse/src/passes/physical/group_and_sort_optimized.h
+++ b/hybridse/src/passes/physical/group_and_sort_optimized.h
@@ -19,6 +19,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+
 #include "passes/physical/transform_up_physical_pass.h"
 
 namespace hybridse {
@@ -41,20 +42,20 @@ class GroupAndSortOptimized : public TransformUpPysicalPass {
     ~GroupAndSortOptimized() {}
 
  private:
-   struct ColIndexInfo {
-      ColIndexInfo(uint32_t idx) : index(idx) {} // NOLINT
+    struct ColIndexInfo {
+        ColIndexInfo(uint32_t idx) : index(idx) {}  // NOLINT
 
-      // the vector index for column reference of the index definition, if column hit one of indexes
-      uint32_t index;
-   };
-   struct IndexBitMap {
-      IndexBitMap() {}
-      IndexBitMap(std::vector<std::optional<ColIndexInfo>> mp) : bitmap(mp) {} // NOLINT
+        // the vector index for column reference of the index definition, if column hit one of indexes
+        uint32_t index;
+    };
+    struct IndexBitMap {
+        IndexBitMap() {}
+        IndexBitMap(std::vector<std::optional<ColIndexInfo>> mp) : bitmap(mp) {}  // NOLINT
 
-      std::vector<std::optional<ColIndexInfo>> bitmap;
-      // total size of keys from the best matched index
-      uint32_t refered_index_key_count = 0;
-   };
+        std::vector<std::optional<ColIndexInfo>> bitmap;
+        // total size of keys from the best matched index
+        uint32_t refered_index_key_count = 0;
+    };
 
  private:
     bool Transform(PhysicalOpNode* in, PhysicalOpNode** output);

--- a/hybridse/src/passes/physical/group_and_sort_optimized_test.cc
+++ b/hybridse/src/passes/physical/group_and_sort_optimized_test.cc
@@ -17,6 +17,7 @@
 #include "passes/physical/group_and_sort_optimized.h"
 
 #include <memory>
+#include <vector>
 
 #include "gtest/gtest.h"
 #include "llvm/IR/LLVMContext.h"

--- a/hybridse/src/passes/physical/group_and_sort_optimized_test.cc
+++ b/hybridse/src/passes/physical/group_and_sort_optimized_test.cc
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2022 4Paradigm
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "passes/physical/group_and_sort_optimized.h"
+
+#include <memory>
+
+#include "gtest/gtest.h"
+#include "llvm/IR/LLVMContext.h"
+#include "plan/plan_api.h"
+#include "testing/test_base.h"
+#include "udf/default_udf_library.h"
+#include "vm/transform.h"
+
+namespace hybridse {
+namespace passes {
+
+struct GASTestCase {
+    absl::string_view sql;
+    absl::string_view physical_tree_str;
+};
+
+std::ostream& operator<<(std::ostream& os, const GASTestCase& obj) {
+    return os << "{sql: '" << obj.sql << "', tree: '" << obj.physical_tree_str << "'}";
+}
+
+class GroupAndSortOptOnCombinedIndexTest : public ::testing::TestWithParam<GASTestCase> {
+ protected:
+    void SetUp() override {
+        hybridse::type::Database db;
+        db.set_name("db");
+
+        hybridse::type::TableDef table_def;
+        table_def.set_name("t1");
+        table_def.set_catalog("db");
+        {
+            auto* c1 = table_def.add_columns();
+            c1->set_type(::hybridse::type::kVarchar);
+            c1->set_name("a");
+
+            auto* c2 = table_def.add_columns();
+            c2->set_type(::hybridse::type::kInt32);
+            c2->set_name("b");
+
+            auto* c3 = table_def.add_columns();
+            c3->set_type(::hybridse::type::kVarchar);
+            c3->set_name("c");
+
+            auto* index = table_def.add_indexes();
+            index->set_name("idx");
+            index->add_first_keys("a");
+            index->add_first_keys("b");
+            index->add_first_keys("c");
+        }
+        vm::AddTable(db, table_def);
+
+        catalog_ = vm::BuildSimpleCatalog(db);
+    }
+
+ protected:
+    node::NodeManager manager_;
+    std::shared_ptr<vm::SimpleCatalog> catalog_;
+};
+
+absl::string_view optimized_plan = R"sql(FILTER_BY(condition=, left_keys=(), right_keys=(), index_keys=(aaa,12,ccc))
+  DATA_PROVIDER(type=Partition, table=t1, index=idx))sql";
+absl::string_view unoptimized_plan =
+    R"sql(FILTER_BY(condition=12 = b AND ccc = c, left_keys=(), right_keys=(), index_keys=)
+  DATA_PROVIDER(table=t1))sql";
+static const std::vector<GASTestCase> cases = {
+    {"select * from t1 where a = 'aaa' and b = 12 and c = 'ccc';", optimized_plan},
+    {"select * from t1 where c = 'ccc' and b = 12 and a = 'aaa';", optimized_plan},
+    {"select * from t1 where b = 12 and c = 'ccc' and a = 'aaa';", optimized_plan},
+    {"select * from t1 where b = 12 and c = 'ccc';", unoptimized_plan},
+};
+
+INSTANTIATE_TEST_SUITE_P(CombinedIndex, GroupAndSortOptOnCombinedIndexTest, testing::ValuesIn(cases));
+
+TEST_P(GroupAndSortOptOnCombinedIndexTest, OptimizeOutOfOrderFilter) {
+    auto& cs = GetParam();
+    ::hybridse::node::PlanNodeList plan_trees;
+    ::hybridse::base::Status base_status;
+    ASSERT_TRUE(plan::PlanAPI::CreatePlanTreeFromScript(std::string(cs.sql), plan_trees, &manager_, base_status))
+        << base_status;
+
+    auto ctx = llvm::make_unique<llvm::LLVMContext>();
+    auto m = llvm::make_unique<llvm::Module>("test_op_generator", *ctx);
+    auto lib = ::hybridse::udf::DefaultUdfLibrary::get();
+    const codec::Schema empty_schema;
+
+    vm::BatchModeTransformer tf(&manager_, "db", catalog_, &empty_schema, m.get(), lib);
+    tf.AddDefaultPasses();
+
+    PhysicalOpNode* physical_plan = nullptr;
+    base::Status status = tf.TransformPhysicalPlan(plan_trees, &physical_plan);
+    EXPECT_EQ(cs.physical_tree_str, physical_plan->GetTreeString());
+}
+
+}  // namespace passes
+}  // namespace hybridse
+
+int main(int argc, char** argv) {
+    ::testing::GTEST_FLAG(color) = "yes";
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/hybridse/src/vm/transform_request_mode_test.cc
+++ b/hybridse/src/vm/transform_request_mode_test.cc
@@ -317,7 +317,7 @@ INSTANTIATE_TEST_SUITE_P(
                                    "LIMIT(limit=10, optimized)\n"
                                    "  PROJECT(type=Aggregation, limit=10)\n"
                                    "    REQUEST_UNION(partition_keys=(), orders=(ASC), "
-                                   "range=(col5, -3, 0), index_keys=(col2,col1))\n"
+                                   "range=(col5, -3, 0), index_keys=(col1,col2))\n"
                                    "      DATA_PROVIDER(request=t1)\n"
                                    "      DATA_PROVIDER(type=Partition, table=t1, index=index12)")));
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

support query with filter conditions that out-of-order with index definition
close #1356 

* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**

