### PR TITLE
feat: new built-in aggregate function median

### DIFF
--- a/cases/function/function/test_udaf_function.yaml
+++ b/cases/function/function/test_udaf_function.yaml
@@ -2509,3 +2509,27 @@ cases:
         6, 4, 4, NULL, NULL
         7, 3, 3, NULL, 4
         8, 2, 2, NULL, 3
+
+  - id: 61
+    desc: median
+    sqlDialect: ["HybridSQL"]
+    inputs:
+      -
+        columns : ["id int","c1 string","c2 smallint","c3 int","c4 bigint","c5 float","c6 double","c7 timestamp","c8 date","c9 string","c10 bool"]
+        indexs: ["index1:c1:c7"]
+        rows:
+          - [1,"aa",1,1,30,1.1,2.1,1590738990000,"2020-05-01","a",true]
+          - [2,"aa",4,4,33,1.4,2.4,1590738991000,"2020-05-03","c",false]
+          - [3,"aa",1,1,33,1.1,2.1,1590738992000,"2020-05-02","b",true]
+          - [4,"aa",NULL,NULL,NULL,NULL,NULL,1590738993000,NULL,NULL,NULL]
+    sql: |
+      SELECT {0}.id, c1, median(c2) OVER w1 as m2,median(c3) OVER w1 as m3,median(c4) OVER w1 as m4,median(c5) OVER w1 as m5,median(c6) OVER w1 as m6 FROM {0} WINDOW
+      w1 AS (PARTITION BY {0}.c1 ORDER BY {0}.c7 ROWS BETWEEN 2 PRECEDING AND CURRENT ROW);
+    expect:
+      order: id
+      columns: ["id int","c1 string","m2 double","m3 double","m4 double","m5 double","m6 double"]
+      rows:
+        - [1,"aa",1,1,30,1.1000000238418579,2.1]
+        - [2,"aa",2.5,2.5,31.5,1.25,2.25]
+        - [3,"aa",1,1,33,1.1000000238418579,2.1]
+        - [4,"aa",2.5,2.5,33,1.25,2.25]

--- a/hybridse/src/udf/default_udf_library.cc
+++ b/hybridse/src/udf/default_udf_library.cc
@@ -22,6 +22,7 @@
 #include <utility>
 #include <vector>
 #include <queue>
+#include <functional>
 
 #include "absl/strings/str_cat.h"
 #include "codegen/date_ir_builder.h"
@@ -314,7 +315,7 @@ struct DistinctCountDef {
 template <typename T>
 struct MedianDef {
     using ArgT = typename DataTypeTrait<T>::CCallArgType;
-    using MaxHeapT = std::priority_queue<T, std::vector<T>, std::less<>>; 
+    using MaxHeapT = std::priority_queue<T, std::vector<T>, std::less<>>;
     using MinHeapT = std::priority_queue<T, std::vector<T>, std::greater<>>;
     using ContainerT = std::tuple<MaxHeapT, MinHeapT>;
 
@@ -332,7 +333,7 @@ struct MedianDef {
         auto &max_heap = std::get<0>(*container);
         auto &min_heap = std::get<1>(*container);
 
-        // invariant: 
+        // invariant:
         // max_heap.size() <= min_heap.size() &&
         // max_head.top() <= median && median < min_head.top()
         if (max_heap.empty() || value <= max_heap.top()) {
@@ -360,7 +361,7 @@ struct MedianDef {
     static void Output(ContainerT* container, double* ret, bool* is_null) {
         auto &max_heap = std::get<0>(*container);
         auto &min_heap = std::get<1>(*container);
-        
+
         if (min_heap.empty() && max_heap.empty()) {
             *is_null = true;
         } else {

--- a/hybridse/src/udf/default_udf_library.cc
+++ b/hybridse/src/udf/default_udf_library.cc
@@ -306,7 +306,7 @@ struct MedianDef {
     using ArgT = typename DataTypeTrait<T>::CCallArgType;
     using VectorT = std::vector<T>;
 
-    void operator()(UdafRegistryHelper& helper) {
+    void operator()(UdafRegistryHelper& helper) {  // NOLINT
         std::string suffix = ".opaque_vector_" + DataTypeTrait<T>::to_string();
         helper.templates<Nullable<double>, Opaque<VectorT>, Nullable<T>>()
             .init("median_init" + suffix, MedianDef::Init)
@@ -2471,7 +2471,7 @@ void DefaultUdfLibrary::InitUdaf() {
                 SELECT median(value) OVER w;
                 -- output 2.5
             @endcode
-            @since 0.5.0
+            @since 0.6.0
         )")
         .args_in<int16_t, int32_t, int64_t, float, double>();
 

--- a/hybridse/src/udf/default_udf_library_test.cc
+++ b/hybridse/src/udf/default_udf_library_test.cc
@@ -67,6 +67,8 @@ TEST_F(DefaultUdfLibraryTest, TestCheckIsUdafByName) {
     ASSERT_TRUE(library->IsUdaf("count"));
     // avg(...) is an udaf
     ASSERT_TRUE(library->IsUdaf("avg"));
+    // median(...) is an udaf
+    ASSERT_TRUE(library->IsUdaf("median"));
 
     // hour(..) isn't an udaf
     ASSERT_TRUE(!library->IsUdaf("hour"));

--- a/hybridse/src/udf/udaf_test.cc
+++ b/hybridse/src/udf/udaf_test.cc
@@ -103,6 +103,24 @@ TEST_F(UdafTest, CountTest) {
 
 // TODO(aceforeverd): add test for sum ,avg, distinct_count
 
+TEST_F(UdafTest, MedianTest) {
+    CheckUdafOneParam<Nullable<double>, Nullable<int32_t>>("median", nullptr, {});
+    CheckUdafOneParam<Nullable<double>, Nullable<int32_t>>("median", nullptr, {nullptr});
+    CheckUdafOneParam<Nullable<double>, Nullable<int32_t>>("median", nullptr, {nullptr, nullptr});
+
+    CheckUdafOneParam<Nullable<double>, Nullable<int32_t>>("median", 1, {0, 1, 2});
+    CheckUdafOneParam<Nullable<double>, Nullable<int32_t>>("median", 1.5, {0, 1, 2, 3});
+    CheckUdafOneParam<Nullable<double>, Nullable<int32_t>>("median", 1, {0, 1, 2, nullptr});
+    CheckUdafOneParam<Nullable<double>, Nullable<int32_t>>("median", 3, {1, 5, 2, 4, 3});
+    CheckUdafOneParam<Nullable<double>, Nullable<int32_t>>("median", 2.5, {1, 2, 4, 3});
+    CheckUdafOneParam<Nullable<double>, Nullable<int32_t>>("median", -0.5, {-1, -2, 0, 1});
+
+    CheckUdafOneParam<Nullable<double>, Nullable<double>>("median", 2.0, {1.0, 2.0, 3.0});
+    CheckUdafOneParam<Nullable<double>, Nullable<double>>("median", 2.5, {1.0, 2.0, 3.0, 4.0});
+    CheckUdafOneParam<Nullable<double>, Nullable<double>>("median", 2.0, {1.0, 2.0, 3.0, nullptr});
+    CheckUdafOneParam<Nullable<double>, Nullable<double>>("median", 3.0, {1.0, 5.0, 2.0, 4.0, 3.0});
+}
+
 TEST_F(UdafTest, sum_where_test) {
     CheckUdf<int32_t, ListRef<int32_t>, ListRef<bool>>(
         "sum_where", 10, MakeList<int32_t>({4, 5, 6}),


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add a new build-in aggregate function `median`.


* **What is the current behavior?** (You can also link to an open issue here)
It should resolve #1960 


* **What is the new behavior (if this is a feature change)?**
a new build-in aggregate function `median`.
