### PR TITLE
chore: delete java dir from gitignore

### DIFF
--- a/hybridse/.gitignore
+++ b/hybridse/.gitignore
@@ -15,24 +15,12 @@ thirdsrc
 src/fe_version.h
 src/hyhridse_version.h
 
-# java ignore
-*.iml
-*.idea*
-java/*/target
-
-# ignore codegen files
-java/fesql-proto/src/main/java/com/*
-java/fesql-native/src/main/java/com/*
-java/hybridse-proto/src/main/java/com/*
-java/hybridse-native/src/main/java/com/*
-
 # ignore docgen
 tools/documentation/udf_doxygen/html
 tools/documentation/udf_doxygen/udfs
 style.xml
 hybridse_version.h
 intermediate_cicd_artifact_.tar.gz
-java/hybridse-spark/src/test/resources/fesql_windows
 .husky
 tools/documentation/api_doxygen/html
 tools/documentation/api_doxygen/xml


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Delete java dir from `/hybridse/.gitignore`

* **What is the current behavior?** (You can also link to an open issue here)

Issue: https://github.com/4paradigm/OpenMLDB/issues/1531

* **What is the new behavior (if this is a feature change)?**

N/A.
