### PR TITLE
refactor: check if null in PreparedStatement

### DIFF
--- a/java/openmldb-jdbc/src/main/java/com/_4paradigm/openmldb/jdbc/PreparedStatement.java
+++ b/java/openmldb-jdbc/src/main/java/com/_4paradigm/openmldb/jdbc/PreparedStatement.java
@@ -272,9 +272,9 @@ public class PreparedStatement implements java.sql.PreparedStatement {
                 columnTypes.AddColumnType(types.get(i + 1));
             }
             this.currentRow = SQLRequestRow.CreateSQLRequestRowFromColumnTypes(columnTypes);
-        if (this.currentRow == null) {
-        	throw new SQLException("failed to build data with row");
-        }
+            if (this.currentRow == null) {
+        	    throw new SQLException("failed to build data with row");
+            }
             this.currentSchema = this.currentRow.GetSchema();
             this.orgTypes = this.types;
         }

--- a/java/openmldb-jdbc/src/main/java/com/_4paradigm/openmldb/jdbc/PreparedStatement.java
+++ b/java/openmldb-jdbc/src/main/java/com/_4paradigm/openmldb/jdbc/PreparedStatement.java
@@ -273,7 +273,7 @@ public class PreparedStatement implements java.sql.PreparedStatement {
             }
             this.currentRow = SQLRequestRow.CreateSQLRequestRowFromColumnTypes(columnTypes);
             if (this.currentRow == null) {
-        	throw new SQLException("failed to build data with row");
+        	throw new SQLException("fail to create sql request row from column types");
             }
             this.currentSchema = this.currentRow.GetSchema();
             this.orgTypes = this.types;

--- a/java/openmldb-jdbc/src/main/java/com/_4paradigm/openmldb/jdbc/PreparedStatement.java
+++ b/java/openmldb-jdbc/src/main/java/com/_4paradigm/openmldb/jdbc/PreparedStatement.java
@@ -272,12 +272,11 @@ public class PreparedStatement implements java.sql.PreparedStatement {
                 columnTypes.AddColumnType(types.get(i + 1));
             }
             this.currentRow = SQLRequestRow.CreateSQLRequestRowFromColumnTypes(columnTypes);
-            // TODO(hw): check if null
+        if (this.currentRow == null) {
+        	throw new SQLException("failed to build data with row");
+        }
             this.currentSchema = this.currentRow.GetSchema();
             this.orgTypes = this.types;
-        }
-        if (this.currentRow == null) {
-            throw new SQLException("fail to build data with null row");
         }
         if (this.currentSchema == null) {
             throw new SQLException("fail to build data with null schema");

--- a/java/openmldb-jdbc/src/main/java/com/_4paradigm/openmldb/jdbc/PreparedStatement.java
+++ b/java/openmldb-jdbc/src/main/java/com/_4paradigm/openmldb/jdbc/PreparedStatement.java
@@ -273,7 +273,7 @@ public class PreparedStatement implements java.sql.PreparedStatement {
             }
             this.currentRow = SQLRequestRow.CreateSQLRequestRowFromColumnTypes(columnTypes);
             if (this.currentRow == null) {
-        	   throw new SQLException("failed to build data with row");
+        	throw new SQLException("failed to build data with row");
             }
             this.currentSchema = this.currentRow.GetSchema();
             this.orgTypes = this.types;

--- a/java/openmldb-jdbc/src/main/java/com/_4paradigm/openmldb/jdbc/PreparedStatement.java
+++ b/java/openmldb-jdbc/src/main/java/com/_4paradigm/openmldb/jdbc/PreparedStatement.java
@@ -273,7 +273,7 @@ public class PreparedStatement implements java.sql.PreparedStatement {
             }
             this.currentRow = SQLRequestRow.CreateSQLRequestRowFromColumnTypes(columnTypes);
             if (this.currentRow == null) {
-        	    throw new SQLException("failed to build data with row");
+        	   throw new SQLException("failed to build data with row");
             }
             this.currentSchema = this.currentRow.GetSchema();
             this.orgTypes = this.types;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
PR checks if "currentRow" variable value is NULL and its checked before calling GetSchema method. If it's null, throws an exception.
Also another if statement previously on line 279 is deleted.
close #1759 

* **What is the current behavior?** (You can also link to an open issue here)
https://github.com/4paradigm/OpenMLDB/issues/1759


* **What is the new behavior (if this is a feature change)?**
As directed by @vagetablechicken "if" statement is placed to check for null value of "currentRow" variable and if value is null exception is thrown.
