### PR TITLE
refactor: removed `std::move`

### DIFF
--- a/src/catalog/sdk_catalog.h
+++ b/src/catalog/sdk_catalog.h
@@ -51,13 +51,13 @@ class SDKTableHandler : public ::hybridse::vm::TableHandler {
     const ::hybridse::vm::IndexHint& GetIndex() override { return index_hint_; }
 
     std::unique_ptr<::hybridse::codec::RowIterator> GetIterator() override {
-        return std::move(std::unique_ptr<::hybridse::codec::RowIterator>());
+        return std::unique_ptr<::hybridse::codec::RowIterator>();
     }
 
     ::hybridse::codec::RowIterator* GetRawIterator() override { return nullptr; }
 
     std::unique_ptr<::hybridse::codec::WindowIterator> GetWindowIterator(const std::string& idx_name) override {
-        return std::move(std::unique_ptr<::hybridse::codec::WindowIterator>());
+        return std::unique_ptr<::hybridse::codec::WindowIterator>();
     }
 
     const uint64_t GetCount() override { return cnt_; }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Removed `std::move` from return statement in catalog/sdk_catalog.h


* **What is the current behavior?** (You can also link to an open issue here)
Fixes #2064 


* **What is the new behavior (if this is a feature change)?**

