### PR TITLE
fix: send snapshot for disk table

### DIFF
--- a/src/client/tablet_client.cc
+++ b/src/client/tablet_client.cc
@@ -156,7 +156,8 @@ bool TabletClient::SQLBatchRequestQuery(const std::string& db, const std::string
 bool TabletClient::CreateTable(const std::string& name, uint32_t tid, uint32_t pid, uint64_t abs_ttl, uint64_t lat_ttl,
                                bool leader, const std::vector<std::string>& endpoints,
                                const ::openmldb::type::TTLType& type, uint32_t seg_cnt, uint64_t term,
-                               const ::openmldb::type::CompressType compress_type) {
+                               const ::openmldb::type::CompressType compress_type,
+                               ::openmldb::common::StorageMode storage_mode) {
     ::openmldb::api::CreateTableRequest request;
     if (type == ::openmldb::type::kLatestTime) {
         if (lat_ttl > FLAGS_latest_ttl_max) {
@@ -177,6 +178,7 @@ bool TabletClient::CreateTable(const std::string& name, uint32_t tid, uint32_t p
     table_meta->set_pid(pid);
     table_meta->set_compress_type(compress_type);
     table_meta->set_seg_cnt(seg_cnt);
+    table_meta->set_storage_mode(storage_mode);
     if (leader) {
         table_meta->set_mode(::openmldb::api::TableMode::kTableLeader);
         table_meta->set_term(term);

--- a/src/client/tablet_client.h
+++ b/src/client/tablet_client.h
@@ -59,7 +59,8 @@ class TabletClient : public Client {
 
     bool CreateTable(const std::string& name, uint32_t tid, uint32_t pid, uint64_t abs_ttl, uint64_t lat_ttl,
                      bool leader, const std::vector<std::string>& endpoints, const ::openmldb::type::TTLType& type,
-                     uint32_t seg_cnt, uint64_t term, const ::openmldb::type::CompressType compress_type);
+                     uint32_t seg_cnt, uint64_t term, const ::openmldb::type::CompressType compress_type,
+                     ::openmldb::common::StorageMode storage_mode = ::openmldb::common::kMemory);
 
     bool CreateTable(const ::openmldb::api::TableMeta& table_meta);
 

--- a/src/tablet/file_sender.cc
+++ b/src/tablet/file_sender.cc
@@ -38,9 +38,10 @@ DECLARE_int32(request_timeout_ms);
 namespace openmldb {
 namespace tablet {
 
-FileSender::FileSender(uint32_t tid, uint32_t pid, const std::string& endpoint)
+FileSender::FileSender(uint32_t tid, uint32_t pid, common::StorageMode storage_mode, const std::string& endpoint)
     : tid_(tid),
       pid_(pid),
+      storage_mode_(storage_mode),
       endpoint_(endpoint),
       cur_try_time_(0),
       max_try_time_(FLAGS_send_file_max_try),
@@ -82,6 +83,7 @@ int FileSender::WriteData(const std::string& file_name, const std::string& dir_n
     ::openmldb::api::SendDataRequest request;
     request.set_tid(tid_);
     request.set_pid(pid_);
+    request.set_storage_mode(storage_mode_);
     request.set_file_name(file_name);
     if (!dir_name.empty()) {
         request.set_dir_name(dir_name);
@@ -210,6 +212,7 @@ int FileSender::CheckFile(const std::string& file_name, const std::string& dir_n
     check_request.set_tid(tid_);
     check_request.set_pid(pid_);
     check_request.set_file(file_name);
+    check_request.set_storage_mode(storage_mode_);
     if (!dir_name.empty()) {
         check_request.set_dir_name(dir_name);
     }

--- a/src/tablet/file_sender.h
+++ b/src/tablet/file_sender.h
@@ -28,7 +28,7 @@ namespace tablet {
 
 class FileSender {
  public:
-    FileSender(uint32_t tid, uint32_t pid, const std::string& endpoint);
+    FileSender(uint32_t tid, uint32_t pid, common::StorageMode storage_mode, const std::string& endpoint);
     ~FileSender();
     bool Init();
     int SendFile(const std::string& file_name, const std::string& dir_name, const std::string& full_path);
@@ -43,6 +43,7 @@ class FileSender {
  private:
     uint32_t tid_;
     uint32_t pid_;
+    common::StorageMode storage_mode_;
     std::string endpoint_;
     uint32_t cur_try_time_;
     uint32_t max_try_time_;

--- a/src/tablet/tablet_impl.cc
+++ b/src/tablet/tablet_impl.cc
@@ -2756,7 +2756,7 @@ void TabletImpl::SendSnapshotInternal(const std::string& endpoint, uint32_t tid,
             }
             real_endpoint = iter->second;
         }
-        FileSender sender(remote_tid, pid, real_endpoint);
+        FileSender sender(remote_tid, pid, table->GetStorageMode(), real_endpoint);
         if (!sender.Init()) {
             PDLOG(WARNING, "Init FileSender failed. tid[%u] pid[%u] endpoint[%s]", tid, pid, endpoint.c_str());
             break;
@@ -4730,7 +4730,7 @@ void TabletImpl::SendIndexDataInternal(std::shared_ptr<::openmldb::storage::Tabl
                 }
                 real_endpoint = iter->second;
             }
-            FileSender sender(tid, kv.first, real_endpoint);
+            FileSender sender(tid, kv.first, table->GetStorageMode(), real_endpoint);
             if (!sender.Init()) {
                 PDLOG(WARNING,
                       "Init FileSender failed. tid[%u] pid[%u] des_pid[%u] "

--- a/src/tablet/tablet_impl.cc
+++ b/src/tablet/tablet_impl.cc
@@ -155,7 +155,9 @@ TabletImpl::~TabletImpl() {
     gc_pool_.Stop(true);
     io_pool_.Stop(true);
     snapshot_pool_.Stop(true);
-    delete zk_client_;
+    if (zk_client_) {
+        delete zk_client_;
+    }
 }
 
 bool TabletImpl::Init(const std::string& real_endpoint) {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
fix #2026


* **What is the current behavior?** (You can also link to an open issue here)
Currently the `storage_mode` is not passed when sending snapshot. Thus the follower tablet copies the data into the wrong directory.


