### PR TITLE
fix: delete unused include from codec/codec.h

### DIFF
--- a/src/codec/codec.h
+++ b/src/codec/codec.h
@@ -17,9 +17,6 @@
 #ifndef SRC_CODEC_CODEC_H_
 #define SRC_CODEC_CODEC_H_
 
-#include <stdio.h>
-#include <stdlib.h>
-
 #include <map>
 #include <memory>
 #include <sstream>
@@ -27,7 +24,6 @@
 #include <utility>
 #include <vector>
 
-#include "base/endianconv.h"
 #include "base/strings.h"
 #include "proto/common.pb.h"
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Deleted the unused include from codec/codec.h


* **What is the current behavior?** (You can also link to an open issue here)
https://github.com/4paradigm/OpenMLDB/issues/2076#issue-1294228097


* **What is the new behavior (if this is a feature change)?**
Should be the same just cleaner code
