### PR TITLE
fix: fix typo `kPhysicalOpAggrerate` to `kPhysicalOpAggregate`

### DIFF
--- a/hybridse/include/vm/physical_op.h
+++ b/hybridse/include/vm/physical_op.h
@@ -39,7 +39,7 @@ enum PhysicalOpType {
     kPhysicalOpFilter,
     kPhysicalOpGroupBy,
     kPhysicalOpSortBy,
-    kPhysicalOpAggrerate,
+    kPhysicalOpAggregate,
     kPhysicalOpProject,
     kPhysicalOpSimpleProject,
     kPhysicalOpConstProject,

--- a/hybridse/src/vm/physical_op.cc
+++ b/hybridse/src/vm/physical_op.cc
@@ -37,7 +37,7 @@ static absl::flat_hash_map<PhysicalOpType, absl::string_view> CreatePhysicalOpTy
         {kPhysicalOpProject, "PROJECT"},
         {kPhysicalOpSimpleProject, "SIMPLE_PROJECT"},
         {kPhysicalOpConstProject, "CONST_PROJECT"},
-        {kPhysicalOpAggrerate, "AGGRERATE"},
+        {kPhysicalOpAggregate, "AGGREGATE"},
         {kPhysicalOpLimit, "LIMIT"},
         {kPhysicalOpRename, "RENAME"},
         {kPhysicalOpDistinct, "DISTINCT"},


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- renamed `kPhysicalOpAggrerate` to `kPhysicalOpAggregate` in hybridse/include/vm/physical_op.h and hybridse/src/vm/physical_op.cc

rename "AGGRERATE" to "AGGREGATE" in hybridse/src/vm/physical_op.cc

Closes #1977 