### PR TITLE
feat: support zk log options & flags fix

### DIFF
--- a/src/cmd/openmldb.cc
+++ b/src/cmd/openmldb.cc
@@ -3957,6 +3957,7 @@ void StartAPIServer() {
         ::openmldb::sdk::ClusterOptions cluster_options;
         cluster_options.zk_cluster = FLAGS_zk_cluster;
         cluster_options.zk_path = FLAGS_zk_root_path;
+        cluster_options.session_timeout = FLAGS_zk_session_timeout;
         if (!api_service->Init(cluster_options)) {
             PDLOG(WARNING, "Fail to init");
             exit(1);

--- a/src/cmd/openmldb.cc
+++ b/src/cmd/openmldb.cc
@@ -29,8 +29,8 @@
 #include "base/glog_wapper.h"
 #include "base/hash.h"
 #include "base/ip.h"
-#include "base/linenoise.h"
 #include "base/kv_iterator.h"
+#include "base/linenoise.h"
 #include "base/server_name.h"
 #include "base/strings.h"
 #if defined(__linux__) || defined(__mac_tablet__)
@@ -325,7 +325,7 @@ int PutData(uint32_t tid, const std::map<uint32_t, std::vector<std::pair<std::st
 }
 
 ::openmldb::base::Status PutSchemaData(const ::openmldb::nameserver::TableInfo& table_info, uint64_t ts,
-                                          const std::vector<std::string>& input_value) {
+                                       const std::vector<std::string>& input_value) {
     std::string value;
     ::openmldb::codec::SDKCodec codec(table_info);
     std::map<uint32_t, ::openmldb::codec::Dimension> dimensions;
@@ -2192,7 +2192,7 @@ int GenTableInfo(const std::string& path,
     if (table_info.has_key_entry_max_height()) {
         if (table_info.key_entry_max_height() > FLAGS_skiplist_max_height) {
             printf("Fail to create table. key_entry_max_height %u is greater than the max heght %u\n",
-                table_info.key_entry_max_height(), FLAGS_skiplist_max_height);
+                   table_info.key_entry_max_height(), FLAGS_skiplist_max_height);
             return -1;
         }
         if (table_info.key_entry_max_height() == 0) {
@@ -3943,7 +3943,7 @@ void StartAPIServer() {
         }
         int32_t port = 0;
         try {
-             port = boost::lexical_cast<uint32_t>(vec[1]);
+            port = boost::lexical_cast<uint32_t>(vec[1]);
         } catch (std::exception const& e) {
             PDLOG(WARNING, "Invalid nameserver format");
             exit(1);

--- a/src/cmd/sql_cmd.h
+++ b/src/cmd/sql_cmd.h
@@ -37,14 +37,18 @@
 #include "version.h"  // NOLINT
 DEFINE_bool(interactive, true, "Set the interactive");
 DEFINE_string(database, "", "Set database");
+DECLARE_string(cmd);
+
+// cluster mode
 DECLARE_string(zk_cluster);
 DECLARE_string(zk_root_path);
 DECLARE_int32(zk_session_timeout);
-DECLARE_string(cmd);
+DECLARE_uint32(zk_log_level); 
+DECLARE_string(zk_log_file);
+
 // stand-alone mode
 DECLARE_string(host);
 DECLARE_int32(port);
-DECLARE_int32(request_timeout_ms);
 
 namespace openmldb::cmd {
 const std::string LOGO =  // NOLINT
@@ -206,6 +210,8 @@ bool InitClusterSDK() {
     copt.zk_cluster = FLAGS_zk_cluster;
     copt.zk_path = FLAGS_zk_root_path;
     copt.session_timeout = FLAGS_zk_session_timeout;
+    copt.zk_log_level = FLAGS_zk_log_level;
+    copt.zk_log_file = FLAGS_zk_log_file;
     cs = new ::openmldb::sdk::ClusterSDK(copt);
     if (!cs->Init()) {
         std::cout << "ERROR: Failed to connect to db" << std::endl;

--- a/src/cmd/sql_cmd.h
+++ b/src/cmd/sql_cmd.h
@@ -29,12 +29,13 @@
 #include "absl/strings/match.h"
 #include "absl/strings/strip.h"
 #include "base/linenoise.h"
-#include "boost/regex.hpp"
 #include "base/texttable.h"
+#include "boost/regex.hpp"
 #include "gflags/gflags.h"
 #include "sdk/db_sdk.h"
 #include "sdk/sql_cluster_router.h"
 #include "version.h"  // NOLINT
+
 DEFINE_bool(interactive, true, "Set the interactive");
 DEFINE_string(database, "", "Set database");
 DECLARE_string(cmd);
@@ -43,7 +44,7 @@ DECLARE_string(cmd);
 DECLARE_string(zk_cluster);
 DECLARE_string(zk_root_path);
 DECLARE_int32(zk_session_timeout);
-DECLARE_uint32(zk_log_level); 
+DECLARE_uint32(zk_log_level);
 DECLARE_string(zk_log_file);
 
 // stand-alone mode

--- a/src/cmd/sql_cmd.h
+++ b/src/cmd/sql_cmd.h
@@ -39,6 +39,7 @@ DEFINE_bool(interactive, true, "Set the interactive");
 DEFINE_string(database, "", "Set database");
 DECLARE_string(zk_cluster);
 DECLARE_string(zk_root_path);
+DECLARE_int32(zk_session_timeout);
 DECLARE_string(cmd);
 // stand-alone mode
 DECLARE_string(host);
@@ -204,6 +205,7 @@ bool InitClusterSDK() {
     ::openmldb::sdk::ClusterOptions copt;
     copt.zk_cluster = FLAGS_zk_cluster;
     copt.zk_path = FLAGS_zk_root_path;
+    copt.session_timeout = FLAGS_zk_session_timeout;
     cs = new ::openmldb::sdk::ClusterSDK(copt);
     if (!cs->Init()) {
         std::cout << "ERROR: Failed to connect to db" << std::endl;

--- a/src/flags.cc
+++ b/src/flags.cc
@@ -18,7 +18,7 @@
 // cluster config
 DEFINE_string(endpoint, "", "ip:port, config the ip and port that openmldb serves for");
 DEFINE_string(openmldb_log_dir, "./logs", "config the log dir");
-DEFINE_int32(zk_session_timeout, 2000, "config the zk session timeout of client, tablet or nameserver");
+DEFINE_int32(zk_session_timeout, 2000, "config the zk session timeout of cli, apiserver, tablet or nameserver");
 DEFINE_uint32(tablet_heartbeat_timeout, 5 * 60 * 1000, "config the heartbeat of tablet offline");
 DEFINE_uint32(tablet_offline_check_interval, 1000, "config the check interval of tablet offline");
 DEFINE_string(zk_cluster, "", "config the zookeeper cluster eg ip:2181,ip2:2181,ip3:2181");
@@ -26,8 +26,8 @@ DEFINE_string(zk_root_path, "/openmldb", "config the root path of zookeeper");
 DEFINE_string(tablet, "", "config the endpoint of tablet");
 DEFINE_string(nameserver, "", "config the endpoint of nameserver");
 DEFINE_int32(zk_keep_alive_check_interval, 15000, "config the interval of keep alive check");
-DEFINE_uint32(zk_log_level, 1, "set level integer: ZOO_LOG_LEVEL_ERROR=1,ZOO_LOG_LEVEL_WARN=2,ZOO_LOG_LEVEL_INFO=3,ZOO_LOG_LEVEL_DEBUG=4");
-DEFINE_string(zk_log_stream, "", "set zk log file, empty means no log output");
+DEFINE_uint32(zk_log_level, 0, "CLI: set level integer, DISABLE_LOGGING=0, ZOO_LOG_LEVEL_ERROR=1,ZOO_LOG_LEVEL_WARN=2,ZOO_LOG_LEVEL_INFO=3,ZOO_LOG_LEVEL_DEBUG=4");
+DEFINE_string(zk_log_file, "", "CLI: set zk log file, empty means stderr(default in zk)");
 DEFINE_string(host, "", "used in stand-alone mode, config the name server ip");
 DEFINE_int32(port, 0, "used in stand-alone mode, config the name server port");
 DEFINE_int32(get_task_status_interval, 2000, "config the interval of get task status");

--- a/src/flags.cc
+++ b/src/flags.cc
@@ -26,7 +26,9 @@ DEFINE_string(zk_root_path, "/openmldb", "config the root path of zookeeper");
 DEFINE_string(tablet, "", "config the endpoint of tablet");
 DEFINE_string(nameserver, "", "config the endpoint of nameserver");
 DEFINE_int32(zk_keep_alive_check_interval, 15000, "config the interval of keep alive check");
-DEFINE_uint32(zk_log_level, 0, "CLI: set level integer, DISABLE_LOGGING=0, ZOO_LOG_LEVEL_ERROR=1,ZOO_LOG_LEVEL_WARN=2,ZOO_LOG_LEVEL_INFO=3,ZOO_LOG_LEVEL_DEBUG=4");
+DEFINE_uint32(zk_log_level, 0,
+              "CLI: set level integer, DISABLE_LOGGING=0, "
+              "ZOO_LOG_LEVEL_ERROR=1,ZOO_LOG_LEVEL_WARN=2,ZOO_LOG_LEVEL_INFO=3,ZOO_LOG_LEVEL_DEBUG=4");
 DEFINE_string(zk_log_file, "", "CLI: set zk log file, empty means stderr(default in zk)");
 DEFINE_string(host, "", "used in stand-alone mode, config the name server ip");
 DEFINE_int32(port, 0, "used in stand-alone mode, config the name server port");
@@ -43,8 +45,7 @@ DEFINE_uint32(name_server_op_execute_timeout, 2 * 60 * 60 * 1000, "config the ti
 DEFINE_bool(auto_failover, false, "enable or disable auto failover");
 DEFINE_int32(max_op_num, 10000, "config the max op num");
 DEFINE_uint32(partition_num, 8, "config the default partition_num");
-DEFINE_uint32(replica_num, 3,
-              "config the default replica_num. if set 3, there is one leader and two followers");
+DEFINE_uint32(replica_num, 3, "config the default replica_num. if set 3, there is one leader and two followers");
 DEFINE_uint32(system_table_replica_num, 1, "config the default replica_num of system table.");
 DEFINE_int32(gc_interval, 120, "the gc interval of tablet every two hour");
 DEFINE_int32(disk_gc_interval, 120, "the rocksdb gc interval of tablet");

--- a/src/flags.cc
+++ b/src/flags.cc
@@ -26,6 +26,8 @@ DEFINE_string(zk_root_path, "/openmldb", "config the root path of zookeeper");
 DEFINE_string(tablet, "", "config the endpoint of tablet");
 DEFINE_string(nameserver, "", "config the endpoint of nameserver");
 DEFINE_int32(zk_keep_alive_check_interval, 15000, "config the interval of keep alive check");
+DEFINE_uint32(zk_log_level, 1, "set level integer: ZOO_LOG_LEVEL_ERROR=1,ZOO_LOG_LEVEL_WARN=2,ZOO_LOG_LEVEL_INFO=3,ZOO_LOG_LEVEL_DEBUG=4");
+DEFINE_string(zk_log_stream, "", "set zk log file, empty means no log output");
 DEFINE_string(host, "", "used in stand-alone mode, config the name server ip");
 DEFINE_int32(port, 0, "used in stand-alone mode, config the name server port");
 DEFINE_int32(get_task_status_interval, 2000, "config the interval of get task status");

--- a/src/flags.cc
+++ b/src/flags.cc
@@ -18,7 +18,7 @@
 // cluster config
 DEFINE_string(endpoint, "", "ip:port, config the ip and port that openmldb serves for");
 DEFINE_string(openmldb_log_dir, "./logs", "config the log dir");
-DEFINE_int32(zk_session_timeout, 2000, "config the session timeout of tablet or nameserver");
+DEFINE_int32(zk_session_timeout, 2000, "config the zk session timeout of client, tablet or nameserver");
 DEFINE_uint32(tablet_heartbeat_timeout, 5 * 60 * 1000, "config the heartbeat of tablet offline");
 DEFINE_uint32(tablet_offline_check_interval, 1000, "config the check interval of tablet offline");
 DEFINE_string(zk_cluster, "", "config the zookeeper cluster eg ip:2181,ip2:2181,ip3:2181");

--- a/src/sdk/db_sdk.cc
+++ b/src/sdk/db_sdk.cc
@@ -203,14 +203,13 @@ void ClusterSDK::CheckZk() {
 
 bool ClusterSDK::Init() {
     zk_client_ = new ::openmldb::zk::ZkClient(options_.zk_cluster, "", options_.session_timeout, "", options_.zk_path);
-    bool ok = zk_client_->Init();
+    
+    bool ok = zk_client_->Init(options_.zk_log_level, options_.zk_log_file);
     if (!ok) {
-        LOG(WARNING) << "fail to init zk client with zk cluster " << options_.zk_cluster << " , zk path "
-                     << options_.zk_path << " and session timeout " << options_.session_timeout;
+        LOG(WARNING) << "fail to init zk client with " << options_.to_string();
         return false;
     }
-    LOG(INFO) << "init zk client with zk cluster " << options_.zk_cluster << " , zk path " << options_.zk_path
-              << ",session timeout " << options_.session_timeout << " and session id " << zk_client_->GetSessionTerm();
+    LOG(INFO) << "init zk client with " << options_.to_string() << " and session id " << zk_client_->GetSessionTerm();
 
     ::hybridse::vm::EngineOptions eopt;
     eopt.SetCompileOnly(true);

--- a/src/sdk/db_sdk.cc
+++ b/src/sdk/db_sdk.cc
@@ -203,7 +203,7 @@ void ClusterSDK::CheckZk() {
 
 bool ClusterSDK::Init() {
     zk_client_ = new ::openmldb::zk::ZkClient(options_.zk_cluster, "", options_.session_timeout, "", options_.zk_path);
-    
+
     bool ok = zk_client_->Init(options_.zk_log_level, options_.zk_log_file);
     if (!ok) {
         LOG(WARNING) << "fail to init zk client with " << options_.to_string();
@@ -231,12 +231,10 @@ void ClusterSDK::WatchNotify() {
     zk_client_->CancelWatchItem(notify_path_);
     zk_client_->WatchItem(notify_path_, [this] { Refresh(); });
     zk_client_->WatchChildren(options_.zk_path + "/data/function",
-            std::bind(&ClusterSDK::RefreshExternalFun, this, std::placeholders::_1));
+                              std::bind(&ClusterSDK::RefreshExternalFun, this, std::placeholders::_1));
 }
 
-void ClusterSDK::RefreshExternalFun(const std::vector<std::string>& funs) {
-    InitExternalFun();
-}
+void ClusterSDK::RefreshExternalFun(const std::vector<std::string>& funs) { InitExternalFun(); }
 
 bool ClusterSDK::TriggerNotify(::openmldb::type::NotifyType type) const {
     if (type == ::openmldb::type::NotifyType::kTable) {

--- a/src/sdk/db_sdk.h
+++ b/src/sdk/db_sdk.h
@@ -41,6 +41,16 @@ struct ClusterOptions {
     std::string zk_cluster;
     std::string zk_path;
     int32_t session_timeout = 2000;
+    int32_t zk_log_level = 3;
+    std::string zk_log_file;
+    std::string to_string(){
+       std::stringstream ss;
+       ss << "zk options [cluster:"<< zk_cluster <<", path:" << zk_path 
+       <<", session_timeout:" << session_timeout 
+       <<", log_level:" << zk_log_level << ", log_file:" << zk_log_file
+       <<"]";
+       return ss.str();
+    }
 };
 
 class DBSDK {

--- a/src/sdk/db_sdk.h
+++ b/src/sdk/db_sdk.h
@@ -43,13 +43,11 @@ struct ClusterOptions {
     int32_t session_timeout = 2000;
     int32_t zk_log_level = 3;
     std::string zk_log_file;
-    std::string to_string(){
-       std::stringstream ss;
-       ss << "zk options [cluster:"<< zk_cluster <<", path:" << zk_path 
-       <<", session_timeout:" << session_timeout 
-       <<", log_level:" << zk_log_level << ", log_file:" << zk_log_file
-       <<"]";
-       return ss.str();
+    std::string to_string() {
+        std::stringstream ss;
+        ss << "zk options [cluster:" << zk_cluster << ", path:" << zk_path << ", session_timeout:" << session_timeout
+           << ", log_level:" << zk_log_level << ", log_file:" << zk_log_file << "]";
+        return ss.str();
     }
 };
 

--- a/src/zk/zk_client.cc
+++ b/src/zk/zk_client.cc
@@ -19,11 +19,11 @@
 #include <algorithm>
 #include <utility>
 
+#include "absl/cleanup/cleanup.h"
 #include "base/glog_wapper.h"
 #include "base/strings.h"
 #include "boost/algorithm/string.hpp"
 #include "boost/lexical_cast.hpp"
-#include "absl/cleanup/cleanup.h"
 #include "gflags/gflags.h"
 
 namespace openmldb {
@@ -113,7 +113,7 @@ ZkClient::~ZkClient() {
     if (zk_) {
         zookeeper_close(zk_);
     }
-    if(zk_log_stream_file_){
+    if (zk_log_stream_file_) {
         fclose(zk_log_stream_file_);
     }
 }
@@ -121,9 +121,9 @@ ZkClient::~ZkClient() {
 bool ZkClient::Init(int log_level, const std::string& log_file) {
     std::unique_lock<std::mutex> lock(mu_);
     zoo_set_debug_level(ZooLogLevel(log_level));
-    if(!log_file.empty()){
+    if (!log_file.empty()) {
         zk_log_stream_file_ = fopen(log_file.c_str(), "w");
-        zoo_set_log_stream(zk_log_stream_file_);    
+        zoo_set_log_stream(zk_log_stream_file_);
     }
 
     zk_ = zookeeper_init(hosts_.c_str(), LogEventWrapper, session_timeout_, 0, (void*)this, 0);  // NOLINT
@@ -506,9 +506,7 @@ bool ZkClient::GetChildrenUnLocked(const std::string& path, std::vector<std::str
     struct String_vector data;
     data.count = 0;
     data.data = NULL;
-    absl::Cleanup data_deallocator = [&data] {
-        deallocate_String_vector(&data);
-    };
+    absl::Cleanup data_deallocator = [&data] { deallocate_String_vector(&data); };
     int ret = zoo_get_children(zk_, path.c_str(), 0, &data);
     if (ret != ZOK) {
         PDLOG(WARNING, "fail to get children from path %s with errno %d", path.c_str(), ret);
@@ -534,9 +532,7 @@ bool ZkClient::GetNodes(std::vector<std::string>& endpoints) {
     struct String_vector data;
     data.count = 0;
     data.data = NULL;
-    absl::Cleanup data_deallocator = [&data] {
-        deallocate_String_vector(&data);
-    };
+    absl::Cleanup data_deallocator = [&data] { deallocate_String_vector(&data); };
     int ret = zoo_get_children(zk_, nodes_root_path_.c_str(), 0, &data);
     if (ret != ZOK) {
         PDLOG(WARNING, "fail to get children from path %s with errno %d", nodes_root_path_.c_str(), ret);

--- a/src/zk/zk_client.cc
+++ b/src/zk/zk_client.cc
@@ -26,9 +26,6 @@
 #include "absl/cleanup/cleanup.h"
 #include "gflags/gflags.h"
 
-DECLARE_uint32(zk_log_level);
-DECLARE_string(zk_log_stream);
-
 namespace openmldb {
 namespace zk {
 
@@ -121,16 +118,13 @@ ZkClient::~ZkClient() {
     }
 }
 
-bool ZkClient::Init() {
+bool ZkClient::Init(int log_level, const std::string& log_file) {
     std::unique_lock<std::mutex> lock(mu_);
-    zoo_set_debug_level(ZooLogLevel(FLAGS_zk_log_level));
-
-    if(!FLAGS_zk_log_stream.empty()){
-        zk_log_stream_file_ = fopen(FLAGS_zk_log_stream.c_str(), "w");    
-    } else {
-        zk_log_stream_file_ = fopen("/dev/null", "w");
+    zoo_set_debug_level(ZooLogLevel(log_level));
+    if(!log_file.empty()){
+        zk_log_stream_file_ = fopen(log_file.c_str(), "w");
+        zoo_set_log_stream(zk_log_stream_file_);    
     }
-    zoo_set_log_stream(zk_log_stream_file_);
 
     zk_ = zookeeper_init(hosts_.c_str(), LogEventWrapper, session_timeout_, 0, (void*)this, 0);  // NOLINT
     // one second

--- a/src/zk/zk_client.h
+++ b/src/zk/zk_client.h
@@ -19,6 +19,7 @@
 
 #include <atomic>
 #include <condition_variable>  // NOLINT
+#include <cstdio>
 #include <map>
 #include <mutex>  // NOLINT
 #include <string>
@@ -27,7 +28,6 @@
 #include "boost/function.hpp"
 
 extern "C" {
-#include "stdio.h"
 #include "zookeeper/zookeeper.h"
 }
 

--- a/src/zk/zk_client.h
+++ b/src/zk/zk_client.h
@@ -27,6 +27,7 @@
 #include "boost/function.hpp"
 
 extern "C" {
+#include "stdio.h"
 #include "zookeeper/zookeeper.h"
 }
 
@@ -141,6 +142,8 @@ class ZkClient {
     std::string endpoint_;
     std::string zk_root_path_;
     std::string real_endpoint_;
+
+    FILE* zk_log_stream_file_ = NULL;
 
     // internal args
     std::string nodes_root_path_;

--- a/src/zk/zk_client.h
+++ b/src/zk/zk_client.h
@@ -42,7 +42,7 @@ const uint32_t ZK_MAX_BUFFER_SIZE = 1024 * 1024;
 
 class ZkClient {
  public:
-    // hosts , the zookeeper server lists eg host1:2181,host2:2181
+    // hosts, the zookeeper server lists eg host1:2181,host2:2181
     // session_timeout, the session timeout
     // endpoint, the client endpoint
     ZkClient(const std::string& hosts, const std::string& real_endpoint, int32_t session_timeout,
@@ -53,7 +53,10 @@ class ZkClient {
     ~ZkClient();
 
     // init zookeeper connections
-    bool Init();
+    // log level: DISABLE_LOGGING=0, ZOO_LOG_LEVEL_ERROR=1,ZOO_LOG_LEVEL_WARN=2,ZOO_LOG_LEVEL_INFO=3,ZOO_LOG_LEVEL_DEBUG=4
+    // log file: empty means no file, it'll print to stderr
+    // If you want to disable zk log, set level 0, or set the file "/dev/null".
+    bool Init(int log_level = 3, const std::string& log_file = {});
 
     // the client will create a ephemeral node in zk_root_path
     // eg {zk_root_path}/nodes/000000 -> endpoint

--- a/src/zk/zk_client.h
+++ b/src/zk/zk_client.h
@@ -53,9 +53,10 @@ class ZkClient {
     ~ZkClient();
 
     // init zookeeper connections
-    // log level: DISABLE_LOGGING=0, ZOO_LOG_LEVEL_ERROR=1,ZOO_LOG_LEVEL_WARN=2,ZOO_LOG_LEVEL_INFO=3,ZOO_LOG_LEVEL_DEBUG=4
-    // log file: empty means no file, it'll print to stderr
-    // If you want to disable zk log, set level 0, or set the file "/dev/null".
+    // log level: DISABLE_LOGGING=0, ZOO_LOG_LEVEL_ERROR=1, ZOO_LOG_LEVEL_WARN=2, ZOO_LOG_LEVEL_INFO=3,
+    // ZOO_LOG_LEVEL_DEBUG=4
+    // log file: empty means no file, it'll print to stderr If you want to disable zk log, set
+    // level 0, or set the file "/dev/null".
     bool Init(int log_level = 3, const std::string& log_file = {});
 
     // the client will create a ephemeral node in zk_root_path


### PR DESCRIPTION
Closes #1500 
CLI: disable zk log by default(log level 0). use gflags zk_log_level & zk_log_file to modify `ClusterOptions`.
other sdk: use default `ClusterOptions ` now, info level and use stream stderr(default in zk).

make more flag desc.
