### PR TITLE
fix: delete inline keywords from the declaration of getrecordbytesize

### DIFF
--- a/src/storage/disk_table.h
+++ b/src/storage/disk_table.h
@@ -420,7 +420,7 @@ class DiskTable : public Table {
     uint64_t GetRecordIdxCnt() override;
     bool GetRecordIdxCnt(uint32_t idx, uint64_t** stat, uint32_t* size) override;
     uint64_t GetRecordPkCnt() override;
-    inline uint64_t GetRecordByteSize() const override { return 0; }
+    uint64_t GetRecordByteSize() const override { return 0; }
     uint64_t GetRecordIdxByteSize() override;
 
     int GetCount(uint32_t index, const std::string& pk, uint64_t& count) override; // NOLINT

--- a/src/storage/mem_table.h
+++ b/src/storage/mem_table.h
@@ -193,7 +193,7 @@ class MemTable : public Table {
     void SetCompressType(::openmldb::type::CompressType compress_type);
     ::openmldb::type::CompressType GetCompressType();
 
-    inline uint64_t GetRecordByteSize() const override { return record_byte_size_.load(std::memory_order_relaxed); }
+    uint64_t GetRecordByteSize() const override { return record_byte_size_.load(std::memory_order_relaxed); }
 
     uint64_t GetRecordCnt() const override { return record_cnt_.load(std::memory_order_relaxed); }
 

--- a/src/storage/table.h
+++ b/src/storage/table.h
@@ -173,7 +173,7 @@ class Table {
     virtual uint64_t GetRecordIdxCnt() = 0;
     virtual bool GetRecordIdxCnt(uint32_t idx, uint64_t** stat, uint32_t* size) = 0;
     virtual uint64_t GetRecordPkCnt() = 0;
-    virtual inline uint64_t GetRecordByteSize() const = 0;
+    virtual uint64_t GetRecordByteSize() const = 0;
     virtual uint64_t GetRecordIdxByteSize() = 0;
 
     virtual int GetCount(uint32_t index, const std::string& pk, uint64_t& count) = 0; // NOLINT


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Fixed #1865 


* **What is the new behavior (if this is a feature change)?**
Delete `inline` keywords from the declaration of `GetRecordByteSize`

