### PR TITLE
docs: updated the supported execution mode of limit clause

### DIFF
--- a/docs/zh/reference/sql/dql/LIMIT_CLAUSE.md
+++ b/docs/zh/reference/sql/dql/LIMIT_CLAUSE.md
@@ -1,6 +1,6 @@
 # Limit Clause
 
-Limit 子句用于限制结果条数。OpenMLDB 目前仅支持Limit 接受一个参数，表示返回数据的最大行数；
+Limit子句用于限制返回的结果条数。目前Limit仅支持接受一个参数，表示返回数据的最大行数。
 
 ## Syntax
 
@@ -17,16 +17,15 @@ SELECT ... LIMIT ...
 
 ## 边界说明
 
-| SELECT语句元素 | 边界                 | 说明                                                         |
-| :------------- | -------------------- | :----------------------------------------------------------- |
-| LIMIT Clause   | 不支持Online Serving | Limit 子句用于限制结果条数。OpenMLDB 目前仅支持Limit 接受一个参数，表示返回数据的最大行数； |
+| SELECT语句元素 | 边界 | 说明                                                         |
+| :------------- |--| :----------------------------------------------------------- |
+| LIMIT Clause   | 单机版和集群版的所有执行模式均支持 | Limit 子句用于限制返回的结果条数。目前Limit仅支持接受一个参数，表示返回数据的最大行数。 |
 
 ## Example
 
 ### SELECT with LIMIT
 
 ```SQL
--- desc: SELECT Limit
-  SELECT t1.COL1 c1 FROM t1 limit 10;
+>SELECT t1.COL1 c1 FROM t1 limit 10;
 ```
 

--- a/docs/zh/reference/sql/dql/LIMIT_CLAUSE.md
+++ b/docs/zh/reference/sql/dql/LIMIT_CLAUSE.md
@@ -26,6 +26,6 @@ SELECT ... LIMIT ...
 ### SELECT with LIMIT
 
 ```SQL
->SELECT t1.COL1 c1 FROM t1 limit 10;
+SELECT t1.COL1 c1 FROM t1 limit 10;
 ```
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
docs


* **What is the current behavior?** (You can also link to an open issue here)
there are some Chinese syntax errors like line 3
the execution modes which supported LIMIT are outdated
* **What is the new behavior (if this is a feature change)?**
updated the supported execution mode of LIMIT clause
fixed syntax srrors
