### PR TITLE
fix: resolved different signedness issue

### DIFF
--- a/hybridse/examples/toydb/src/sdk/tablet_sdk.cc
+++ b/hybridse/examples/toydb/src/sdk/tablet_sdk.cc
@@ -297,7 +297,7 @@ void TabletSdkImpl::BuildInsertRequest(const std::string& db,
     request->set_db(db);
 
     std::unordered_set<std::string> column_set;
-    for (size_t i = 0; i < (unsigned)schema.columns().size(); i++) {
+    for (int i = 0; i < schema.columns().size(); i++) {
         column_set.insert(schema.columns(i).name());
     }
     std::map<std::string, node::ConstNode*> column_value_map;

--- a/hybridse/examples/toydb/src/sdk/tablet_sdk.cc
+++ b/hybridse/examples/toydb/src/sdk/tablet_sdk.cc
@@ -297,7 +297,7 @@ void TabletSdkImpl::BuildInsertRequest(const std::string& db,
     request->set_db(db);
 
     std::unordered_set<std::string> column_set;
-    for (size_t i = 0; i < schema.columns().size(); i++) {
+    for (size_t i = 0; i < (unsigned)schema.columns().size(); i++) {
         column_set.insert(schema.columns(i).name());
     }
     std::map<std::string, node::ConstNode*> column_value_map;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
it was a label :"good first issue" 
 it resolves the different signedness at line 300 in 
[hybridse/examples/toydb/src/sdk/tablet_sdk.cc]{https://github.com/4paradigm/OpenMLDB/blob/main/hybridse/examples/toydb/src/sdk/tablet_sdk.cc#L300}
* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**

