### PR TITLE
fix: remove unused gflag variable (#1775)

### DIFF
--- a/src/flags.cc
+++ b/src/flags.cc
@@ -39,7 +39,6 @@ DEFINE_uint32(name_server_task_max_concurrency, 8, "config the max concurrency o
 DEFINE_int32(name_server_task_wait_time, 1000, "config the time of task wait");
 DEFINE_uint32(name_server_op_execute_timeout, 2 * 60 * 60 * 1000, "config the timeout of nameserver op");
 DEFINE_bool(auto_failover, false, "enable or disable auto failover");
-DEFINE_bool(enable_timeseries_table, true, "enable or disable timeseries table");
 DEFINE_int32(max_op_num, 10000, "config the max op num");
 DEFINE_uint32(partition_num, 8, "config the default partition_num");
 DEFINE_uint32(replica_num, 3,

--- a/src/nameserver/name_server_impl.cc
+++ b/src/nameserver/name_server_impl.cc
@@ -67,7 +67,6 @@ DECLARE_int32(make_snapshot_time);
 DECLARE_int32(make_snapshot_check_interval);
 DECLARE_bool(use_name);
 DECLARE_bool(enable_distsql);
-DECLARE_bool(enable_timeseries_table);
 DECLARE_uint32(sync_deploy_stats_timeout);
 
 using ::openmldb::api::OPType::kAddIndexOP;

--- a/src/nameserver/name_server_test.cc
+++ b/src/nameserver/name_server_test.cc
@@ -45,7 +45,6 @@ DECLARE_int32(make_snapshot_threshold_offset);
 DECLARE_uint32(name_server_task_max_concurrency);
 DECLARE_uint32(system_table_replica_num);
 DECLARE_bool(auto_failover);
-DECLARE_bool(enable_timeseries_table);
 
 using brpc::Server;
 using openmldb::tablet::TabletImpl;

--- a/src/nameserver/standalone_test.cc
+++ b/src/nameserver/standalone_test.cc
@@ -43,7 +43,6 @@ DECLARE_int32(zk_keep_alive_check_interval);
 DECLARE_int32(make_snapshot_threshold_offset);
 DECLARE_uint32(name_server_task_max_concurrency);
 DECLARE_bool(auto_failover);
-DECLARE_bool(enable_timeseries_table);
 
 using brpc::Server;
 using openmldb::tablet::TabletImpl;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

close #1775 to remove instances of  (enable_timeseries_table)


* **What is the current behavior?** (You can also link to an open issue here)
Just some code delete

* **What is the new behavior (if this is a feature change)?**
This doesn't actually change anything about the behavior 
