### PR TITLE
fix: core dump in macos running sql_cluster_test

### DIFF
--- a/cases/query/window_with_union_query.yaml
+++ b/cases/query/window_with_union_query.yaml
@@ -174,7 +174,6 @@ cases:
         55,6, 10, 10.5, 55.5, 110, 11, 2, 5, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   - id: 4
     desc: Window SQL WITH UNION 子查询, 样本表PK命中, UNION表PK命中
-    mode: cluster-unsupport
     db: db1
     sql: |
       SELECT col2, col5, sum(col1) OVER w1 as w1_col1_sum, sum(col3) OVER w1 as w1_col3_sum,
@@ -233,7 +232,6 @@ cases:
         55,6, 14, 14.9, 99.9, 165, 15, 3, 5, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   - id: 5
     desc: Window SQL WITH UNION 子查询, 样本表PK命中, UNION表PK命中
-    mode: cluster-unsupport
     db: db1
     sql: |
       SELECT col2, col5, sum(col1) OVER w1 as w1_col1_sum, sum(col3) OVER w1 as w1_col3_sum,

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
 codecov:
   notify:
-    wait_for_ci: no
+    wait_for_ci: yes
+    require_ci_to_pass: no

--- a/hybridse/include/case/sql_case.h
+++ b/hybridse/include/case/sql_case.h
@@ -210,18 +210,9 @@ class SqlCase {
         return false;
     }
     static std::set<std::string> HYBRIDSE_LEVEL();
-    static std::string SqlCaseBaseDir() {
-        const char* env_name = "SQL_CASE_BASE_DIR";
-        char* value = getenv(env_name);
-        if (value != nullptr) {
-            return std::string(value);
-        }
-        value = getenv("YAML_CASE_BASE_DIR");
-        if (value != nullptr) {
-            return std::string(value);
-        }
-        return "";
-    }
+
+    static std::string SqlCaseBaseDir();
+
     static bool IsDebug() {
         const char* env_name = "HYBRIDSE_DEV";
         char* value = getenv(env_name);

--- a/hybridse/src/case/sql_case.cc
+++ b/hybridse/src/case/sql_case.cc
@@ -1619,5 +1619,17 @@ std::set<std::string> SqlCase::HYBRIDSE_LEVEL() {
         return std::set<std::string>({"0"});
     }
 }
+
+std::string SqlCase::SqlCaseBaseDir() {
+    char* value = getenv("SQL_CASE_BASE_DIR");
+    if (value != nullptr) {
+        return std::string(value);
+    }
+    value = getenv("YAML_CASE_BASE_DIR");
+    if (value != nullptr) {
+        return std::string(value);
+    }
+    return "";
+}
 }  // namespace sqlcase
 }  // namespace hybridse

--- a/hybridse/src/vm/runner.cc
+++ b/hybridse/src/vm/runner.cc
@@ -2290,9 +2290,8 @@ void Runner::PrintData(std::ostringstream& oss,
                 break;
             }
             while (iter->Valid() && cnt++ < MAX_DEBUG_LINES_CNT) {
-                t.add("KEY: " + std::string(reinterpret_cast<const char*>(
-                                                iter->GetKey().buf()),
-                                            iter->GetKey().size()));
+                auto key = iter->GetKey();
+                t.add("KEY: " + key.ToString());
                 t.end_of_row();
                 auto segment_iter = iter->GetValue();
                 if (!segment_iter) {

--- a/src/catalog/distribute_iterator.cc
+++ b/src/catalog/distribute_iterator.cc
@@ -179,47 +179,31 @@ void DistributeWindowIterator::Reset() {
     cur_pid_ = INVALID_PID;
 }
 
+// seek to the pos where key = `key` on success
+// or do nothing on fail (preserve old stat)
 void DistributeWindowIterator::Seek(const std::string& key) {
     DLOG(INFO) << "seek to key " << key;
-    Reset();
-    if (!tables_) {
+    const auto& stat = SeekByKey(key);
+    if (stat.pid < 0) {
+        DLOG(INFO) << "no pos found for key " << key;
         return;
     }
-    if (pid_num_ > 0) {
-        cur_pid_ = (uint32_t)(::openmldb::base::hash64(key) % pid_num_);
+
+    if (stat.it != nullptr) {
+        Reset();
+        it_.reset(stat.it);
+    } else if (stat.kv_it != nullptr) {
+        Reset();
+        response_vec_.push_back(stat.kv_it->GetResponse());
+        kv_it_ = stat.kv_it;
+    } else {
+        DLOG(INFO) << "no pos found for key " << key;
+        return;
     }
-    auto iter = tables_->find(cur_pid_);
-    if (iter != tables_->end()) {
-        it_.reset(iter->second->NewWindowIterator(index_));
-        it_->Seek(key);
-        if (it_->Valid()) {
-            return;
-        }
-    }
-    DLOG(INFO) << "seek to key " << key << " from remote. " << " cur_pid " << cur_pid_;
-    auto client_iter = tablet_clients_.find(cur_pid_);
-    if (client_iter != tablet_clients_.end()) {
-        std::string msg;
-        kv_it_ = client_iter->second->Scan(tid_, cur_pid_, key, index_name_, 0, 0,
-                    FLAGS_traverse_cnt_limit, msg);
-        if (kv_it_ && kv_it_->Valid()) {
-            response_vec_.emplace_back(kv_it_->GetResponse());
-            return;
-        }
-    }
-    for (const auto& kv : *tables_) {
-        if (kv.first <= cur_pid_) {
-            continue;
-        }
-        it_.reset(kv.second->NewWindowIterator(index_));
-        it_->SeekToFirst();
-        if (it_->Valid()) {
-            cur_pid_ = kv.first;
-            break;
-        }
-    }
+    cur_pid_ = stat.pid;
 }
 
+// seek to first pos where key exists
 void DistributeWindowIterator::SeekToFirst() {
     DLOG(INFO) << "seek to first";
     Reset();
@@ -251,6 +235,52 @@ void DistributeWindowIterator::SeekToFirst() {
         }
     }
     DLOG(INFO) << "empty window iterator";
+}
+
+DistributeWindowIterator::ItStat DistributeWindowIterator::SeekByKey(const std::string& key) const {
+    if (!tables_ || pid_num_ <= 0) {
+        return {-1, nullptr, {}};
+    }
+
+    uint32_t pid = static_cast<uint32_t>(::openmldb::base::hash64(key) % pid_num_);
+
+    auto iter = tables_->find(pid);
+    if (iter != tables_->end()) {
+        auto it = iter->second->NewWindowIterator(index_);
+        if (it != nullptr) {
+            it->Seek(key);
+            if (it->Valid()) {
+                return {static_cast<int32_t>(pid), it, {}};
+            }
+            delete it;
+        }
+    }
+    DLOG(INFO) << "seek to key " << key << " from remote. "
+               << " cur_pid " << cur_pid_;
+    auto client_iter = tablet_clients_.find(pid);
+    if (client_iter != tablet_clients_.end()) {
+        std::string msg;
+        auto it = client_iter->second->Scan(tid_, pid, key, index_name_, 0, 0, FLAGS_traverse_cnt_limit, msg);
+        if (it != nullptr && it->Valid()) {
+            return {static_cast<int32_t>(pid), {}, it};
+        }
+    }
+
+    // fallback
+    for (const auto& kv : *tables_) {
+        if (kv.first <= cur_pid_) {
+            continue;
+        }
+        auto it = kv.second->NewWindowIterator(index_);
+        if (it != nullptr) {
+            it->SeekToFirst();
+            if (it->Valid()) {
+                return {static_cast<int32_t>(kv.first), it, {}};
+            }
+            delete it;
+        }
+    }
+    return {-1, nullptr, {}};
 }
 
 void DistributeWindowIterator::Next() {

--- a/src/catalog/distribute_iterator.cc
+++ b/src/catalog/distribute_iterator.cc
@@ -255,8 +255,8 @@ DistributeWindowIterator::ItStat DistributeWindowIterator::SeekByKey(const std::
             delete it;
         }
     }
-    DLOG(INFO) << "seek to key " << key << " from remote. "
-               << " cur_pid " << cur_pid_;
+    DLOG(INFO) << "seeking to key " << key << " from remote. "
+               << " cur_pid " << pid;
     auto client_iter = tablet_clients_.find(pid);
     if (client_iter != tablet_clients_.end()) {
         std::string msg;
@@ -268,7 +268,7 @@ DistributeWindowIterator::ItStat DistributeWindowIterator::SeekByKey(const std::
 
     // fallback
     for (const auto& kv : *tables_) {
-        if (kv.first <= cur_pid_) {
+        if (kv.first <= pid) {
             continue;
         }
         auto it = kv.second->NewWindowIterator(index_);

--- a/src/catalog/distribute_iterator.cc
+++ b/src/catalog/distribute_iterator.cc
@@ -267,19 +267,6 @@ DistributeWindowIterator::ItStat DistributeWindowIterator::SeekByKey(const std::
     }
 
     // fallback
-    for (const auto& kv : *tables_) {
-        if (kv.first <= pid) {
-            continue;
-        }
-        auto it = kv.second->NewWindowIterator(index_);
-        if (it != nullptr) {
-            it->SeekToFirst();
-            if (it->Valid()) {
-                return {static_cast<int32_t>(kv.first), it, {}};
-            }
-            delete it;
-        }
-    }
     return {-1, nullptr, {}};
 }
 

--- a/src/catalog/distribute_iterator.cc
+++ b/src/catalog/distribute_iterator.cc
@@ -236,6 +236,7 @@ void DistributeWindowIterator::SeekToFirst() {
                 cur_pid_ = kv.first;
                 return;
             }
+            delete it;
         }
     }
     for (const auto& kv : tablet_clients_) {

--- a/src/catalog/distribute_iterator.h
+++ b/src/catalog/distribute_iterator.h
@@ -145,12 +145,13 @@ class DistributeWindowIterator : public ::hybridse::codec::WindowIterator {
     ItStat SeekByKey(const std::string& key) const;
 
  private:
-    uint32_t tid_;
-    uint32_t pid_num_;
+    const uint32_t tid_;
+    const uint32_t pid_num_;
     std::shared_ptr<Tables> tables_;
     std::map<uint32_t, std::shared_ptr<openmldb::client::TabletClient>> tablet_clients_;
-    uint32_t index_;
-    std::string index_name_;
+    const uint32_t index_;
+    const std::string index_name_;
+
     uint32_t cur_pid_;
     // iterator to locally data
     IT it_;

--- a/src/catalog/distribute_iterator.h
+++ b/src/catalog/distribute_iterator.h
@@ -124,8 +124,25 @@ class DistributeWindowIterator : public ::hybridse::codec::WindowIterator {
     ::hybridse::codec::RowIterator* GetRawValue() override;
     const ::hybridse::codec::Row GetKey() override;
 
+ public:
+    using IT = std::unique_ptr<::hybridse::codec::WindowIterator>;
+    using KV_IT = std::shared_ptr<::openmldb::base::KvIterator>;
+
+    // structure used for iterator result by Seek or SeekToFirst
+    struct ItStat {
+        // if pid < 0, stat is invalid
+        int32_t pid;
+        ::hybridse::codec::WindowIterator* it;
+        KV_IT kv_it;
+
+        ItStat() = delete;
+        ItStat(int32_t p, ::hybridse::codec::WindowIterator* i, KV_IT kv) : pid(p), it(i), kv_it(kv) {}
+    };
+
  private:
     void Reset();
+
+    ItStat SeekByKey(const std::string& key) const;
 
  private:
     uint32_t tid_;
@@ -135,8 +152,11 @@ class DistributeWindowIterator : public ::hybridse::codec::WindowIterator {
     uint32_t index_;
     std::string index_name_;
     uint32_t cur_pid_;
-    std::unique_ptr<::hybridse::codec::WindowIterator> it_;
-    std::shared_ptr<::openmldb::base::KvIterator> kv_it_;
+    // iterator to locally data
+    IT it_;
+    // iterator to remote data, only zero or one of `it_` and `kv_it_` can be non-null
+    KV_IT kv_it_;
+    // underlaying data pointed by `kv_it_`
     std::vector<std::shared_ptr<::google::protobuf::Message>> response_vec_;
 };
 

--- a/src/catalog/distribute_iterator_test.cc
+++ b/src/catalog/distribute_iterator_test.cc
@@ -275,7 +275,7 @@ TEST_F(DistributeIteratorTest, TraverseLimit) {
     std::map<uint32_t, uint32_t> cout_map = {{0, 0}, {1, 0}, {2, 0}, {3, 0}};
     for (int i = 0; i < 100; i++) {
         std::string key = "card" + std::to_string(i);
-        uint32_t pid = (uint32_t)(::openmldb::base::hash64(key)) % 4;
+        uint32_t pid = static_cast<uint32_t>(::openmldb::base::hash64(key)) % 4;
         cout_map[pid]++;
         if (pid % 2 == 0) {
             PutKey(key, (*tables)[pid]);
@@ -317,7 +317,7 @@ TEST_F(DistributeIteratorTest, WindowIterator) {
     std::map<uint32_t, std::shared_ptr<openmldb::client::TabletClient>> tablet_clients = {{1, client1}, {3, client2}};
     for (int i = 0; i < 20; i++) {
         std::string key = "card" + std::to_string(i);
-        uint32_t pid = (uint32_t)(::openmldb::base::hash64(key)) % 4;
+        uint32_t pid = static_cast<uint32_t>(::openmldb::base::hash64(key)) % 4;
         if (pid % 2 == 0) {
             PutKey(key, (*tables)[pid]);
         } else {

--- a/src/sdk/sql_sdk_test.h
+++ b/src/sdk/sql_sdk_test.h
@@ -46,6 +46,8 @@ INSTANTIATE_TEST_SUITE_P(SQLSDKTestConstsSelect, SQLSDKQueryTest,
                          testing::ValuesIn(SQLSDKQueryTest::InitCases("/cases/query/const_query.yaml")));
 INSTANTIATE_TEST_SUITE_P(SQLSDKHavingQuery, SQLSDKQueryTest,
                          testing::ValuesIn(SQLSDKQueryTest::InitCases("/cases/query/having_query.yaml")));
+INSTANTIATE_TEST_SUITE_P(SQLSDKLastJoinQuery, SQLSDKQueryTest,
+                         testing::ValuesIn(SQLSDKQueryTest::InitCases("/cases/query/last_join_query.yaml")));
 INSTANTIATE_TEST_SUITE_P(SQLSDKLastJoinWindowQuery, SQLSDKQueryTest,
                          testing::ValuesIn(SQLSDKQueryTest::InitCases("/cases/query/last_join_window_query.yaml")));
 INSTANTIATE_TEST_SUITE_P(SQLSDKParameterizedQuery, SQLSDKQueryTest,

--- a/src/sdk/sql_sdk_test.h
+++ b/src/sdk/sql_sdk_test.h
@@ -149,6 +149,9 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     SQLSDKTestWindowUnion, SQLSDKQueryTest,
     testing::ValuesIn(SQLSDKQueryTest::InitCases("/cases/function/window/test_window_union.yaml")));
+INSTANTIATE_TEST_SUITE_P(
+    WindowUnion, SQLSDKQueryTest,
+    testing::ValuesIn(SQLSDKQueryTest::InitCases("/cases/query/window_with_union_query.yaml")));
 
 
 


### PR DESCRIPTION
1. fix a `sql_cluster_test` core in darwin: when there is no partition data for a table locally, the `DistributeWindowIterator::SeekToFirst` set `it_` still. This cores the program when user want to `DistributeWindowIterator::GetKey()` because `it_` is not null, so it try to get key data from `it_`
2. enable more last join and window union test for cluster/request mode
3. update codecov.yml
4. improve `toydb_run_engine` bootstrapping