### PR TITLE
fix: define the ordering for rows having same key/ts in window union but from different datasource

### DIFF
--- a/cases/function/window/test_window_union.yaml
+++ b/cases/function/window/test_window_union.yaml
@@ -901,4 +901,68 @@ cases:
       data: |
         1, 6, 999, 0, 200, 233
         2, 7, 10000, 0, 21, 200
+  - id: 19-2
+    mode: cluster-unsupport
+    desc: |
+      rows order for pure history window union
+    inputs:
+      - name: t1
+        columns:
+          - id int
+          - ts timestamp
+          - g int
+          - val int
+        indexs:
+          - idx:g:ts
+        data: |
+          1, 100, 111, 21
+          2, 100, 111, 10000
+      - name: t2
+        columns:
+          - id int
+          - ts timestamp
+          - g int
+          - val int
+        indexs:
+          - idx:g:ts
+        data: |
+          1,  88, 111, 999
+          1, 100, 111, 233
+          1, 100, 111, 200
+      - name: t3
+        columns:
+          - id int
+          - ts timestamp
+          - g int
+          - val int
+        indexs:
+          - idx:g:ts
+        data: |
+          1, 100, 111, 0
+          1, 100, 111, 33
+    sql: |
+       select
+          id, count(val) over w as cnt,
+          max(val) over w as mv,
+          min(val) over w as mi,
+          lag(val, 1) over w as l1,
+          lag(val, 2) over w as l2,
+          lag(val, 3) over w as l3
+       from t1 window w as(
+          union t2,t3
+          partition by `g` order by `ts`
+          ROWS BETWEEN 3 preceding and 1 preceding INSTANCE_NOT_IN_WINDOW);
+    expect:
+      columns:
+        - id int
+        - cnt int64
+        - mv int
+        - mi int
+        - l1 int
+        - l2 int
+        - l3 int
+      order: id
+      data: |
+        1, 3, 233, 33, 200, 233, 33
+        2, 3, 233, 33, 200, 233, 33
 

--- a/cases/function/window/test_window_union.yaml
+++ b/cases/function/window/test_window_union.yaml
@@ -575,12 +575,13 @@ cases:
         - [4,"dd",20,96]
         - [5,"ee",21,34]
 
-  # test correctness for window union when there are rows in union rows and original rows whose key is the same
+  # test correctness for window union when there are rows in union rows and original rows whose ts/key is the same
   # refer https://github.com/4paradigm/OpenMLDB/issues/1776#issuecomment-1121258571 for the specification
   # - 18-1 & 18-2 test simple case for UNION ROWS_RANGE and UNION ROWS
   # - 18-3 test test UNION ROWS_RANGE with MAXSIZE
   # - 18-4 & 18-5 test EXCLUDE CURRENT_TIME for UNION ROWS_RANGE/ROWS
   - id: 18-1
+    mode: cluster-unsupport
     desc: |
       when UNION ROWS_RANGE has the same key with original rows, original rows first then union rows
     inputs:
@@ -614,7 +615,7 @@ cases:
           min(val) over w as mi,
           lag(val, 1) over w as l1
        from (select * from t1) window w as(
-          union (select * from t2)
+          union t2
           partition by `g` order by `ts`
           rows_range between 1s preceding and 0s preceding);
     expect:
@@ -629,6 +630,7 @@ cases:
         1, 3, 233, 21, 200
         2, 4, 400, 21, 21
   - id: 18-2
+    mode: cluster-unsupport
     desc: |
       when UNION ROWS has the same key with original rows, original rows first then union rows,
       union rows filtered out first for max window size limitation
@@ -679,6 +681,7 @@ cases:
         1, 3, 233, 21, 200
         2, 3, 400, 21, 21
   - id: 18-3
+    mode: cluster-unsupport
     desc: |
       when UNION ROWS_RANGE MAXSIZE has the same key with original rows, original rows first then union rows
       union rows filtered out for max window size first
@@ -728,6 +731,7 @@ cases:
         1, 2, 200, 21, 200
         2, 2, 21, 0, 21
   - id: 18-4
+    mode: cluster-unsupport
     desc: |
       when UNION ROWS_RANGE EXCLUDE CURRENT_TIME has the same key with original rows, original rows first then union rows
       other rows except current row filtered out by EXCLUDE CURRENT_TIME
@@ -778,6 +782,7 @@ cases:
         2, 2, 233, 5,  233
 
   - id: 18-5
+    mode: cluster-unsupport
     desc: |
       UNION ROWS current time rows filtered out
     inputs:
@@ -827,4 +832,71 @@ cases:
       data: |
         1, 3, 999, 21, 233
         2, 3, 10000, 233, 233
+
+  # for the case that window unions multiple tables
+  # the order for rows between those multiple union tables that has same ts key,
+  # is undefined by specification.
+  # However, SQL engine explicitly use the order as master table -> first union table in SQL -> second union table in SQL -> ....
+  #
+  # 19-* series test case tests for this for SQL engine only, you should never reply on this behavior anyway
+  - id: 19-1
+    mode: cluster-unsupport
+    desc: |
+      window unions multiple tables, the order for rows in union tables with same ts is explicitly as the order in SQL
+    inputs:
+      - name: t1
+        columns:
+          - id int
+          - ts timestamp
+          - g int
+          - val int
+        indexs:
+          - idx:g:ts
+        data: |
+          1, 100, 111, 21
+          2, 100, 111, 10000
+      - name: t2
+        columns:
+          - id int
+          - ts timestamp
+          - g int
+          - val int
+        indexs:
+          - idx:g:ts
+        data: |
+          1,  88, 111, 999
+          1, 100, 111, 233
+          1, 100, 111, 200
+      - name: t3
+        columns:
+          - id int
+          - ts timestamp
+          - g int
+          - val int
+        indexs:
+          - idx:g:ts
+        data: |
+          1, 100, 111, 0
+          1, 100, 111, 33
+    sql: |
+       select
+          id, count(val) over w as cnt,
+          max(val) over w as mv,
+          min(val) over w as mi,
+          lag(val, 2) over w as l1
+       from t1 window w as(
+          union t2,t3
+          partition by `g` order by `ts`
+          ROWS_RANGE BETWEEN 2s preceding and 0s preceding);
+    expect:
+      columns:
+        - id int
+        - cnt int64
+        - mv int
+        - mi int
+        - l1 int
+      order: mv
+      data: |
+        1, 6, 999, 0, 233
+        2, 7, 10000, 0, 200
 

--- a/cases/function/window/test_window_union.yaml
+++ b/cases/function/window/test_window_union.yaml
@@ -776,7 +776,7 @@ cases:
         - mv int
         - mi int
         - l1 int
-      order: mv
+      order: id
       data: |
         1, 2, 233, 21, 233
         2, 2, 233, 5,  233
@@ -828,7 +828,7 @@ cases:
         - mv int
         - mi int
         - l1 int
-      order: mv
+      order: id
       data: |
         1, 3, 999, 21, 233
         2, 3, 10000, 233, 233
@@ -883,7 +883,8 @@ cases:
           id, count(val) over w as cnt,
           max(val) over w as mv,
           min(val) over w as mi,
-          lag(val, 2) over w as l1
+          lag(val, 1) over w as l1,
+          lag(val, 2) over w as l2
        from t1 window w as(
           union t2,t3
           partition by `g` order by `ts`
@@ -895,8 +896,9 @@ cases:
         - mv int
         - mi int
         - l1 int
-      order: mv
+        - l2 int
+      order: id
       data: |
-        1, 6, 999, 0, 233
-        2, 7, 10000, 0, 200
+        1, 6, 999, 0, 200, 233
+        2, 7, 10000, 0, 21, 200
 

--- a/cases/function/window/test_window_union.yaml
+++ b/cases/function/window/test_window_union.yaml
@@ -576,6 +576,7 @@ cases:
         - [5,"ee",21,34]
 
   # test correctness for window union when there are rows in union rows and original rows whose key is the same
+  # refer https://github.com/4paradigm/OpenMLDB/issues/1776#issuecomment-1121258571 for the specification
   # - 18-1 & 18-2 test simple case for UNION ROWS_RANGE and UNION ROWS
   # - 18-3 test test UNION ROWS_RANGE with MAXSIZE
   # - 18-4 & 18-5 test EXCLUDE CURRENT_TIME for UNION ROWS_RANGE/ROWS
@@ -593,6 +594,7 @@ cases:
           - idx:g:ts
         data: |
           1, 100, 111, 21
+          2, 100, 111, 400
       - name: t2
         columns:
           - id int
@@ -602,7 +604,7 @@ cases:
         indexs:
           - idx:g:ts
         data: |
-          1,  99, 111, 233
+          1, 100, 111, 233
           1, 100, 111, 200
           1, 101, 111, 17
     sql: |
@@ -622,9 +624,10 @@ cases:
         - mv int
         - mi int
         - l1 int
-      order: mv
+      order: id
       data: |
         1, 3, 233, 21, 200
+        2, 4, 400, 21, 21
   - id: 18-2
     desc: |
       when UNION ROWS has the same key with original rows, original rows first then union rows,
@@ -640,6 +643,7 @@ cases:
           - idx:g:ts
         data: |
           1, 100, 111, 21
+          2, 100, 111, 400
       - name: t2
         columns:
           - id int
@@ -650,7 +654,7 @@ cases:
           - idx:g:ts
         data: |
           1,  88, 111, 999
-          1,  99, 111, 233
+          1, 100, 111, 233
           1, 100, 111, 200
           1, 101, 111, 17
     sql: |
@@ -670,9 +674,10 @@ cases:
         - mv int
         - mi int
         - l1 int
-      order: mv
+      order: id
       data: |
         1, 3, 233, 21, 200
+        2, 3, 400, 21, 21
   - id: 18-3
     desc: |
       when UNION ROWS_RANGE MAXSIZE has the same key with original rows, original rows first then union rows
@@ -688,6 +693,7 @@ cases:
           - idx:g:ts
         data: |
           1, 100, 111, 21
+          2, 100, 111, 0
       - name: t2
         columns:
           - id int
@@ -717,9 +723,10 @@ cases:
         - mv int
         - mi int
         - l1 int
-      order: mv
+      order: id
       data: |
         1, 2, 200, 21, 200
+        2, 2, 21, 0, 21
   - id: 18-4
     desc: |
       when UNION ROWS_RANGE EXCLUDE CURRENT_TIME has the same key with original rows, original rows first then union rows
@@ -735,6 +742,7 @@ cases:
           - idx:g:ts
         data: |
           1, 100, 111, 21
+          2, 100, 111, 5
       - name: t2
         columns:
           - id int
@@ -767,6 +775,7 @@ cases:
       order: mv
       data: |
         1, 2, 233, 21, 233
+        2, 2, 233, 5,  233
 
   - id: 18-5
     desc: |
@@ -782,6 +791,7 @@ cases:
           - idx:g:ts
         data: |
           1, 100, 111, 21
+          2, 100, 111, 10000
       - name: t2
         columns:
           - id int
@@ -816,3 +826,5 @@ cases:
       order: mv
       data: |
         1, 3, 999, 21, 233
+        2, 3, 10000, 233, 233
+

--- a/cases/function/window/test_window_union.yaml
+++ b/cases/function/window/test_window_union.yaml
@@ -574,3 +574,245 @@ cases:
         - [1,"aa",20,30]
         - [4,"dd",20,96]
         - [5,"ee",21,34]
+
+  # test correctness for window union when there are rows in union rows and original rows whose key is the same
+  # - 18-1 & 18-2 test simple case for UNION ROWS_RANGE and UNION ROWS
+  # - 18-3 test test UNION ROWS_RANGE with MAXSIZE
+  # - 18-4 & 18-5 test EXCLUDE CURRENT_TIME for UNION ROWS_RANGE/ROWS
+  - id: 18-1
+    desc: |
+      when UNION ROWS_RANGE has the same key with original rows, original rows first then union rows
+    inputs:
+      - name: t1
+        columns:
+          - id int
+          - ts timestamp
+          - g int
+          - val int
+        indexs:
+          - idx:g:ts
+        data: |
+          1, 100, 111, 21
+      - name: t2
+        columns:
+          - id int
+          - ts timestamp
+          - g int
+          - val int
+        indexs:
+          - idx:g:ts
+        data: |
+          1,  99, 111, 233
+          1, 100, 111, 200
+          1, 101, 111, 17
+    sql: |
+       select
+          id, count(val) over w as cnt,
+          max(val) over w as mv,
+          min(val) over w as mi,
+          lag(val, 1) over w as l1
+       from (select * from t1) window w as(
+          union (select * from t2)
+          partition by `g` order by `ts`
+          rows_range between 1s preceding and 0s preceding);
+    expect:
+      columns:
+        - id int
+        - cnt int64
+        - mv int
+        - mi int
+        - l1 int
+      order: mv
+      data: |
+        1, 3, 233, 21, 200
+  - id: 18-2
+    desc: |
+      when UNION ROWS has the same key with original rows, original rows first then union rows,
+      union rows filtered out first for max window size limitation
+    inputs:
+      - name: t1
+        columns:
+          - id int
+          - ts timestamp
+          - g int
+          - val int
+        indexs:
+          - idx:g:ts
+        data: |
+          1, 100, 111, 21
+      - name: t2
+        columns:
+          - id int
+          - ts timestamp
+          - g int
+          - val int
+        indexs:
+          - idx:g:ts
+        data: |
+          1,  88, 111, 999
+          1,  99, 111, 233
+          1, 100, 111, 200
+          1, 101, 111, 17
+    sql: |
+       select
+          id, count(val) over w as cnt,
+          max(val) over w as mv,
+          min(val) over w as mi,
+          lag(val, 1) over w as l1
+       from (select * from t1) window w as(
+          union (select * from t2)
+          partition by `g` order by `ts`
+          ROWS BETWEEN 2 preceding and 0 preceding);
+    expect:
+      columns:
+        - id int
+        - cnt int64
+        - mv int
+        - mi int
+        - l1 int
+      order: mv
+      data: |
+        1, 3, 233, 21, 200
+  - id: 18-3
+    desc: |
+      when UNION ROWS_RANGE MAXSIZE has the same key with original rows, original rows first then union rows
+      union rows filtered out for max window size first
+    inputs:
+      - name: t1
+        columns:
+          - id int
+          - ts timestamp
+          - g int
+          - val int
+        indexs:
+          - idx:g:ts
+        data: |
+          1, 100, 111, 21
+      - name: t2
+        columns:
+          - id int
+          - ts timestamp
+          - g int
+          - val int
+        indexs:
+          - idx:g:ts
+        data: |
+          1,  99, 111, 233
+          1, 100, 111, 200
+          1, 101, 111, 17
+    sql: |
+       select
+          id, count(val) over w as cnt,
+          max(val) over w as mv,
+          min(val) over w as mi,
+          lag(val, 1) over w as l1
+       from (select * from t1) window w as(
+          union (select * from t2)
+          partition by `g` order by `ts`
+          rows_range between 1s preceding and 0s preceding MAXSIZE 2);
+    expect:
+      columns:
+        - id int
+        - cnt int64
+        - mv int
+        - mi int
+        - l1 int
+      order: mv
+      data: |
+        1, 2, 200, 21, 200
+  - id: 18-4
+    desc: |
+      when UNION ROWS_RANGE EXCLUDE CURRENT_TIME has the same key with original rows, original rows first then union rows
+      other rows except current row filtered out by EXCLUDE CURRENT_TIME
+    inputs:
+      - name: t1
+        columns:
+          - id int
+          - ts timestamp
+          - g int
+          - val int
+        indexs:
+          - idx:g:ts
+        data: |
+          1, 100, 111, 21
+      - name: t2
+        columns:
+          - id int
+          - ts timestamp
+          - g int
+          - val int
+        indexs:
+          - idx:g:ts
+        data: |
+          1,  99, 111, 233
+          1, 100, 111, 200
+          1, 101, 111, 17
+    sql: |
+       select
+          id, count(val) over w as cnt,
+          max(val) over w as mv,
+          min(val) over w as mi,
+          lag(val, 1) over w as l1
+       from (select * from t1) window w as(
+          union (select * from t2)
+          partition by `g` order by `ts`
+          rows_range between 1s preceding and 0s preceding EXCLUDE CURRENT_TIME);
+    expect:
+      columns:
+        - id int
+        - cnt int64
+        - mv int
+        - mi int
+        - l1 int
+      order: mv
+      data: |
+        1, 2, 233, 21, 233
+
+  - id: 18-5
+    desc: |
+      UNION ROWS current time rows filtered out
+    inputs:
+      - name: t1
+        columns:
+          - id int
+          - ts timestamp
+          - g int
+          - val int
+        indexs:
+          - idx:g:ts
+        data: |
+          1, 100, 111, 21
+      - name: t2
+        columns:
+          - id int
+          - ts timestamp
+          - g int
+          - val int
+        indexs:
+          - idx:g:ts
+        data: |
+          1,  87, 111, 300
+          1,  88, 111, 999
+          1,  99, 111, 233
+          1, 100, 111, 200
+          1, 101, 111, 17
+    sql: |
+       select
+          id, count(val) over w as cnt,
+          max(val) over w as mv,
+          min(val) over w as mi,
+          lag(val, 1) over w as l1
+       from (select * from t1) window w as(
+          union (select * from t2)
+          partition by `g` order by `ts`
+          ROWS BETWEEN 2 preceding and 0 preceding EXCLUDE CURRENT_TIME);
+    expect:
+      columns:
+        - id int
+        - cnt int64
+        - mv int
+        - mi int
+        - l1 int
+      order: mv
+      data: |
+        1, 3, 999, 21, 233

--- a/hybridse/examples/toydb/src/cmd/toydb_run_engine.cc
+++ b/hybridse/examples/toydb/src/cmd/toydb_run_engine.cc
@@ -27,7 +27,7 @@ DEFINE_bool(
 DEFINE_bool(enable_expr_opt, true,
             "Specify whether do expression optimization");
 DEFINE_int32(run_iters, 0, "Measure the approximate run time if specified");
-DEFINE_int32(case_id, -1, "Specify the case id to run and skip others");
+DEFINE_string(case_id, "", "Specify the case id to run and skip others");
 
 // jit options
 DEFINE_bool(enable_mcjit, false, "Use llvm legacy mcjit engine");
@@ -76,8 +76,7 @@ int RunSingle(const std::string& yaml_path) {
     jit_options.SetEnablePerf(FLAGS_enable_perf);
 
     for (auto& sql_case : cases) {
-        if (FLAGS_case_id >= 0 &&
-            std::to_string(FLAGS_case_id) != sql_case.id()) {
+        if (!FLAGS_case_id.empty() && FLAGS_case_id != sql_case.id()) {
             continue;
         }
         EngineMode mode;

--- a/hybridse/src/vm/runner.cc
+++ b/hybridse/src/vm/runner.cc
@@ -1544,8 +1544,7 @@ void WindowAggRunner::RunWindowAggOnKey(
             min_union_pos = IteratorStatus::FindLastIteratorWithMininumKey(union_segment_status);
         }
         if (windows_join_gen_.Valid()) {
-            Row row = instance_row;
-            row = windows_join_gen_.Join(instance_row, join_right_tables, parameter);
+            Row row = windows_join_gen_.Join(instance_row, join_right_tables, parameter);
             output_table->AddRow(window_project_gen_.Gen(instance_segment_iter->GetKey(), row, parameter, true,
                                                          append_slices_, &window));
         } else {

--- a/hybridse/src/vm/runner.cc
+++ b/hybridse/src/vm/runner.cc
@@ -1441,14 +1441,13 @@ std::shared_ptr<DataHandler> WindowAggRunner::Run(
     instance_partition_iter->SeekToFirst();
 
     // Partition Union Table
-    auto union_inpus = windows_union_gen_.RunInputs(ctx);
-    auto union_partitions = windows_union_gen_.PartitionEach(union_inpus, parameter);
+    auto union_inputs = windows_union_gen_.RunInputs(ctx);
+    auto union_partitions = windows_union_gen_.PartitionEach(union_inputs, parameter);
     // Prepare Join Tables
     auto join_right_tables = windows_join_gen_.RunInputs(ctx);
 
     // Compute output
-    std::shared_ptr<MemTableHandler> output_table =
-        std::shared_ptr<MemTableHandler>(new MemTableHandler());
+    std::shared_ptr<MemTableHandler> output_table = std::make_shared<MemTableHandler>();
     while (instance_partition_iter->Valid()) {
         auto key = instance_partition_iter->GetKey().ToString();
         RunWindowAggOnKey(parameter, instance_partition, union_partitions,
@@ -1847,8 +1846,7 @@ std::shared_ptr<TableHandler> SortGenerator::Sort(
         is_asc == (table->GetOrderType() == kAscOrder)) {
         return table;
     }
-    auto output_table = std::shared_ptr<MemTimeTableHandler>(
-        new MemTimeTableHandler(table->GetSchema()));
+    auto output_table = std::make_shared<MemTimeTableHandler>(table->GetSchema());
     output_table->SetOrderType(table->GetOrderType());
     auto iter = std::dynamic_pointer_cast<TableHandler>(table)->GetIterator();
     if (!iter) {

--- a/hybridse/src/vm/runner.cc
+++ b/hybridse/src/vm/runner.cc
@@ -1527,7 +1527,7 @@ void WindowAggRunner::RunWindowAggOnKey(
         const Row& instance_row = instance_segment_iter->GetValue();
         uint64_t instance_order = instance_segment_iter->GetKey();
         while (min_union_pos >= 0 &&
-               union_segment_status[min_union_pos].key_ < instance_order) {
+               union_segment_status[min_union_pos].key_ <= instance_order) {
             Row row = union_segment_iters[min_union_pos]->GetValue();
             if (windows_join_gen_.Valid()) {
                 row = windows_join_gen_.Join(row, join_right_tables, parameter);

--- a/hybridse/src/vm/runner.cc
+++ b/hybridse/src/vm/runner.cc
@@ -3873,7 +3873,7 @@ int32_t IteratorStatus::FindFirstIteratorWithMaximizeKey(const std::vector<Itera
         if (status_list.at(i).is_valid_) {
             auto key = status_list.at(i).key_;
             if (!min_union_order.has_value() || key > min_union_order.value()) {
-                min_union_order = key;
+                min_union_order.emplace(key);
                 min_union_pos = static_cast<int32_t>(i);
             }
         }

--- a/hybridse/src/vm/runner.h
+++ b/hybridse/src/vm/runner.h
@@ -573,14 +573,17 @@ class IteratorStatus {
     explicit IteratorStatus(uint64_t key) : is_valid_(true), key_(key) {}
     virtual ~IteratorStatus() {}
 
-    static int32_t PickIteratorWithMininumKey(
-        std::vector<IteratorStatus>* status_list_ptr);
-
-    /// \brief find the iterators whose iterator key are the maximum of all iterators given
+    /// \brief find the vaild iterators whose iterator key are the minium of all iterators given
     ///
-    /// \param status_list_ptr: a list of iterators
+    /// \param status_list: a list of iterators
+    /// \return index of last found iterators, -1 if not found
+    static int32_t FindLastIteratorWithMininumKey(const std::vector<IteratorStatus>& status_list);
+
+    /// \brief find the vaild iterators whose iterator key are the maximum of all iterators given
+    ///
+    /// \param status_list: a list of iterators
     /// \return index of first found iterators, -1 if not found
-    static int32_t FindFirstIteratorWithMaximizeKey(std::vector<IteratorStatus>* status_list_ptr);
+    static int32_t FindFirstIteratorWithMaximizeKey(const std::vector<IteratorStatus>& status_list);
 
     void MarkInValid() {
         is_valid_ = false;

--- a/hybridse/src/vm/runner.h
+++ b/hybridse/src/vm/runner.h
@@ -572,10 +572,16 @@ class IteratorStatus {
     IteratorStatus() : is_valid_(false), key_(0) {}
     explicit IteratorStatus(uint64_t key) : is_valid_(true), key_(key) {}
     virtual ~IteratorStatus() {}
+
     static int32_t PickIteratorWithMininumKey(
         std::vector<IteratorStatus>* status_list_ptr);
-    static int32_t PickIteratorWithMaximizeKey(
-        std::vector<IteratorStatus>* status_list_ptr);
+
+    /// \brief find the iterators whose iterator key are the maximum of all iterators given
+    ///
+    /// \param status_list_ptr: a list of iterators
+    /// \return index of first found iterators, -1 if not found
+    static int32_t FindFirstIteratorWithMaximizeKey(std::vector<IteratorStatus>* status_list_ptr);
+
     void MarkInValid() {
         is_valid_ = false;
         key_ = 0;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

close #1776 


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**

