### PR TITLE
fix: move in return stmt preventing copy elision

### DIFF
--- a/hybridse/include/codec/list_iterator_codec.h
+++ b/hybridse/include/codec/list_iterator_codec.h
@@ -94,9 +94,7 @@ class ColumnImpl : public WrapListImpl<V, Row> {
 
     // TODO(xxx): iterator of nullable V
     std::unique_ptr<ConstIterator<uint64_t, V>> GetIterator() override {
-        auto iter = std::unique_ptr<ConstIterator<uint64_t, V>>(
-            new ColumnIterator<V>(root_, this));
-        return std::move(iter);
+        return std::make_unique<ColumnIterator<V>>(root_, this);
     }
     ConstIterator<uint64_t, V> *GetRawIterator() override {
         return new ColumnIterator<V>(root_, this);


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Fixes #2004
Follows suggestion from the issue desc.


* **What is the current behavior?** 
Move prevents copy elision
https://pvs-studio.com/en/docs/warnings/v828/
https://en.cppreference.com/w/cpp/language/copy_elision

* **What is the new behavior?**
Copy Elision is guaranteed when an object is returned directly (>C++17)