### PR TITLE
refractor: Fix typo of PhysicalAggrerationNode

### DIFF
--- a/hybridse/include/vm/physical_op.h
+++ b/hybridse/include/vm/physical_op.h
@@ -759,14 +759,14 @@ class PhysicalSimpleProjectNode : public PhysicalUnaryNode {
     ColumnProjects project_;
 };
 
-class PhysicalAggrerationNode : public PhysicalProjectNode {
+class PhysicalAggregationNode : public PhysicalProjectNode {
  public:
-    PhysicalAggrerationNode(PhysicalOpNode *node, const ColumnProjects &project, const node::ExprNode *condition)
+    PhysicalAggregationNode(PhysicalOpNode *node, const ColumnProjects &project, const node::ExprNode *condition)
         : PhysicalProjectNode(node, kAggregation, project, true), having_condition_(condition) {
         output_type_ = kSchemaTypeRow;
         fn_infos_.push_back(&having_condition_.fn_info());
     }
-    virtual ~PhysicalAggrerationNode() {}
+    virtual ~PhysicalAggregationNode() {}
     virtual void Print(std::ostream &output, const std::string &tab) const;
     ConditionFilter having_condition_;
 };
@@ -774,7 +774,7 @@ class PhysicalAggrerationNode : public PhysicalProjectNode {
 class PhysicalReduceAggregationNode : public PhysicalProjectNode {
  public:
     PhysicalReduceAggregationNode(PhysicalOpNode *node, const ColumnProjects &project,
-                                  const node::ExprNode *condition, const PhysicalAggrerationNode *orig_aggr)
+                                  const node::ExprNode *condition, const PhysicalAggregationNode *orig_aggr)
         : PhysicalProjectNode(node, kReduceAggregation, project, true), having_condition_(condition) {
         output_type_ = kSchemaTypeRow;
         fn_infos_.push_back(&having_condition_.fn_info());
@@ -784,7 +784,7 @@ class PhysicalReduceAggregationNode : public PhysicalProjectNode {
     base::Status InitSchema(PhysicalPlanContext *) override;
     virtual void Print(std::ostream &output, const std::string &tab) const;
     ConditionFilter having_condition_;
-    const PhysicalAggrerationNode* orig_aggr_ = nullptr;
+    const PhysicalAggregationNode* orig_aggr_ = nullptr;
 };
 
 class PhysicalGroupAggrerationNode : public PhysicalProjectNode {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
PR involves a refractory change. It changes `PhysicalAggrerationNode` to `PhysicalAggregationNode`


* **What is the current behavior?** (You can also link to an open issue here)
gh- #1767 


* **What is the new behavior (if this is a feature change)?**
On lines 762,764, 769, and 777 `PhysicalAggrerationNode` was changed to `PhysicalAggregationNode`