### PR TITLE
fix(#1587): pure history rows range window iterator initialize position wrongly

### DIFF
--- a/cases/function/window/test_window.yaml
+++ b/cases/function/window/test_window.yaml
@@ -1022,15 +1022,116 @@ cases:
         - [5,"aa",34,34,34,312,312]
         - [6,"aa",35,35,35,35,408]
 
+  - id: 33
+    desc: |
+      first_value results in two rows_range window, refer https://github.com/4paradigm/OpenMLDB/issues/1587
+    inputs:
+      - columns: [ "id int","ts timestamp","group1 string","val1 int" ]
+        indexs: [ "index1:group1:ts" ]
+        name: t1
+        data: |
+          1, 1612130400000, g1, 1
+          2, 1612130401000, g1, 2
+          3, 1612130402000, g1, 3
+          4, 1612130403000, g1, 4
+          5, 1612130404000, g1, 5
+          6, 1612130404000, g2, 4
+          7, 1612130405000, g2, 3
+          8, 1612130406000, g2, 2
+    sql: |
+      select
+      `id`,
+      `val1`,
+      first_value(val1) over w1 as agg1,
+      first_value(val1) over w2 as agg2,
+      from `t1` WINDOW
+        w1 as (partition by `group1` order by `ts` rows_range between 5s preceding and 0s preceding),
+        w2 as (partition by `group1` order by `ts` rows_range between 5s preceding and 1s preceding);
+    expect:
+      columns: ["id int", "val1 int", "agg1 int", "agg2 int"]
+      order: id
+      data: |
+        1, 1, 1, NULL
+        2, 2, 2, 1
+        3, 3, 3, 2
+        4, 4, 4, 3
+        5, 5, 5, 4
+        6, 4, 4, NULL
+        7, 3, 3, 4
+        8, 2, 2, 3
 
+  - id: 34
+    desc: |
+      first_value results in two rows windows
+    inputs:
+      - columns: [ "id int","ts timestamp","group1 string","val1 int" ]
+        indexs: [ "index1:group1:ts" ]
+        name: t1
+        data: |
+          1, 1612130400000, g1, 1
+          2, 1612130401000, g1, 2
+          3, 1612130402000, g1, 3
+          4, 1612130403000, g1, 4
+          5, 1612130404000, g1, 5
+          6, 1612130404000, g2, 4
+          7, 1612130405000, g2, 3
+          8, 1612130406000, g2, 2
+    sql: |
+      select
+      `id`,
+      `val1`,
+      first_value(val1) over w1 as agg1,
+      first_value(val1) over w2 as agg2,
+      from `t1` WINDOW
+        w1 as (partition by `group1` order by `ts` rows between 5 preceding and 0 preceding),
+        w2 as (partition by `group1` order by `ts` rows between 5 preceding and 1 preceding);
+    expect:
+      columns: ["id int", "val1 int", "agg1 int", "agg2 int"]
+      order: id
+      data: |
+        1, 1, 1, NULL
+        2, 2, 2, 1
+        3, 3, 3, 2
+        4, 4, 4, 3
+        5, 5, 5, 4
+        6, 4, 4, NULL
+        7, 3, 3, 4
+        8, 2, 2, 3
 
-
-
-
-
-
-
-
-
-
-
+  - id: 35
+    desc: |
+      first_value results in rows/rows_range windows
+    inputs:
+      - columns: [ "id int","ts timestamp","group1 string","val1 int" ]
+        indexs: [ "index1:group1:ts" ]
+        name: t1
+        data: |
+          1, 1612130400000, g1, 1
+          2, 1612130401000, g1, 2
+          3, 1612130402000, g1, 3
+          4, 1612130403000, g1, 4
+          5, 1612130404000, g1, 5
+          6, 1612130404000, g2, 4
+          7, 1612130405000, g2, 3
+          8, 1612130406000, g2, 2
+    sql: |
+      select
+      `id`,
+      `val1`,
+      first_value(val1) over w1 as agg1,
+      first_value(val1) over w2 as agg2,
+      from `t1` WINDOW
+        w1 as (partition by `group1` order by `ts` rows_range between 5s preceding and 0s preceding),
+        w2 as (partition by `group1` order by `ts` rows between 5 preceding and 1 preceding);
+    expect:
+      columns: ["id int", "val1 int", "agg1 int", "agg2 int"]
+      order: id
+      data: |
+        1, 1, 1, NULL
+        2, 2, 2, 1
+        3, 3, 3, 2
+        4, 4, 4, 3
+        5, 5, 5, 4
+        6, 4, 4, NULL
+        7, 3, 3, 4
+        8, 2, 2, 3

--- a/hybridse/include/codec/list_iterator_codec.h
+++ b/hybridse/include/codec/list_iterator_codec.h
@@ -398,7 +398,7 @@ class InnerRangeIterator : public ConstIterator<uint64_t, V> {
           start_(start),
           end_(end) {
         if (nullptr != root_) {
-            root_->SeekToFirst();
+            SeekToFirst();
             start_key_ = root_->Valid() ? root_->GetKey() : 0;
         }
     }
@@ -416,9 +416,13 @@ class InnerRangeIterator : public ConstIterator<uint64_t, V> {
         root_->Seek(start_);
     }
     virtual bool IsSeekable() const { return root_->IsSeekable(); }
+
     std::unique_ptr<ConstIterator<uint64_t, V>> root_;
+    // the row key corresponding to the window
     uint64_t start_key_;
+    // range start, key decrease start to end
     const uint64_t start_;
+    // range end, key decrease start to end
     const uint64_t end_;
 };
 

--- a/hybridse/include/vm/mem_catalog.h
+++ b/hybridse/include/vm/mem_catalog.h
@@ -411,7 +411,7 @@ class HistoryWindow : public Window {
  protected:
     bool BufferCurrentHistoryBuffer(uint64_t key, const Row& row,
                                     uint64_t end_ts) {
-        current_history_buffer_.emplace_front(std::make_pair(key, row));
+        current_history_buffer_.emplace_front(key, row);
         int64_t sub = (key + window_range_.start_offset_);
         uint64_t start_ts = sub < 0 ? 0u : static_cast<uint64_t>(sub);
         while (!current_history_buffer_.empty()) {

--- a/hybridse/src/udf/default_defs/window_functions_def.cc
+++ b/hybridse/src/udf/default_defs/window_functions_def.cc
@@ -70,7 +70,7 @@ node::ExprNode* BuildAt(UdfResolveContext* ctx, ExprNode* input, ExprNode* idx,
     if (default_val != nullptr) {
         auto default_type = default_val->GetOutputType();
         if (default_type->base() != node::kNull) {
-            if (node::TypeEquals(default_type, input_type->GetGenericType(0))) {
+            if (!node::TypeEquals(default_type, input_type->GetGenericType(0))) {
                 ctx->SetError(
                     "Default value type must be same with input element "
                     "type: " +

--- a/hybridse/src/vm/mem_catalog.cc
+++ b/hybridse/src/vm/mem_catalog.cc
@@ -123,11 +123,11 @@ std::unique_ptr<WindowIterator> MemTimeTableHandler::GetWindowIterator(
 }
 
 void MemTimeTableHandler::AddRow(const uint64_t key, const Row& row) {
-    table_.emplace_back(std::make_pair(key, row));
+    table_.emplace_back(key, row);
 }
 
 void MemTimeTableHandler::AddFrontRow(const uint64_t key, const Row& row) {
-    table_.emplace_front(std::make_pair(key, row));
+    table_.emplace_front(key, row);
 }
 void MemTimeTableHandler::PopBackRow() { table_.pop_back(); }
 


### PR DESCRIPTION
**TL;DR**

InnerRangeList should call `SeekToFirst` on construct, close #1587 

previous code use `root_->SeekToFirst`, which result `root_` to the
current row instead the first element inside window. That is different
when the window is a pure history window


