### PR TITLE
refactor: delete RowContext src/codec/codec.h

### DIFF
--- a/src/codec/codec.h
+++ b/src/codec/codec.h
@@ -41,8 +41,6 @@ class RowBuilder;
 class RowView;
 class RowProject;
 
-// TODO(wangtaize) share the row codec context
-
 class RowProject {
  public:
     RowProject(const std::map<int32_t, std::shared_ptr<Schema>>& vers_schema, const ProjectList& plist);

--- a/src/codec/codec.h
+++ b/src/codec/codec.h
@@ -37,13 +37,11 @@ static constexpr uint8_t SIZE_LENGTH = 4;
 static constexpr uint8_t HEADER_LENGTH = VERSION_LENGTH + SIZE_LENGTH;
 static constexpr uint32_t UINT24_MAX = (1 << 24) - 1;
 
-struct RowContext;
 class RowBuilder;
 class RowView;
 class RowProject;
 
 // TODO(wangtaize) share the row codec context
-struct RowContext {};
 
 class RowProject {
  public:


### PR DESCRIPTION
Delete RowContext in src/codec/codec.h because unused, requested in issues #2095 