### PR TITLE
refactor: mv session_timeout to cluster router options and rename to it

### DIFF
--- a/java/openmldb-jdbc/src/main/java/com/_4paradigm/openmldb/sdk/impl/SqlClusterExecutor.java
+++ b/java/openmldb-jdbc/src/main/java/com/_4paradigm/openmldb/sdk/impl/SqlClusterExecutor.java
@@ -64,7 +64,7 @@ public class SqlClusterExecutor implements SqlExecutor {
 
         if (option.isClusterMode()) {
             SQLRouterOptions sqlOpt = new SQLRouterOptions();
-            sqlOpt.setSession_timeout(option.getSessionTimeout());
+            sqlOpt.setZk_session_timeout(option.getSessionTimeout());
             sqlOpt.setZk_cluster(option.getZkCluster());
             sqlOpt.setZk_path(option.getZkPath());
             sqlOpt.setEnable_debug(option.getEnableDebug());
@@ -73,7 +73,6 @@ public class SqlClusterExecutor implements SqlExecutor {
             sqlOpt.delete();
         } else {
             StandaloneOptions sqlOpt = new StandaloneOptions();
-            sqlOpt.setSession_timeout(option.getSessionTimeout());
             sqlOpt.setEnable_debug(option.getEnableDebug());
             sqlOpt.setRequest_timeout(option.getRequestTimeout());
             sqlOpt.setHost(option.getHost());

--- a/python/openmldb/sdk/sdk.py
+++ b/python/openmldb/sdk/sdk.py
@@ -35,7 +35,7 @@ class OpenMLDBClusterSdkOptions(object):
     def __init__(self, zk_cluster, zk_path, session_timeout=3000):
         self.zk_cluster = zk_cluster
         self.zk_path = zk_path
-        self.session_timeout = session_timeout
+        self.zk_session_timeout = session_timeout
 
 
 class OpenMLDBStandaloneSdkOptions(object):

--- a/src/apiserver/api_server_test.cc
+++ b/src/apiserver/api_server_test.cc
@@ -52,7 +52,7 @@ class APIServerTestEnv : public testing::Environment {
         ASSERT_TRUE(queue_svc->Init(cluster_sdk));
 
         sdk::SQLRouterOptions sql_opt;
-        sql_opt.session_timeout = 30000;
+        sql_opt.zk_session_timeout = 30000;
         sql_opt.zk_cluster = mc->GetZkCluster();
         sql_opt.zk_path = mc->GetZkPath();
         // sql_opt.enable_debug = true;

--- a/src/sdk/sql_cluster_router.cc
+++ b/src/sdk/sql_cluster_router.cc
@@ -222,7 +222,7 @@ bool SQLClusterRouter::Init() {
             ClusterOptions coptions;
             coptions.zk_cluster = options_.zk_cluster;
             coptions.zk_path = options_.zk_path;
-            coptions.zk_session_timeout = options_.session_timeout;
+            coptions.zk_session_timeout = options_.zk_session_timeout;
             cluster_sdk_ = new ClusterSDK(coptions);
             bool ok = cluster_sdk_->Init();
             if (!ok) {

--- a/src/sdk/sql_cluster_test.cc
+++ b/src/sdk/sql_cluster_test.cc
@@ -383,7 +383,7 @@ TEST_F(SQLSDKQueryTest, GetTabletClient) {
         "                index(key=col2, ts=col3)) "
         "options(partitionnum=2);";
     SQLRouterOptions sql_opt;
-    sql_opt.session_timeout = 30000;
+    sql_opt.zk_session_timeout = 30000;
     sql_opt.zk_cluster = mc_->GetZkCluster();
     sql_opt.zk_path = mc_->GetZkPath();
     sql_opt.enable_debug = hybridse::sqlcase::SqlCase::IsDebug();
@@ -677,7 +677,7 @@ static std::shared_ptr<SQLRouter> GetNewSQLRouter() {
     SQLRouterOptions sql_opt;
     sql_opt.zk_cluster = mc_->GetZkCluster();
     sql_opt.zk_path = mc_->GetZkPath();
-    sql_opt.session_timeout = 60000;
+    sql_opt.zk_session_timeout = 60000;
     sql_opt.enable_debug = hybridse::sqlcase::SqlCase::IsDebug();
     auto router = NewClusterSQLRouter(sql_opt);
     SetOnlineMode(router);

--- a/src/sdk/sql_router.h
+++ b/src/sdk/sql_router.h
@@ -38,7 +38,6 @@ namespace sdk {
 
 struct BasicRouterOptions {
     bool enable_debug = false;
-    uint32_t session_timeout = 2000;
     uint32_t max_sql_cache_size = 10;
     uint32_t request_timeout = 60000;
 };
@@ -46,6 +45,7 @@ struct BasicRouterOptions {
 struct SQLRouterOptions : BasicRouterOptions {
     std::string zk_cluster;
     std::string zk_path;
+    uint32_t zk_session_timeout = 2000;
 };
 
 struct StandaloneOptions : BasicRouterOptions {

--- a/src/sdk/sql_router_test.cc
+++ b/src/sdk/sql_router_test.cc
@@ -58,7 +58,7 @@ TEST_F(SQLRouterTest, bad_zk) {
     SQLRouterOptions sql_opt;
     sql_opt.zk_cluster = "127.0.0.1:1111";
     sql_opt.zk_path = "/path";
-    sql_opt.session_timeout = 10;
+    sql_opt.zk_session_timeout = 10;
     auto router = NewClusterSQLRouter(sql_opt);
     ASSERT_TRUE(router == nullptr);
 }

--- a/src/sdk/sql_sdk_test.cc
+++ b/src/sdk/sql_sdk_test.cc
@@ -48,7 +48,7 @@ static std::shared_ptr<SQLRouter> GetNewSQLRouter() {
     SQLRouterOptions sql_opt;
     sql_opt.zk_cluster = mc_->GetZkCluster();
     sql_opt.zk_path = mc_->GetZkPath();
-    sql_opt.session_timeout = 60000;
+    sql_opt.zk_session_timeout = 60000;
     sql_opt.enable_debug = hybridse::sqlcase::SqlCase::IsDebug();
     auto router = NewClusterSQLRouter(sql_opt);
     SetOnlineMode(router);
@@ -94,7 +94,7 @@ TEST_P(SQLSDKTest, SqlSdkBatchTest) {
         return;
     }
     SQLRouterOptions sql_opt;
-    sql_opt.session_timeout = 30000;
+    sql_opt.zk_session_timeout = 30000;
     sql_opt.zk_cluster = mc_->GetZkCluster();
     sql_opt.zk_path = mc_->GetZkPath();
     sql_opt.enable_debug = sql_case.debug() || hybridse::sqlcase::SqlCase::IsDebug();
@@ -216,7 +216,7 @@ TEST_F(SQLSDKQueryTest, ExecuteLatestWhereTest) {
         "create table latest_table(c1 string, c2 int, c3 timestamp, c4 timestamp, "
         "index(key=(c1),ts=c4,ttl_type=latest, ttl=2));";
     SQLRouterOptions sql_opt;
-    sql_opt.session_timeout = 30000;
+    sql_opt.zk_session_timeout = 30000;
     sql_opt.zk_cluster = mc_->GetZkCluster();
     sql_opt.zk_path = mc_->GetZkPath();
     sql_opt.enable_debug = hybridse::sqlcase::SqlCase::IsDebug();
@@ -280,7 +280,7 @@ TEST_F(SQLSDKQueryTest, ExecuteWhereTest) {
         "                   index(key=pay_card_no, ts=txn_time),\n"
         "                   index(key=merch_id, ts=txn_time));";
     SQLRouterOptions sql_opt;
-    sql_opt.session_timeout = 30000;
+    sql_opt.zk_session_timeout = 30000;
     sql_opt.zk_cluster = mc_->GetZkCluster();
     sql_opt.zk_path = mc_->GetZkPath();
     sql_opt.enable_debug = hybridse::sqlcase::SqlCase::IsDebug();
@@ -357,7 +357,7 @@ TEST_F(SQLSDKQueryTest, ExecuteInsertLoopsTest) {
     int64_t error_cnt = 0;
     int64_t cnt = 0;
     SQLRouterOptions sql_opt;
-    sql_opt.session_timeout = 30000;
+    sql_opt.zk_session_timeout = 30000;
     sql_opt.zk_cluster = mc_->GetZkCluster();
     sql_opt.zk_path = mc_->GetZkPath();
     sql_opt.enable_debug = hybridse::sqlcase::SqlCase::IsDebug();
@@ -410,7 +410,7 @@ TEST_F(SQLSDKQueryTest, CreateNoTs) {
         "                c2 bigint,\n"
         "                index(key=c1, ttl=14400m, ttl_type=absolute));";
     SQLRouterOptions sql_opt;
-    sql_opt.session_timeout = 30000;
+    sql_opt.zk_session_timeout = 30000;
     sql_opt.zk_cluster = mc_->GetZkCluster();
     sql_opt.zk_path = mc_->GetZkPath();
     sql_opt.enable_debug = hybridse::sqlcase::SqlCase::IsDebug();
@@ -454,7 +454,7 @@ TEST_F(SQLSDKQueryTest, RequestProcedureTest) {
     SQLRouterOptions sql_opt;
     sql_opt.zk_cluster = mc_->GetZkCluster();
     sql_opt.zk_path = mc_->GetZkPath();
-    sql_opt.session_timeout = 30000;
+    sql_opt.zk_session_timeout = 30000;
     sql_opt.enable_debug = hybridse::sqlcase::SqlCase::IsDebug();
     auto router = NewClusterSQLRouter(sql_opt);
     if (!router) {
@@ -586,7 +586,7 @@ TEST_F(SQLSDKQueryTest, DropTableWithProcedureTest) {
     SQLRouterOptions sql_opt;
     sql_opt.zk_cluster = mc_->GetZkCluster();
     sql_opt.zk_path = mc_->GetZkPath();
-    sql_opt.session_timeout = 30000;
+    sql_opt.zk_session_timeout = 30000;
     sql_opt.enable_debug = hybridse::sqlcase::SqlCase::IsDebug();
     auto router = NewClusterSQLRouter(sql_opt);
     if (!router) {
@@ -791,7 +791,7 @@ TEST_F(SQLSDKQueryTest, ExecuteWhereWithParameter) {
         "                   index(key=pay_card_no, ts=txn_time),\n"
         "                   index(key=merch_id, ts=txn_time));";
     SQLRouterOptions sql_opt;
-    sql_opt.session_timeout = 30000;
+    sql_opt.zk_session_timeout = 30000;
     sql_opt.zk_cluster = mc_->GetZkCluster();
     sql_opt.zk_path = mc_->GetZkPath();
     sql_opt.enable_debug = hybridse::sqlcase::SqlCase::IsDebug();


### PR DESCRIPTION
Signed-off-by: mango <xu.weiKyrie@foxmail.com>

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Refactor


* **What is the current behavior?** (You can also link to an open issue here)
mv session_timeout to cluster router options and rename to  zk_session_timeout
Fixed #1941

* **What is the new behavior (if this is a feature change)?**
None
