### PR TITLE
docs: added sql examples in join clause and fixed syntax errors

### DIFF
--- a/docs/zh/reference/sql/ddl/CREATE_DATABASE_STATEMENT.md
+++ b/docs/zh/reference/sql/ddl/CREATE_DATABASE_STATEMENT.md
@@ -20,14 +20,14 @@ DBName ::=
 
 ```sql
 CREATE DATABASE db1;
--- SUCCEED: Create database successfully
+-- SUCCEED
 ```
 
-在创建一个名字为`db2`的数据库：
+再创建一个名字为`db2`的数据库：
 
 ```sql
 CREATE DATABASES db2;
--- SUCCEED: Create database successfully
+-- SUCCEED
 ```
 
 显示数据库列表:

--- a/docs/zh/reference/sql/ddl/CREATE_TABLE_STATEMENT.md
+++ b/docs/zh/reference/sql/ddl/CREATE_TABLE_STATEMENT.md
@@ -17,13 +17,12 @@ TableElementList ::=
     TableElement ( ',' TableElement )*
 
 TableElement ::=
-    ColumnDef
-|   ColumnIndex
+    ColumnDef | ColumnIndex
 ```
 
  `CREATE TABLE` 语句用于创建一张表。同一个数据库下，表名在必须是唯一的，在同一个数据库下，重复创建同名表，会发生错误。
 
-建表语句中需要定义`table_element`列表。`table_element`分为列描述`ColumnDef`和`Constraint`。OpenMLDB要求`table_element`列表中至少包含一个`ColumnDef`。
+建表语句中需要定义`table_element`列表。`table_element`分为列描述`ColumnDef`和列索引`ColumnIndex`。OpenMLDB要求`table_element`列表中至少包含一个`ColumnDef`。
 
 ### 相关语法元素
 
@@ -33,8 +32,8 @@ TableElement ::=
 ColumnDef ::=
     ColumnName ( ColumnType ) [ColumnOptionList]
 
-ColumnName
-         ::= Identifier ( '.' Identifier ( '.' Identifier )? )?      
+ColumnName ::=
+    Identifier ( '.' Identifier ( '.' Identifier )? )?      
          
 ColumnType ::=
 						'INT' | 'INT32'
@@ -46,22 +45,22 @@ ColumnType ::=
 						|'DATE'
 						|'STRING' | 'VARCHAR'
 						
-ColumnOptionList
-         ::= ColumnOption*	
-ColumnOption 
-				 ::= ['DEFAULT' DefaultValueExpr ] ['NOT' 'NULL']
+ColumnOptionList ::= 
+    ColumnOption*	
+ColumnOption ::= 
+    ['DEFAULT' DefaultValueExpr ] ['NOT' 'NULL']
 				 	  
-DefaultValueExpr
-				::= int_literal | float_literal | double_literal | string_literal
+DefaultValueExpr ::= 
+    int_literal | float_literal | double_literal | string_literal
 ```
 
 一张表中包含一个或多个列。每一列的列描述`ColumnDef`描述了列名、列类型以及类配置。
 
 - 列名：列在表中的名字。同一张表内的列名必须是唯一的。
-- 列类型：列的类型。想要了解OpenMLDB支持的数据类型，可以参考[数据类型](../data_types/reference.md)。
+- 列类型：列的类型。想要了解OpenMLDB支持的数据类型，可以参考[数据类型](https://openmldb.ai/docs/zh/main/reference/sql/data_types/index.html)。
 - 列约束配置：
-  - `NOT NULL`: 配置列的不允许为空值。
-  - `DEFAULT`: 配置列默认值。`NOT NULL`的属性会同时配置`DEFAULT`默认值，这样的话，查入数据时，若没有定义该列的值，会插入默认值。若配置`NOT NULL`属性且没有配置`DEFAULT`值，插入语句中未定义改列值时，OpenMLDB会抛出错误。
+  - `NOT NULL`: 该列的取值不允许为空。
+  - `DEFAULT`: 设置该列的默认值。`NOT NULL`的属性推荐同时配置`DEFAULT`默认值，在插入数据时，若没有定义该列的值，会插入默认值。若设置了`NOT NULL`属性但没有配置`DEFAULT`值，插入语句中未定义该列值时，OpenMLDB会抛出错误。
 
 ##### Example: 创建一张表
 
@@ -69,22 +68,27 @@ DefaultValueExpr
 
 ```sql
 CREATE DATABASE db1;
--- SUCCEED: Create database successfully
+-- SUCCEED
 
 USE db1;
 -- SUCCEED: Database changed
 
 CREATE TABLE t1(col0 STRING);
--- SUCCEED: Create successfully
+-- SUCCEED
 
 ```
 
-指定在数据库`db1`中创建一张表`t1`，包含列`col0`，列类型为STRING
+假如当前会话不在数据库`db1`下，但是仍要在`db1`中创建一张表`t2`，包含列`col0`，列类型为STRING；列`col1`，列类型为int。
 
 ```sql
-CREATE TABLE db1.t1 (col0 STRING, col1 int);
--- SUCCEED: Create successfully
-desc t1;
+CREATE TABLE db1.t2 (col0 STRING, col1 int);
+-- SUCCEED
+```
+切换到数据库`db1`，查看表`t2`的详细信息。
+```sql
+USE db1;
+-- SUCCEED: Database changed
+desc t2;
  --- ------- --------- ------ --------- 
   #   Field   Type      Null   Default  
  --- ------- --------- ------ --------- 
@@ -96,113 +100,122 @@ desc t1;
  --- -------------------- ------ ---- ------ --------------- 
   1   INDEX_0_1639524201   col0   -    0min   kAbsoluteTime  
  --- -------------------- ------ ---- ------ --------------- 
+ --------------
+  storage_mode
+ --------------
+  Memory
+ --------------
 ```
 
-##### Example: 创建一张表，配置列不允许为空NOT NULL
-
-```sql
-USE db1;
-CREATE TABLE t1 (col0 STRING NOT NULL, col1 int);
--- SUCCEED: Create successfully
-```
-
-```sql
-desc t1;
- --- ------- --------- ------ --------- 
-  #   Field   Type      Null   Default  
- --- ------- --------- ------ --------- 
-  1   col0    Varchar   NO              
-  2   col1    Int       YES             
- --- ------- --------- ------ --------- 
- --- -------------------- ------ ---- ------ --------------- 
-  #   name                 keys   ts   ttl    ttl_type       
- --- -------------------- ------ ---- ------ --------------- 
-  1   INDEX_0_1639523978   col0   -    0min   kAbsoluteTime  
- --- -------------------- ------ ---- ------ --------------- 
-```
-
-##### Example: 创建一张表，配置列配置默认值
-
-```sql
-USE db1;
-CREATE TABLE t1 (col0 STRING DEFAULT "NA", col1 int);
--- SUCCEED: Create successfully
-```
-
-```sql
-desc t1;
---- ------- --------- ------ --------- 
-  #   Field   Type      Null   Default  
---- ------- --------- ------ --------- 
-  1   col0    Varchar   NO     NA       
-  2   col1    Int       YES             
---- ------- --------- ------ --------- 
---- -------------------- ------ ---- ------ --------------- 
-  #   name                 keys   ts   ttl    ttl_type       
---- -------------------- ------ ---- ------ --------------- 
-  1   INDEX_0_1639524344   col0   -    0min   kAbsoluteTime  
---- -------------------- ------ ---- ------ --------------- 
-```
 
 ##### Example: 在同一个数据库下重复创建同名表
 
 ```sql
-USE db1;
 CREATE TABLE t1 (col0 STRING NOT NULL, col1 int);
--- SUCCEED: Create successfully
-CREATE TABLE t1 (col1 STRING NOT NULL, col1 int);
--- SUCCEED: Create successfully
+-- SUCCEED
+CREATE TABLE t1 (col0 STRING NOT NULL, col1 int);
+-- Error: table already exists
+CREATE TABLE t1 (col0 STRING NOT NULL, col1 string);
+-- Error: table already exists
 ```
+
+
+##### Example: 创建一张表，配置列不允许为空（NOT NULL）
+
+```sql
+USE db1;
+CREATE TABLE t3 (col0 STRING NOT NULL, col1 int);
+-- SUCCEED
+```
+查看该表的详细信息
+```sql
+desc t3;
+ --- ------- --------- ------ ---------
+  #   Field   Type      Null   Default
+ --- ------- --------- ------ ---------
+  1   col0    Varchar   NO
+  2   col1    Int       YES
+ --- ------- --------- ------ ---------
+ --- -------------------- ------ ---- ------ ---------------
+  #   name                 keys   ts   ttl    ttl_type
+ --- -------------------- ------ ---- ------ ---------------
+  1   INDEX_0_1657327434   col0   -    0min   kAbsoluteTime
+ --- -------------------- ------ ---- ------ ---------------
+ --------------
+  storage_mode
+ --------------
+  Memory
+ --------------
+```
+
+##### Example: 创建一张表，设置列默认值
+
+```sql
+USE db1;
+CREATE TABLE t4 (col0 STRING DEFAULT "NA", col1 int);
+-- SUCCEED
+```
+
+```sql
+desc t4;
+ --- ------- --------- ------ ---------
+  #   Field   Type      Null   Default
+ --- ------- --------- ------ ---------
+  1   col0    Varchar   YES    NA
+  2   col1    Int       YES
+ --- ------- --------- ------ ---------
+ --- -------------------- ------ ---- ------ ---------------
+  #   name                 keys   ts   ttl    ttl_type
+ --- -------------------- ------ ---- ------ ---------------
+  1   INDEX_0_1657327593   col0   -    0min   kAbsoluteTime
+ --- -------------------- ------ ---- ------ ---------------
+ --------------
+  storage_mode
+ --------------
+  Memory
+ --------------
+```
+
 
 #### 列索引ColumnIndex（可选）
 
 ```sql
-ColumnIndex
-         ::= 'INDEX' IndexName '(' IndexOptionList ')' 
+ColumnIndex ::= 
+    'INDEX' IndexName '(' IndexOptionList ')' 
  
-IndexOptionList
-         ::= IndexOption ( ',' IndexOption )*
-IndexOption
-         ::=  'KEY' '=' ColumnNameList 
-              | 'TS' '=' ColumnName
-              | 
-              | 'TTL' = int_literal
-              | 'REPLICANUM' = int_literal
+IndexOptionList ::= 
+    IndexKeyOption ( ',' IndexOption )*
+ 
+IndexKeyOption ::= 
+    'KEY' '=' ColumnNameList     
+
+ColumnNameList ::= 
+    '(' ColumnName (',' ColumnName)* ')'    
+    
+IndexOption ::= 
+    'TS' '=' ColumnName
+    | 'TTL' '=' IndexTtlOption
+    | 'TTL_TYPE' '=' TTLType
   
--- IndexKeyOption
-IndexKeyOption 
-						::= 'KEY' '=' ColumnNameList 
-ColumnNameList
-				 :: = '(' ColumnName (',' ColumnName)* ')'
--- IndexTsOption         
-IndexTsOption 
-						::= 'TS' '=' ColumnName
--- IndexTtlTypeOption					
-IndexTtlTypeOption
-						::= 'TTL_TYPE' '=' TTLType
+IndexTtlOption := 
+    int_literal | interval_literal | '(' interval_literal ',' int_literal ')'
+
+interval_literal ::= 
+    int_literal 'S'|'D'|'M'|'H'    
+    
 TTLType ::= 
-						'ABSOLUTE'
-						| 'LATEST'
-						| 'ABSORLAT'
-						| 'ABSANDLAT'
-   
--- IndexTtlOption
-IndexTtlOption
-						::= 'TTL' '=' int_literal|interval_literal
-
-interval_literal ::= int_literal 'S'|'D'|'M'|'H'
-
+    'ABSOLUTE'| 'LATEST'| 'ABSORLAT'| 'ABSANDLAT'
 
 ```
 
-索引可以被数据库搜索引擎用来加速数据的检索。 简单说来，索引就是指向表中数据的指针。配置一个列索引一般需要配置索引key，索引时间列, TTL和TTL_TYPE。其中索引key是必须配置的，其他配置项都为可选。下表列出了列索引配置项：
+索引可以被数据库搜索引擎用来加速数据的检索。 简单说来，索引就是指向表中数据的指针。配置一个列索引一般需要配置索引`KEY`，索引时间列`TS`, 最大存活时间/条数`TTL`和淘汰规则`TTL_TYPE`。其中`KEY`是必须配置的，其他配置项都为可选项。下表介绍了各索引配置项的含义及用法：
 
-| 配置项     | 描述                                                         | 用法示例                                                     |
-| ---------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| `KEY`      | 索引列（必选）。OpenMLDB支持单列索引，也支持联合索引。当`KEY`=一列时，配置的是单列索引。当`KEY`=多列时，配置的是这几列的联合索引，具体来说会将几列按顺序拼接成一个字符串作为索引。 | 单列索引：`INDEX(KEY=col1)`<br />联合索引：`INDEX(KEY=(col1, col2))` |
-| `TS`       | 索引时间列（可选）。同一个索引上的数据将按照时间索引列排序。当不显式配置`TS`时，使用数据插入的时间戳作为索引时间。 | `INDEX(KEY=col1, TS=std_time)`。索引列为col1,col1相同的数据行按std_time排序。 |
-| `TTL_TYPE` | 淘汰规则（可选）。包括：`ABSOLUTE`, `LATEST`, `ABSORLAT`, `ABSANDLAT`这四种类型。当不显式配置`TTL_TYPE`时，默认使用`ABSOLUTE`过期配置。 | 具体用法可以参考“TTL和TTL_TYPE的配置细则”                    |
-| `TTL`      | 最大存活时间/条数（）可选。不同的TTL_TYPE有不同的配置方式。当不显式配置`TTL`时，`TTL=0`。`TTL`为0表示不设置淘汰规则，OpenMLDB将不会淘汰记录。 |                                                              |
+| 配置项     | 描述                                                                                                  | 用法示例                                                           |
+| ---------- |-----------------------------------------------------------------------------------------------------|----------------------------------------------------------------|
+| `KEY`      | 索引列（必选）。OpenMLDB支持单列索引，也支持联合索引。当`KEY`后只有一列时，仅在该列上建立索引。当`KEY`后有多列时，建立这几列的联合索引：将多列按顺序拼接成一个字符串作为索引。    | 单列索引：`INDEX(KEY=col1)`<br />联合索引：`INDEX(KEY=(col1, col2))`     |
+| `TS`       | 索引时间列（可选）。同一个索引上的数据将按照时间索引列排序。当不显式配置`TS`时，使用数据插入的时间戳作为索引时间。                                         | `INDEX(KEY=col1, TS=std_time)`。索引列为col1,col1相同的数据行按std_time排序。 |
+| `TTL_TYPE` | 淘汰规则（可选）。包括四种类型：`ABSOLUTE`, `LATEST`, `ABSORLAT`, `ABSANDLAT`。当不显式配置`TTL_TYPE`时，默认使用`ABSOLUTE`过期配置。 | 具体用法可以参考下文“TTL和TTL_TYPE的配置细则”                                  |
+| `TTL`      | 最大存活时间/条数（可选）。根据不同的`TTL_TYPE`有不同的`TTL` 配置方式。当不显式配置`TTL`时，`TTL=0`，表示不设置淘汰规则，OpenMLDB将不会淘汰记录。                 |                                                                |
 
 TTL和TTL_TYPE的配置细则：
 
@@ -410,14 +423,11 @@ TableOptionItem
 						    | DistributeOption
 						    | StorageModeOption
 								
--- PartitionNum
 PartitionNumOption
 						::= 'PARTITIONNUM' '=' int_literal
--- ReplicaNumOption
 ReplicaNumOption
 						::= 'REPLICANUM' '=' int_literal
 						
--- DistributeOption				
 DistributeOption
 						::= 'DISTRIBUTION' '=' DistributionList
 DistributionList
@@ -431,7 +441,6 @@ FollowerEndpointList
 Endpoint
 				::= string_literals
 
--- StorageModeOption
 StorageModeOption
 						::= 'STORAGE_MODE' '=' StorageMode
 
@@ -446,13 +455,13 @@ StorageMode
 | 配置项            | 描述                                                                                                                                                               | 用法示例                                                                          |
 |----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
 | `PARTITIONNUM` | 配置表的分区数。OpenMLDB将表分为不同的分区块来存储。分区是OpenMLDB的存储、副本、以及故障恢复相关操作的基本单元。不显式配置时，`PARTITIONNUM`默认值为8。                                                                      | `OPTIONS (PARTITIONNUM=8)`                                                    |
-| `REPLICANUM`   | 配置表的副本数。请注意，副本数只有在Cluster OpenMLDB中才可以配置。                                                                                                                        | `OPTIONS (REPLICANUM=3)`                                                      |
-| `DISTRIBUTION` | 配置分布式的节点endpoint配置。一般包含一个Leader节点和若干follower节点。`(leader, [follower1, follower2, ..])`。不显式配置是，OpenMLDB会自动的根据环境和节点来配置`DISTRIBUTION`。                               | `DISTRIBUTION = [ ('127.0.0.1:6527', [ '127.0.0.1:6528','127.0.0.1:6529' ])]` |
-| `STORAGE_MODE` | 表的存储模式，支持的模式为`Memory`、`HDD`或`SSD`。不显式配置时，默认为`Memory`。<br/>如果需要支持非`Memory`模式的存储模式，`tablet`需要额外的配置选项，具体可参考[tablet配置文件 conf/tablet.flags](../../../deploy/conf.md)。 | `OPTIONS (STORAGE_MODE='HDD')`                                                |
+| `REPLICANUM`   | 配置表的副本数。请注意，副本数只有在集群版中才可以配置。                                                                                                                                     | `OPTIONS (REPLICANUM=3)`                                                      |
+| `DISTRIBUTION` | 配置分布式的节点endpoint。一般包含一个Leader节点和若干Follower节点。`(leader, [follower1, follower2, ..])`。不显式配置时，OpenMLDB会自动根据环境和节点来配置`DISTRIBUTION`。                                  | `DISTRIBUTION = [ ('127.0.0.1:6527', [ '127.0.0.1:6528','127.0.0.1:6529' ])]` |
+| `STORAGE_MODE` | 表的存储模式，支持的模式有`Memory`、`HDD`或`SSD`。不显式配置时，默认为`Memory`。<br/>如果需要支持非`Memory`模式的存储模式，`tablet`需要额外的配置选项，具体可参考[tablet配置文件 conf/tablet.flags](../../../deploy/conf.md)。 | `OPTIONS (STORAGE_MODE='HDD')`                                                |
 
 ##### 磁盘表（`STORAGE_MODE` == `HDD`|`SSD`）与内存表（`STORAGE_MODE` == `Memory`）区别
 - 目前磁盘表不支持GC操作
-- 磁盘表插入数据，同一个索引下如果（`key`, `ts`）相同，会覆盖老的数据；内存表则会插入一条新的数据
+- 磁盘表插入数据，同一个索引下如果（`key`, `ts`）相同，会覆盖旧的数据；内存表则会插入一条新的数据
 - 磁盘表不支持`addindex`和`deleteindex`操作，所以创建磁盘表的时候需要定义好所有需要的索引
 （`deploy`命令会自动添加需要的索引，所以对于磁盘表，如果创建的时候缺失对应的索引，则`deploy`会失败）
 

--- a/docs/zh/reference/sql/ddl/CREATE_TABLE_STATEMENT.md
+++ b/docs/zh/reference/sql/ddl/CREATE_TABLE_STATEMENT.md
@@ -445,7 +445,7 @@ StorageMode
 （`deploy`命令会自动添加需要的索引，所以对于磁盘表，如果创建的时候缺失对应的索引，则`deploy`会失败）
 
 ##### Example
-创建一张带表，配置分片数为8，副本数为3，存储模式为HDD
+创建一张表，配置分片数为8，副本数为3，存储模式为HDD
 ```sql
 USE db1;
 --SUCCEED: Database changed    

--- a/docs/zh/reference/sql/ddl/CREATE_TABLE_STATEMENT.md
+++ b/docs/zh/reference/sql/ddl/CREATE_TABLE_STATEMENT.md
@@ -177,13 +177,8 @@ ColumnIndex ::=
     'INDEX' <OptionalIndexName> '(' IndexOptionList ')' 
  
 IndexOptionList ::= 
-    IndexKeyOption ( ',' IndexOption )*
- 
-IndexKeyOption ::= 
-    'KEY' '=' ColumnNameList     
-ColumnNameList ::= 
-    '(' ColumnName (',' ColumnName)* ')'    
-    
+    IndexOption ( ',' IndexOption )*
+   
 IndexOption ::= 
     IndexOptionName '=' expr
 ```

--- a/docs/zh/reference/sql/ddl/CREATE_TABLE_STATEMENT.md
+++ b/docs/zh/reference/sql/ddl/CREATE_TABLE_STATEMENT.md
@@ -184,16 +184,14 @@ ColumnIndex ::=
     'INDEX' IndexName '(' IndexOptionList ')' 
  
 IndexOptionList ::= 
-    IndexKeyOption ( ',' IndexOption )*
- 
-IndexKeyOption ::= 
-    'KEY' '=' ColumnNameList     
-
+    IndexOption ( ',' IndexOption )*
+    
 ColumnNameList ::= 
     '(' ColumnName (',' ColumnName)* ')'    
     
 IndexOption ::= 
-    'TS' '=' ColumnName
+    'KEY' '=' ColumnNameList
+    |'TS' '=' ColumnName
     | 'TTL' '=' IndexTtlOption
     | 'TTL_TYPE' '=' TTLType
   

--- a/docs/zh/reference/sql/ddl/SHOW_TABLES_STATEMENT.md
+++ b/docs/zh/reference/sql/ddl/SHOW_TABLES_STATEMENT.md
@@ -10,16 +10,16 @@ SHOW TABLES;
 
 ```sql
 CREATE DATABASE db1;
---SUCCEED: Create database successfully
+--SUCCEED
 
 USE db1;
 --SUCCEED: Database changed
 
 CREATE TABLE t1(col0 STRING);
--- SUCCEED: Create successfully
+-- SUCCEED
 
 CREATE TABLE t2(col0 STRING);
--- SUCCEED: Create successfully
+-- SUCCEED
 
 SHOW TABLES;
  -------- 

--- a/docs/zh/reference/sql/dql/JOIN_CLAUSE.md
+++ b/docs/zh/reference/sql/dql/JOIN_CLAUSE.md
@@ -2,11 +2,12 @@
 
 OpenMLDB目前仅支持`LAST JOIN`一种**JoinType**。
 
-LAST JOIN可以看作一种特殊的LEFT JOIN。在满足JOIN条件的前提下，左表的每一行拼取一条符合条件的最后一行。LAST JOIN分为无排序拼接，和排序拼接。
+LAST JOIN可以看作一种特殊的LEFT JOIN。在满足JOIN条件的前提下，左表的每一行拼接符合条件的最后一行。LAST JOIN分为无排序拼接，和排序拼接。
 
 - 无排序拼接是指：未对右表作排序，直接拼接。
-- 排序拼接是指：在先对右表排序，然后再拼接。
-
+- 排序拼接是指：先对右表排序，然后再拼接。
+- 
+与LEFT JOIN相同，LAST JOIN也会返回左表中所有行，即使右表中没有匹配的行。
 ## Syntax
 
 ```
@@ -29,15 +30,9 @@ SELECT ... FROM table_ref LAST JOIN table_ref;
 
 ### LAST JOIN without ORDER BY
 
-#### Example: **LAST JOIN无排序拼接**
+#### Example1: **LAST JOIN无排序拼接**
 
-```sql
--- desc: 简单拼表查询 without ORDER BY
-
-SELECT t1.col1 as t1_col1, t2.col1 as t2_col2 from t1 LAST JOIN t2 ON t1.col1 = t2.col1
-```
-
-`LAST JOIN`无排序拼接时，拼接第一条命中的数据行
+`LAST JOIN`无排序拼接时，拼接最后一条命中的数据行。
 
 ![Figure 7: last join without order](../dql/images/last_join_without_order.png)
 
@@ -46,16 +41,100 @@ SELECT t1.col1 as t1_col1, t2.col1 as t2_col2 from t1 LAST JOIN t2 ON t1.col1 = 
 
 ![Figure 8: last join without order result](../dql/images/last_join_without_order2.png)
 
-最后的拼表结果如上图所示。
+最后的拼接结果如上图所示。
+##### OpenMLDB CLI执行示例
+启动单机版OpenMLDB服务端和CLI客户端
+```bash
+./init.sh standalone
+./openmldb/bin/openmldb --host 127.0.0.1 --port 6527
+```
+建立上述左表t1，插入数据。为了便于查看结果，在col1上建立单列索引，以std_ts作为TS。在本例中也可以不在左表上建立索引，不影响拼接结果。
+```sql
+>CREATE TABLE t1 (id INT, col1 STRING,std_ts TIMESTAMP,INDEX(KEY=col1,ts=std_ts));
+SUCCEED
+>INSERT INTO t1 values(1,'a',20200520101112);
+SUCCEED
+>INSERT INTO t1 values(2,'b',20200520101114);
+SUCCEED
+>INSERT INTO t1 values(3,'c',20200520101116);
+SUCCEED
+>SELECT * from t1;
+ ---- ------ ----------------
+  id   col1   std_ts
+ ---- ------ ----------------
+  1    a      20200520101112
+  2    b      20200520101114
+  3    c      20200520101116
+ ---- ------ ----------------
 
+3 rows in set
+```      
+
+建立上述右表t2，建立索引，插入数据。
+```{note}
+底层存储顺序不一定与插入顺序一致，而底层存储顺序会影响JOIN时的命中顺序。本例为了便于验证拼接结果，需要实现上图右表的存储顺序。t2必须建立下述索引（注意不能添加TS），且逐条按序插入数据，原因见[列索引](https://openmldb.ai/docs/zh/main/reference/sql/ddl/CREATE_TABLE_STATEMENT.html#columnindex)。
+```
+```sql
+>CREATE TABLE t2 (id INT, col1 string,std_ts TIMESTAMP,INDEX(KEY=col1));
+SUCCEED
+>INSERT INTO t2 values(1,'a',20200520101112);
+SUCCEED
+>INSERT INTO t2 values(2,'a',20200520101113);
+SUCCEED
+>INSERT INTO t2 values(3,'b',20200520101113);
+SUCCEED
+>INSERT INTO t2 values(4,'c',20200520101114);
+SUCCEED
+>INSERT INTO t2 values(5,'b',20200520101112);
+SUCCEED
+>INSERT INTO t2 values(6,'c',20200520101113);
+SUCCEED
+>SELECT * from t2;
+ ---- ------ ----------------
+  id   col1   std_ts
+ ---- ------ ----------------
+  2    a      20200520101113
+  1    a      20200520101112
+  5    b      20200520101112
+  3    b      20200520101113
+  6    c      20200520101113
+  4    c      20200520101114
+ ---- ------ ----------------
+
+6 rows in set
+```
+执行LAST JOIN
+```sql
+> SELECT * from t1 LAST JOIN t2 ON t1.col1 = t2.col1;
+ ---- ------ ---------------- ---- ------ ----------------
+  id   col1   std_ts           id   col1   std_ts
+ ---- ------ ---------------- ---- ------ ----------------
+  1    a      20200520101112   2    a      20200520101113
+  2    b      20200520101114   5    b      20200520101112
+  3    c      20200520101116   6    c      20200520101113
+ ---- ------ ---------------- ---- ------ ----------------
+
+3 rows in set
+```
+若不在t1上建立索引，拼接结果相同，仅SELECT展示顺序不同。
+```sql
+> SELECT * from t1 LAST JOIN t2 ON t1.col1 = t2.col1;
+ ---- ------ ---------------- ---- ------ ----------------
+  id   col1   std_ts           id   col1   std_ts
+ ---- ------ ---------------- ---- ------ ----------------
+  3    c      20200520101116   6    c      20200520101113
+  1    a      20200520101112   2    a      20200520101113
+  2    b      20200520101114   5    b      20200520101112
+ ---- ------ ---------------- ---- ------ ----------------
+
+3 rows in set
+```
+```{note}
+`LAST JOIN`使用了索引优化：使用`LAST JOIN` 的 condition 和 order by 列寻找最匹配的表索引；如果有index就会使用该index的ts项作为未排序last join隐式使用的order；反之没有index，就使用表的存储顺序。没有索引的表的底层存储顺序是不可预测的。请注意，在建表时若没有显示指出索引的ts项，OpenMLDB会使用该条数据被插入时的时间戳作为ts。
+```
 ### LAST JOIN with ORDER BY
 
-#### Example: LAST JOIN排序拼接 
-
-```SQL
--- desc: 简单拼表查询 with ORDER BY
-SELECT t1.col1 as t1_col1, t2.col1 as t2_col2 from t1 LAST JOIN t2 ORDER BY t2.std_ts ON t1.col1 = t2.col1
-```
+#### Example2: LAST JOIN排序拼接 
 
 `LAST JOIN`时配置 `Order By` ，则右表按Order排序，拼接最后一条命中的数据行。
 
@@ -66,3 +145,82 @@ SELECT t1.col1 as t1_col1, t2.col1 as t2_col2 from t1 LAST JOIN t2 ORDER BY t2.s
 ![Figure 10: last join with order result](../dql/images/last_join_with_order2.png)
 
 最后的拼表结果如上图所示。
+##### OpenMLDB CLI执行示例
+建立上述左表t1，插入数据。可以不建立索引。
+```SQL
+>CREATE TABLE t1 (id INT, col1 STRING,std_ts TIMESTAMP);
+SUCCEED
+>INSERT INTO t1 values(1,'a',20200520101112);
+SUCCEED
+>INSERT INTO t1 values(2,'b',20200520101114);
+SUCCEED
+>INSERT INTO t1 values(3,'c',20200520101116);
+SUCCEED
+>SELECT * from t1;
+ ---- ------ ----------------
+  id   col1   std_ts
+ ---- ------ ----------------
+  1    a      20200520101112
+  2    b      20200520101114
+  3    c      20200520101116
+ ---- ------ ----------------
+
+3 rows in set
+```
+建立上述右表t2，插入数据。可以不建立索引。
+```sql
+>CREATE TABLE t2 (id INT, col1 string,std_ts TIMESTAMP);
+SUCCEED
+>INSERT INTO t2 values(1,'a',20200520101112);
+SUCCEED
+>INSERT INTO t2 values(2,'a',20200520101113);
+SUCCEED
+>INSERT INTO t2 values(3,'b',20200520101113);
+SUCCEED
+>INSERT INTO t2 values(4,'c',20200520101114);
+SUCCEED
+>INSERT INTO t2 values(5,'b',20200520101112);
+SUCCEED
+>INSERT INTO t2 values(6,'c',20200520101113);
+SUCCEED
+>SELECT * from t2;
+ ---- ------ ----------------
+  id   col1   std_ts
+ ---- ------ ----------------
+  2    a      20200520101113
+  1    a      20200520101112
+  5    b      20200520101112
+  3    b      20200520101113
+  6    c      20200520101113
+  4    c      20200520101114
+ ---- ------ ----------------
+
+6 rows in set
+```
+执行LAST JOIN
+```sql
+>SELECT * from t1 LAST JOIN t2 ON t1.col1 = t2.col1;
+ ---- ------ ---------------- ---- ------ ----------------
+  id   col1   std_ts           id   col1   std_ts
+ ---- ------ ---------------- ---- ------ ----------------
+  1    a      20200520101112   2    a      20200520101113
+  2    b      20200520101114   3    b      20200520101113
+  3    c      20200520101116   4    c      20200520101114
+ ---- ------ ---------------- ---- ------ ----------------
+```
+
+#### Example3: LAST JOIN未命中
+在Example2中的t1表中插入新行并执行LAST JOIN
+```sql
+>INSERT INTO t1 values(4,'d',20220707111111);
+SUCCEED
+>SELECT * from t1 LAST JOIN t2 ORDER BY t2.std_ts ON t1.col1 = t2.col1;
+ ---- ------ ---------------- ------ ------ ----------------
+  id   col1   std_ts           id     col1   std_ts
+ ---- ------ ---------------- ------ ------ ----------------
+  4    d      20220707111111   NULL   NULL   NULL
+  3    c      20200520101116   4      c      20200520101114
+  1    a      20200520101112   2      a      20200520101113
+  2    b      20200520101114   3      b      20200520101113
+ ---- ------ ---------------- ------ ------ ----------------
+```


### PR DESCRIPTION

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
docs


* **What is the current behavior?** (You can also link to an open issue here)
there are no sql commands in docs/zh/reference/sql/dql/JOIN_CLAUSE.md
the grammar introduction block of ColumnIndex in docs/zh/reference/sql/ddl/CREATE_TABLE_STATEMENT.md are ambiguous

* **What is the new behavior (if this is a feature change)?**
added sql examples in JOIN_CLAUSE
completed the grammar introduction block of ColumnIndex
fixed other syntax errors
