### PR TITLE
fix: thread-safe for `RequestAggUnionRunner`

### DIFF
--- a/hybridse/src/vm/runner.cc
+++ b/hybridse/src/vm/runner.cc
@@ -2683,38 +2683,36 @@ bool RequestAggUnionRunner::InitAggregator() {
     }
 
     agg_type_ = type_it->second;
-    type::Type agg_col_type;
     if (agg_col_->GetExprType() == node::kExprColumnRef) {
-        agg_col_type = producers_[1]->row_parser()->GetType(agg_col_name_);
+        agg_col_type_ = producers_[1]->row_parser()->GetType(agg_col_name_);
     } else if (agg_col_->GetExprType() == node::kExprAll) {
         if (agg_type_ != kCount) {
             LOG(ERROR) << "only support " << ExprTypeName(agg_col_->GetExprType()) << "on count op";
             return false;
         }
-        agg_col_type = type::Type::kInt64;
+        agg_col_type_ = type::Type::kInt64;
     } else {
         LOG(ERROR) << "non-support aggr expr type " << ExprTypeName(agg_col_->GetExprType());
         return false;
     }
+    return true;
+}
+
+std::unique_ptr<BaseAggregator> RequestAggUnionRunner::CreateAggregator() const {
     switch (agg_type_) {
         case kSum:
-            aggregator_ = MakeOverflowAggregator<SumAggregator>(agg_col_type, *output_schemas_->GetOutputSchema());
-            return true;
+            return MakeOverflowAggregator<SumAggregator>(agg_col_type_, *output_schemas_->GetOutputSchema());
         case kAvg:
-            aggregator_ = std::make_unique<AvgAggregator>(agg_col_type, *output_schemas_->GetOutputSchema());
-            return true;
+            return std::make_unique<AvgAggregator>(agg_col_type_, *output_schemas_->GetOutputSchema());
         case kCount:
-            aggregator_ = std::make_unique<CountAggregator>(agg_col_type, *output_schemas_->GetOutputSchema());
-            return true;
+            return std::make_unique<CountAggregator>(agg_col_type_, *output_schemas_->GetOutputSchema());
         case kMin:
-            aggregator_ = MakeSameTypeAggregator<MinAggregator>(agg_col_type, *output_schemas_->GetOutputSchema());
-            return true;
+            return MakeSameTypeAggregator<MinAggregator>(agg_col_type_, *output_schemas_->GetOutputSchema());
         case kMax:
-            aggregator_ = MakeSameTypeAggregator<MaxAggregator>(agg_col_type, *output_schemas_->GetOutputSchema());
-            return true;
+            return MakeSameTypeAggregator<MaxAggregator>(agg_col_type_, *output_schemas_->GetOutputSchema());
         default:
-            LOG(ERROR) << "RequestAggUnionRunner does not support for op " << func_name;
-            return false;
+            LOG(ERROR) << "RequestAggUnionRunner does not support for op " << func_->GetName();
+            return nullptr;
     }
 }
 
@@ -2795,7 +2793,7 @@ std::shared_ptr<TableHandler> RequestAggUnionRunner::RequestUnionWindow(
     const Row& request,
     std::vector<std::shared_ptr<TableHandler>> union_segments, int64_t ts_gen,
     const WindowRange& window_range, const bool output_request_row,
-    const bool exclude_current_time) {
+    const bool exclude_current_time) const {
     // TOOD(zhanghao): for now, we only support AggUnion with 1 base table and 1 agg table
     size_t unions_cnt = union_segments.size();
     if (unions_cnt != 2) {
@@ -2837,13 +2835,13 @@ std::shared_ptr<TableHandler> RequestAggUnionRunner::RequestUnionWindow(
     }
     int64_t request_key = ts_gen > 0 ? ts_gen : 0;
 
-    auto update_base_aggregator = [row_parser = base_row_parser, this](const Row& row) {
+    auto aggregator = CreateAggregator();
+    auto update_base_aggregator = [aggregator = aggregator.get(), row_parser = base_row_parser, this](const Row& row) {
         if (!agg_col_name_.empty() && row_parser->IsNull(row, agg_col_name_)) {
             return;
         }
 
-        auto type = aggregator_->type();
-        auto aggregator = aggregator_.get();
+        auto type = aggregator->type();
         if (agg_type_ == kCount) {
             dynamic_cast<Aggregator<int64_t>*>(aggregator)->UpdateValue(1);
             return;
@@ -2896,14 +2894,14 @@ std::shared_ptr<TableHandler> RequestAggUnionRunner::RequestUnionWindow(
         }
     };
 
-    auto update_agg_aggregator = [row_parser = agg_row_parser, this](const Row& row) {
+    auto update_agg_aggregator = [aggregator = aggregator.get(), row_parser = agg_row_parser, this](const Row& row) {
         if (row_parser->IsNull(row, "agg_val")) {
             return;
         }
 
         std::string agg_val;
         row_parser->GetString(row, "agg_val", &agg_val);
-        aggregator_->Update(agg_val);
+        aggregator->Update(agg_val);
     };
 
     int64_t cnt = 0;
@@ -2922,7 +2920,7 @@ std::shared_ptr<TableHandler> RequestAggUnionRunner::RequestUnionWindow(
     auto base_it = union_segments[0]->GetIterator();
     if (!base_it) {
         LOG(WARNING) << "Base window is empty.";
-        window_table->AddRow(start, aggregator_->Output());
+        window_table->AddRow(start, aggregator->Output());
         DLOG(INFO) << "REQUEST AGG UNION cnt = " << window_table->GetCount();
         return window_table;
     }
@@ -3042,7 +3040,7 @@ std::shared_ptr<TableHandler> RequestAggUnionRunner::RequestUnionWindow(
         }
     }
 
-    window_table->AddRow(start, aggregator_->Output());
+    window_table->AddRow(start, aggregator->Output());
     DLOG(INFO) << "REQUEST AGG UNION cnt = " << window_table->GetCount();
     return window_table;
 }

--- a/hybridse/src/vm/runner.h
+++ b/hybridse/src/vm/runner.h
@@ -1005,7 +1005,7 @@ class RequestAggUnionRunner : public Runner {
         const Row& request,
         std::vector<std::shared_ptr<TableHandler>> union_segments,
         int64_t request_ts, const WindowRange& window_range,
-        const bool output_request_row, const bool exclude_current_time);
+        const bool output_request_row, const bool exclude_current_time) const;
     void AddWindowUnion(const RequestWindowOp& window, Runner* runner) {
         windows_union_gen_.AddWindowUnion(window, runner);
     }
@@ -1019,10 +1019,6 @@ class RequestAggUnionRunner : public Runner {
         kMax
     };
 
-    static inline const std::unordered_map<std::string, AggType> agg_type_map_ = {
-        {"sum", kSum}, {"count", kCount}, {"avg", kAvg}, {"min", kMin}, {"max", kMax},
-    };
-
     RequestWindowUnionGenerator windows_union_gen_;
     RangeGenerator range_gen_;
     bool exclude_current_time_;
@@ -1031,7 +1027,12 @@ class RequestAggUnionRunner : public Runner {
     AggType agg_type_;
     const node::ExprNode* agg_col_ = nullptr;
     std::string agg_col_name_;
-    std::unique_ptr<BaseAggregator> aggregator_ = nullptr;
+    type::Type agg_col_type_;
+
+    std::unique_ptr<BaseAggregator> CreateAggregator() const;
+    static inline const std::unordered_map<std::string, AggType> agg_type_map_ = {
+        {"sum", kSum}, {"count", kCount}, {"avg", kAvg}, {"min", kMin}, {"max", kMax},
+    };
 };
 
 class PostRequestUnionRunner : public Runner {

--- a/src/catalog/tablet_catalog_test.cc
+++ b/src/catalog/tablet_catalog_test.cc
@@ -857,6 +857,74 @@ TEST_F(TabletCatalogTest, long_window_smoke_test) {
     }
 }
 
+TEST_F(TabletCatalogTest, long_window_thread_test) {
+    std::shared_ptr<TabletCatalog> catalog(new TabletCatalog());
+    ASSERT_TRUE(catalog->Init());
+    int num_pk = 2, num_ts = 9, bucket_size = 2;
+
+    TestArgs args = PrepareTable("t1", num_pk, num_ts);
+    ASSERT_TRUE(catalog->AddTable(args.meta[0], args.tables[0]));
+
+    TestArgs args2 = PrepareAggTable("aggr_t1", num_pk, num_ts, bucket_size, 1);
+    ASSERT_TRUE(catalog->AddTable(args2.meta[0], args2.tables[0]));
+
+    ::hybridse::vm::AggrTableInfo info1 = {"aggr_t1", "aggr_db", "db1", "t1",
+                                           "sum", "col2", "col1", "col2", "2"};
+    catalog->RefreshAggrTables({info1});
+
+    ::hybridse::vm::Engine engine(catalog);
+    auto options = std::make_shared<std::unordered_map<std::string, std::string>>();
+    (*options)[::hybridse::vm::LONG_WINDOWS] = "w1";
+    ::hybridse::vm::RequestRunSession session;
+    session.EnableDebug();
+    session.SetOptions(options);
+    ::hybridse::base::Status status;
+    ::hybridse::codec::Row request_row(::hybridse::base::RefCountedSlice::Create(args.row.c_str(), args.row.size()));
+
+    std::string sql =
+        "SELECT col1, sum(col2) OVER w1 FROM t1 "
+        "WINDOW w1 AS (PARTITION BY col1 ORDER BY col2 ROWS_RANGE BETWEEN 2 PRECEDING AND CURRENT ROW);";
+    engine.Get(sql, "db1", session, status);
+    if (status.code != ::hybridse::common::kOk) {
+        std::cout << status.msg << std::endl;
+    }
+    ASSERT_EQ(::hybridse::common::kOk, status.code);
+
+    volatile bool stop = false;
+    auto run_and_check = [&]() {
+        while (!stop) {
+            ::hybridse::codec::RowView rv(session.GetSchema());
+            hybridse::codec::Row output;
+            const char *data = NULL;
+            uint32_t data_size = 0;
+            int64_t val = 0;
+            ASSERT_EQ(0, session.Run(request_row, &output));
+            ASSERT_EQ(2, session.GetSchema().size());
+            rv.Reset(output.buf(), output.size());
+            ASSERT_EQ(0, rv.GetInt64(1, &val));
+            int64_t exp = args.ts * 2 + (args.ts - 1) + (args.ts - 2);
+            ASSERT_EQ(val, exp);
+            ASSERT_EQ(0, rv.GetString(0, &data, &data_size));
+            std::string pk(data, data_size);
+            ASSERT_EQ(args.pk, pk);
+        }
+    };
+
+    int iter = 10;
+    for (int i = 0; i < iter; i++) {
+        std::thread t1(run_and_check);
+        std::thread t2(run_and_check);
+        std::thread t3(run_and_check);
+        std::thread t4(run_and_check);
+        sleep(2);
+        stop = true;
+        t1.join();
+        t2.join();
+        t3.join();
+        t4.join();
+    }
+}
+
 TEST_F(TabletCatalogTest, long_window_equal_test) {
     std::shared_ptr<TabletCatalog> catalog(new TabletCatalog());
     ASSERT_TRUE(catalog->Init());


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
close #1837


* **What is the current behavior?** (You can also link to an open issue here)
Currently `aggregator_` is re-used for every `RequestAggUnionRunner::Run`, which is not thread-safe if the `ClusterJob` is also re-used and run in multiple threads (e.g., stored procedure/deployment request).


* **What is the new behavior (if this is a feature change)?**
`aggregator` is dynamically created for every `Run`
