### PR TITLE
refactor: updated default value of concurrency_limit to zero in src/flags.cc

### DIFF
--- a/src/flags.cc
+++ b/src/flags.cc
@@ -88,9 +88,9 @@ DEFINE_uint32(query_slow_log_threshold, 50000, "config the threshold of query sl
 DEFINE_string(db_root_path, "/tmp/", "the root path of db");
 
 // thread pool config
-DEFINE_int32(put_concurrency_limit, 8, "the limit of put concurrency");
+DEFINE_int32(put_concurrency_limit, 0, "the limit of put concurrency");
 DEFINE_int32(thread_pool_size, 16, "the size of thread pool for other api");
-DEFINE_int32(get_concurrency_limit, 8, "the limit of get concurrency");
+DEFINE_int32(get_concurrency_limit, 0, "the limit of get concurrency");
 DEFINE_int32(request_max_retry, 3, "max retry time when request error");
 DEFINE_int32(request_timeout_ms, 20000, "request timeout");
 DEFINE_int32(request_sleep_time, 1000, "the sleep time when request error");


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)
Fixes #2098 


* **What is the new behavior (if this is a feature change)?**

