### PR TITLE
fix: `MakeResultSet` using wrong schema in projection

### DIFF
--- a/src/cmd/sql_cmd_test.cc
+++ b/src/cmd/sql_cmd_test.cc
@@ -284,6 +284,43 @@ TEST_F(SqlCmdTest, SelectMultiPartition) {
     ProcessSQLs(sr, {absl::StrCat("drop table ", name, ";"), absl::StrCat("drop database ", db_name, ";")});
 }
 
+TEST_F(SqlCmdTest, TableReader) {
+    auto sr = cluster_cli.sr;
+    std::string db_name = "test" + GenRand();
+    std::string name = "table" + GenRand();
+    std::string ddl = "create table " + name +
+                      "("
+                      "col1 string not null,"
+                      "col2 bigint default 112 not null,"
+                      "col4 string default 'test4' not null,"
+                      "col5 date default '2000-01-01' not null,"
+                      "col6 int default 10000 not null,"
+                      "index(key=col1, ts=col2));";
+    ProcessSQLs(sr, {"set @@execute_mode = 'online'",
+            absl::StrCat("create database ", db_name, ";"),
+            absl::StrCat("use ", db_name, ";"),
+            ddl});
+    hybridse::sdk::Status status;
+    std::string sql = "insert into " + name + " values('key1', 1, '1', '2021-01-01', 10);";
+    ASSERT_TRUE(sr->ExecuteInsert(db_name, sql, &status));
+    auto reader = sr->GetTableReader();
+    openmldb::sdk::ScanOption option;
+    option.projection = {"col1", "col2", "col6"};
+    auto result_set = reader->Scan(db_name, name, "key1", 0, 0, option, &status);
+    ASSERT_TRUE(status.IsOK());
+    result_set->Next();
+    std::string val;
+    result_set->GetString(0, &val);
+    ASSERT_EQ("key1", val);
+    int64_t val1 = 0;
+    result_set->GetInt64(1, &val1);
+    ASSERT_EQ(1, val1);
+    int32_t val2 = 0;
+    result_set->GetInt32(2, &val2);
+    ASSERT_EQ(10, val2);
+    ProcessSQLs(sr, {absl::StrCat("drop table ", name, ";"), absl::StrCat("drop database ", db_name, ";")});
+}
+
 TEST_P(DBSDKTest, Desc) {
     auto cli = GetParam();
     cs = cli->cs;

--- a/src/sdk/result_set_sql.cc
+++ b/src/sdk/result_set_sql.cc
@@ -98,6 +98,7 @@ std::shared_ptr<::hybridse::sdk::ResultSet> ResultSetSQL::MakeResultSet(
         bool ok = ::openmldb::schema::SchemaAdapter::SubSchema(sdk_table_handler->GetSchema(), projection, &schema);
         if (!ok) {
             *status = {::hybridse::common::StatusCode::kCmdError, "fail to get sub schema"};
+            return {};
         }
         rs = std::make_shared<openmldb::sdk::ResultSetSQL>(schema, response->count(), response->buf_size(), cntl);
     } else {

--- a/src/sdk/result_set_sql.cc
+++ b/src/sdk/result_set_sql.cc
@@ -68,22 +68,18 @@ std::shared_ptr<::hybridse::sdk::ResultSet> ResultSetSQL::MakeResultSet(
     const std::shared_ptr<::openmldb::api::QueryResponse>& response, const std::shared_ptr<brpc::Controller>& cntl,
     hybridse::sdk::Status* status) {
     if (!status || !response || !cntl) {
-        return std::shared_ptr<ResultSet>();
+        return {};
     }
     ::hybridse::vm::Schema schema;
     bool ok = ::hybridse::codec::SchemaCodec::Decode(response->schema(), &schema);
     if (!ok) {
-        status->code = -1;
-        status->msg = "request error, fail to decodec schema";
-        return std::shared_ptr<ResultSet>();
+        *status = {::hybridse::common::StatusCode::kCmdError, "request error, fail to decodec schema"};
+        return {};
     }
-    std::shared_ptr<::openmldb::sdk::ResultSetSQL> rs =
-        std::make_shared<openmldb::sdk::ResultSetSQL>(schema, response->count(), response->byte_size(), cntl);
-    ok = rs->Init();
-    if (!ok) {
-        status->code = -1;
-        status->msg = "request error, ResultSetSQL init failed";
-        return std::shared_ptr<ResultSet>();
+    auto rs = std::make_shared<openmldb::sdk::ResultSetSQL>(schema, response->count(), response->byte_size(), cntl);
+    if (!rs->Init()) {
+        *status = {::hybridse::common::StatusCode::kCmdError, "request error, ResultSetSQL init failed"};
+        return {};
     }
     return rs;
 }
@@ -93,37 +89,26 @@ std::shared_ptr<::hybridse::sdk::ResultSet> ResultSetSQL::MakeResultSet(
     const ::google::protobuf::RepeatedField<uint32_t>& projection, const std::shared_ptr<brpc::Controller>& cntl,
     std::shared_ptr<::hybridse::vm::TableHandler> table_handler, ::hybridse::sdk::Status* status) {
     if (!status || !response || !cntl) {
-        return std::shared_ptr<ResultSet>();
+        return {};
     }
+    std::shared_ptr<::openmldb::sdk::ResultSetSQL> rs;
     auto sdk_table_handler = dynamic_cast<::openmldb::catalog::SDKTableHandler*>(table_handler.get());
     if (projection.size() > 0) {
         ::hybridse::vm::Schema schema;
         bool ok = ::openmldb::schema::SchemaAdapter::SubSchema(sdk_table_handler->GetSchema(), projection, &schema);
         if (!ok) {
-            status->code = -1;
-            status->msg = "fail to get sub schema";
+            *status = {::hybridse::common::StatusCode::kCmdError, "fail to get sub schema"};
         }
-
-        std::shared_ptr<::openmldb::sdk::ResultSetSQL> rs = std::make_shared<openmldb::sdk::ResultSetSQL>(
-            *(sdk_table_handler->GetSchema()), response->count(), response->buf_size(), cntl);
-        ok = rs->Init();
-        if (!ok) {
-            status->code = -1;
-            status->msg = "request error, ResultSetSQL init failed";
-            return std::shared_ptr<ResultSet>();
-        }
-        return rs;
+        rs = std::make_shared<openmldb::sdk::ResultSetSQL>(schema, response->count(), response->buf_size(), cntl);
     } else {
-        std::shared_ptr<::openmldb::sdk::ResultSetSQL> rs = std::make_shared<openmldb::sdk::ResultSetSQL>(
+        rs = std::make_shared<openmldb::sdk::ResultSetSQL>(
             *(sdk_table_handler->GetSchema()), response->count(), response->buf_size(), cntl);
-        bool ok = rs->Init();
-        if (!ok) {
-            status->code = -1;
-            status->msg = "request error, ResultSetSQL init failed";
-            return std::shared_ptr<ResultSet>();
-        }
-        return rs;
     }
+    if (!rs->Init()) {
+        *status = {::hybridse::common::StatusCode::kCmdError, "request error, ResultSetSQL init failed"};
+        return {};
+    }
+    return rs;
 }
 
 std::shared_ptr<::hybridse::sdk::ResultSet> ResultSetSQL::MakeResultSet(


### PR DESCRIPTION
The result  returned by `Scan` function in `TableReader` is incorrect currently.