### PR TITLE
refactor: fix typo of PhysicalAggrerationNode

### DIFF
--- a/hybridse/include/vm/physical_op.h
+++ b/hybridse/include/vm/physical_op.h
@@ -759,14 +759,14 @@ class PhysicalSimpleProjectNode : public PhysicalUnaryNode {
     ColumnProjects project_;
 };
 
-class PhysicalAggrerationNode : public PhysicalProjectNode {
+class PhysicalAggregationNode : public PhysicalProjectNode {
  public:
-    PhysicalAggrerationNode(PhysicalOpNode *node, const ColumnProjects &project, const node::ExprNode *condition)
+    PhysicalAggregationNode(PhysicalOpNode *node, const ColumnProjects &project, const node::ExprNode *condition)
         : PhysicalProjectNode(node, kAggregation, project, true), having_condition_(condition) {
         output_type_ = kSchemaTypeRow;
         fn_infos_.push_back(&having_condition_.fn_info());
     }
-    virtual ~PhysicalAggrerationNode() {}
+    virtual ~PhysicalAggregationNode() {}
     virtual void Print(std::ostream &output, const std::string &tab) const;
     ConditionFilter having_condition_;
 };
@@ -774,7 +774,7 @@ class PhysicalAggrerationNode : public PhysicalProjectNode {
 class PhysicalReduceAggregationNode : public PhysicalProjectNode {
  public:
     PhysicalReduceAggregationNode(PhysicalOpNode *node, const ColumnProjects &project,
-                                  const node::ExprNode *condition, const PhysicalAggrerationNode *orig_aggr)
+                                  const node::ExprNode *condition, const PhysicalAggregationNode *orig_aggr)
         : PhysicalProjectNode(node, kReduceAggregation, project, true), having_condition_(condition) {
         output_type_ = kSchemaTypeRow;
         fn_infos_.push_back(&having_condition_.fn_info());
@@ -784,7 +784,7 @@ class PhysicalReduceAggregationNode : public PhysicalProjectNode {
     base::Status InitSchema(PhysicalPlanContext *) override;
     virtual void Print(std::ostream &output, const std::string &tab) const;
     ConditionFilter having_condition_;
-    const PhysicalAggrerationNode* orig_aggr_ = nullptr;
+    const PhysicalAggregationNode* orig_aggr_ = nullptr;
 };
 
 class PhysicalGroupAggrerationNode : public PhysicalProjectNode {

--- a/hybridse/src/passes/physical/batch_request_optimize.cc
+++ b/hybridse/src/passes/physical/batch_request_optimize.cc
@@ -406,9 +406,9 @@ static Status CreateNewProject(PhysicalPlanContext* ctx, ProjectType ptype,
             break;
         }
         case ProjectType::kAggregation: {
-            PhysicalAggrerationNode* op = nullptr;
+            PhysicalAggregationNode* op = nullptr;
             CHECK_STATUS(
-                ctx->CreateOp<PhysicalAggrerationNode>(&op, input, projects, having_condition));
+                ctx->CreateOp<PhysicalAggregationNode>(&op, input, projects, having_condition));
             *out = op;
             break;
         }
@@ -424,7 +424,7 @@ Status CommonColumnOptimize::ProcessProject(PhysicalPlanContext* ctx,
                                             BuildOpState* state) {
     // process window agg
     if (project_op->project_type_ == ProjectType::kAggregation) {
-        auto window_agg_op = dynamic_cast<PhysicalAggrerationNode*>(project_op);
+        auto window_agg_op = dynamic_cast<PhysicalAggregationNode*>(project_op);
         return ProcessWindow(ctx, window_agg_op, state);
     }
 
@@ -487,7 +487,7 @@ Status CommonColumnOptimize::ProcessProject(PhysicalPlanContext* ctx,
 //    const node::ExprNode* having_condition = project_op->having_condition_.condition();
     vm::ConditionFilter having_condition;
     if (project_op->project_type_ == vm::kAggregation) {
-        having_condition = dynamic_cast<vm::PhysicalAggrerationNode*>(project_op)->having_condition_;
+        having_condition = dynamic_cast<vm::PhysicalAggregationNode*>(project_op)->having_condition_;
     } else if (project_op->project_type_ == vm::kGroupAggregation) {
         having_condition = dynamic_cast<vm::PhysicalGroupAggrerationNode*>(project_op)->having_condition_;
     }
@@ -687,7 +687,7 @@ Status CommonColumnOptimize::ProcessRequestUnion(
 }
 
 Status CommonColumnOptimize::ProcessWindow(PhysicalPlanContext* ctx,
-                                           PhysicalAggrerationNode* agg_op,
+                                           PhysicalAggregationNode* agg_op,
                                            BuildOpState* state) {
     // find request union path
     auto input = agg_op->GetProducer(0);
@@ -795,8 +795,8 @@ Status CommonColumnOptimize::ProcessWindow(PhysicalPlanContext* ctx,
         new_union == agg_op->GetProducer(0)) {
         state->common_op = agg_op;
     } else if (common_projects.size() > 0) {
-        PhysicalAggrerationNode* common_project_op = nullptr;
-        CHECK_STATUS(ctx->CreateOp<PhysicalAggrerationNode>(
+        PhysicalAggregationNode* common_project_op = nullptr;
+        CHECK_STATUS(ctx->CreateOp<PhysicalAggregationNode>(
             &common_project_op, new_union, common_projects, new_having_condition));
         state->common_op = common_project_op;
     } else {
@@ -807,8 +807,8 @@ Status CommonColumnOptimize::ProcessWindow(PhysicalPlanContext* ctx,
         new_union == agg_op->GetProducer(0)) {
         state->non_common_op = agg_op;
     } else if (non_common_projects.size() > 0) {
-        PhysicalAggrerationNode* non_common_project_op = nullptr;
-        CHECK_STATUS(ctx->CreateOp<PhysicalAggrerationNode>(
+        PhysicalAggregationNode* non_common_project_op = nullptr;
+        CHECK_STATUS(ctx->CreateOp<PhysicalAggregationNode>(
             &non_common_project_op, new_union, non_common_projects, new_having_condition));
         state->non_common_op = non_common_project_op;
     } else {

--- a/hybridse/src/passes/physical/batch_request_optimize.h
+++ b/hybridse/src/passes/physical/batch_request_optimize.h
@@ -32,7 +32,7 @@ namespace hybridse {
 namespace passes {
 
 using hybridse::base::Status;
-using hybridse::vm::PhysicalAggrerationNode;
+using hybridse::vm::PhysicalAggregationNode;
 using hybridse::vm::PhysicalDataProviderNode;
 using hybridse::vm::PhysicalProjectNode;
 using hybridse::vm::PhysicalRenameNode;
@@ -119,7 +119,7 @@ class CommonColumnOptimize : public PhysicalPass {
                                 PhysicalSimpleProjectNode*, BuildOpState*);
     Status ProcessProject(PhysicalPlanContext*, PhysicalProjectNode*,
                           BuildOpState*);
-    Status ProcessWindow(PhysicalPlanContext*, PhysicalAggrerationNode*,
+    Status ProcessWindow(PhysicalPlanContext*, PhysicalAggregationNode*,
                          BuildOpState*);
     Status ProcessJoin(PhysicalPlanContext*, PhysicalRequestJoinNode*,
                        BuildOpState*);

--- a/hybridse/src/passes/physical/long_window_optimized.cc
+++ b/hybridse/src/passes/physical/long_window_optimized.cc
@@ -54,11 +54,11 @@ bool LongWindowOptimized::Transform(PhysicalOpNode* in, PhysicalOpNode** output)
         return false;
     }
 
-    auto project_aggr_op = dynamic_cast<vm::PhysicalAggrerationNode*>(project_op);
-    // TODO(zhanghao): we only support transform PhysicalAggrerationNode with one and only one window aggregation op
+    auto project_aggr_op = dynamic_cast<vm::PhysicalAggregationNode*>(project_op);
+    // TODO(zhanghao): we only support transform PhysicalAggregationNode with one and only one window aggregation op
     // we may remove this constraint in a later optimization
     if (!VerifySingleAggregation(project_op)) {
-        LOG(WARNING) << "we only support transform PhysicalAggrerationNode with one and only one window aggregation op";
+        LOG(WARNING) << "we only support transform PhysicalAggregationNode with one and only one window aggregation op";
         return false;
     }
 
@@ -88,7 +88,7 @@ bool LongWindowOptimized::Transform(PhysicalOpNode* in, PhysicalOpNode** output)
     return true;
 }
 
-bool LongWindowOptimized::OptimizeWithPreAggr(vm::PhysicalAggrerationNode* in, int idx, PhysicalOpNode** output) {
+bool LongWindowOptimized::OptimizeWithPreAggr(vm::PhysicalAggregationNode* in, int idx, PhysicalOpNode** output) {
     *output = in;
 
     if (in->producers()[0]->GetOpType() != vm::kPhysicalOpRequestUnion) {

--- a/hybridse/src/passes/physical/long_window_optimized.h
+++ b/hybridse/src/passes/physical/long_window_optimized.h
@@ -32,7 +32,7 @@ class LongWindowOptimized : public TransformUpPysicalPass {
  private:
     bool Transform(PhysicalOpNode* in, PhysicalOpNode** output) override;
     bool VerifySingleAggregation(vm::PhysicalProjectNode* op);
-    bool OptimizeWithPreAggr(vm::PhysicalAggrerationNode* in, int idx, PhysicalOpNode** output);
+    bool OptimizeWithPreAggr(vm::PhysicalAggregationNode* in, int idx, PhysicalOpNode** output);
     static std::string ConcatExprList(std::vector<node::ExprNode*> exprs, const std::string& delimiter = ",");
 
     std::set<std::string> long_windows_;

--- a/hybridse/src/passes/physical/split_aggregation_optimized.h
+++ b/hybridse/src/passes/physical/split_aggregation_optimized.h
@@ -31,8 +31,8 @@ class SplitAggregationOptimized : public TransformUpPysicalPass {
 
  private:
     bool Transform(PhysicalOpNode* in, PhysicalOpNode** output);
-    bool SplitProjects(vm::PhysicalAggrerationNode* in, PhysicalOpNode** output);
-    bool IsSplitable(vm::PhysicalAggrerationNode* op);
+    bool SplitProjects(vm::PhysicalAggregationNode* in, PhysicalOpNode** output);
+    bool IsSplitable(vm::PhysicalAggregationNode* op);
 
     std::set<std::string> long_windows_;
 };

--- a/hybridse/src/vm/physical_op.cc
+++ b/hybridse/src/vm/physical_op.cc
@@ -433,7 +433,7 @@ Status PhysicalProjectNode::WithNewChildren(node::NodeManager* nm, const std::ve
             ConditionFilter new_having_condition;
             {
                 auto& having_condition =
-                    dynamic_cast<PhysicalAggrerationNode*>(this)->having_condition_;
+                    dynamic_cast<PhysicalAggregationNode*>(this)->having_condition_;
                 std::vector<const node::ExprNode*> having_condition_depend_columns;
                 having_condition.ResolvedRelatedColumns(&having_condition_depend_columns);
                 passes::ExprReplacer having_replacer;
@@ -444,7 +444,7 @@ Status PhysicalProjectNode::WithNewChildren(node::NodeManager* nm, const std::ve
                 CHECK_STATUS(having_condition.ReplaceExpr(having_replacer, nm, &new_having_condition));
             }
 
-            op = new PhysicalAggrerationNode(children[0], new_projects, new_having_condition.condition());
+            op = new PhysicalAggregationNode(children[0], new_projects, new_having_condition.condition());
             break;
         }
         case kGroupAggregation: {
@@ -565,7 +565,7 @@ PhysicalWindowAggrerationNode* PhysicalWindowAggrerationNode::CastFrom(PhysicalO
 }
 
 
-void PhysicalAggrerationNode::Print(std::ostream& output,
+void PhysicalAggregationNode::Print(std::ostream& output,
                                          const std::string& tab) const {
     PhysicalOpNode::Print(output, tab);
     output << "(type=" << ProjectTypeName(project_type_);

--- a/hybridse/src/vm/physical_op_test.cc
+++ b/hybridse/src/vm/physical_op_test.cc
@@ -27,7 +27,7 @@ class PhysicalOpTest : public ::testing::Test {
     PhysicalOpTest() {}
     ~PhysicalOpTest() {}
 };
-TEST_F(PhysicalOpTest, PhysicalAggrerationNodeWithNewChildrenTest) {
+TEST_F(PhysicalOpTest, PhysicalAggregationNodeWithNewChildrenTest) {
     node::NodeManager nm;
     hybridse::type::Database db;
     db.set_name("db");
@@ -38,7 +38,7 @@ TEST_F(PhysicalOpTest, PhysicalAggrerationNodeWithNewChildrenTest) {
     auto catalog = BuildSimpleCatalog(db);
 
     vm::PhysicalPlanContext plan_ctx(&nm, udf::DefaultUdfLibrary::get(), "db", catalog, nullptr, false);
-    vm::PhysicalAggrerationNode* aggreration_node;
+    vm::PhysicalAggregationNode* aggreration_node;
     vm::PhysicalTableProviderNode* table_node;
     plan_ctx.CreateOp(&table_node, catalog->GetTable("db", "t1"));
     ColumnProjects projects;

--- a/hybridse/src/vm/runner.cc
+++ b/hybridse/src/vm/runner.cc
@@ -201,7 +201,7 @@ ClusterTask RunnerBuilder::Build(PhysicalOpNode* node, Status& status) {
                 case kAggregation: {
                     AggRunner* runner = nullptr;
                     CreateRunner<AggRunner>(&runner, id_++, node->schemas_ctx(), op->GetLimitCnt(),
-                                            dynamic_cast<const PhysicalAggrerationNode*>(node)->having_condition_,
+                                            dynamic_cast<const PhysicalAggregationNode*>(node)->having_condition_,
                                             op->project().fn_info());
                     return RegisterTask(node,
                                         UnaryInheritTask(cluster_task, runner));

--- a/hybridse/src/vm/transform.cc
+++ b/hybridse/src/vm/transform.cc
@@ -213,7 +213,7 @@ Status BatchModeTransformer::InitFnInfo(PhysicalOpNode* node,
                 }
                 case kAggregation: {
                     // Code generation for having condition
-                    CHECK_STATUS(GenHavingFilter(&(dynamic_cast<PhysicalAggrerationNode*>(node))->having_condition_,
+                    CHECK_STATUS(GenHavingFilter(&(dynamic_cast<PhysicalAggregationNode*>(node))->having_condition_,
                                                     project_op->producers()[0]->schemas_ctx()));
                     break;
                 }
@@ -1183,8 +1183,8 @@ Status BatchModeTransformer::CreatePhysicalProjectNode(
             break;
         }
         case kAggregation: {
-            PhysicalAggrerationNode* agg_op = nullptr;
-            CHECK_STATUS(CreateOp<PhysicalAggrerationNode>(&agg_op, depend,
+            PhysicalAggregationNode* agg_op = nullptr;
+            CHECK_STATUS(CreateOp<PhysicalAggregationNode>(&agg_op, depend,
                                                            column_projects, having_condition));
             *output = agg_op;
             break;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
PR involves refractory changes. It refractors `PhysicalAggrerationNode` to `PhysicalAggregationNode` at various instances in the code


* **What is the current behavior?** (You can also link to an open issue here)
gh #1767 


* **What is the new behavior (if this is a feature change)?**
In various instances as mentioned in `@zhanghaohit` comment, `PhysicalAggrerationNode` has been replaced by `PhysicalAggregationNode`
