### PR TITLE
docs: fixed some syntax errors in zh and sql command

### DIFF
--- a/docs/zh/reference/sql/dql/NO_TABLE_SELECT_CLAUSE.md
+++ b/docs/zh/reference/sql/dql/NO_TABLE_SELECT_CLAUSE.md
@@ -23,8 +23,8 @@ SELECT const_expr [, const_expr ...];
 ## 2. SELECT语句元素
 
 | SELECT语句元素 | 状态                | 说明                                                         |
-| :------------- | ------------------- | :----------------------------------------------------------- |
-| 无标SELECT语句 | OnlineServing不支持 | 无表Select语句计算常量表达式操作列表，表达式计算不需要依赖表和列 |
+|:-----------| ------------------- | :----------------------------------------------------------- |
+| 无表SELECT语句 | OnlineServing不支持 | 无表Select语句计算常量表达式操作列表，表达式计算不需要依赖表和列 |
 
 #### Examples
 
@@ -32,7 +32,7 @@ SELECT const_expr [, const_expr ...];
 -- desc: SELECT 常量字面量
 SELECT 1, 1L, 1.0f, 2.0, 'Hello';
 -- desc: SELECT 常量表达式
-SELECT 1+1， 1L + 1L, 1.0f - 1.0f, 2.0*2.0, 'Hello' LIKE 'He%';
+SELECT 1+1, 1L + 1L, 1.0f - 1.0f, 2.0*2.0, 'Hello' LIKE 'He%';
 -- desc: SELECT 函数表达式
 SELECT substr("hello world", 3, 6);
 ```


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
docs


* **What is the current behavior?** (You can also link to an open issue here)
there are Chinese syntax errors like:无标select语句，line 27
the '`,`'  of sql sommand in line 35 should be En version but now is Chinese version

* **What is the new behavior (if this is a feature change)?**
above questions have been solved
