### PR TITLE
docs: fixed the error that index of en/reference didn't show

### DIFF
--- a/docs/en/reference/index.rst
+++ b/docs/en/reference/index.rst
@@ -2,8 +2,10 @@
 References
 =============================
 
+
 .. toctree::
     :maxdepth: 1
+
     rest_api
     arch/index
     sql/index


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
docs
* **What is the current behavior?** (You can also link to an open issue here)
the subdirectory of en/reference didn't show now


* **What is the new behavior (if this is a feature change)?**
fixed the problem by changing format in docs/en/reference/index.rst 
