### PR TITLE
refactor: rename `RtiDBIndex` to `PBIndex` in src/catalog/sdk_catalog_test.cc

### DIFF
--- a/src/catalog/sdk_catalog_test.cc
+++ b/src/catalog/sdk_catalog_test.cc
@@ -26,7 +26,7 @@ namespace openmldb {
 namespace catalog {
 
 typedef ::google::protobuf::RepeatedPtrField<::openmldb::common::ColumnDesc> PBSchema;
-typedef ::google::protobuf::RepeatedPtrField<::openmldb::common::ColumnKey> RtiDBIndex;
+typedef ::google::protobuf::RepeatedPtrField<::openmldb::common::ColumnKey> PBIndex;
 
 class SDKCatalogTest : public ::testing::Test {};
 
@@ -46,7 +46,7 @@ TestArgs* PrepareTable(const std::string& tname, const std::string& db) {
     auto col2 = schema->Add();
     col2->set_name("col2");
     col2->set_data_type(::openmldb::type::kBigInt);
-    RtiDBIndex* index = args->meta.mutable_column_key();
+    PBIndex* index = args->meta.mutable_column_key();
     auto key1 = index->Add();
     key1->set_index_name("index0");
     key1->add_col_name("col1");


### PR DESCRIPTION
change all RtiDBIndex to PBIndex.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**

