### PR TITLE
feat(api-server): return result set for the new query api

### DIFF
--- a/src/apiserver/api_server_impl.cc
+++ b/src/apiserver/api_server_impl.cc
@@ -137,11 +137,16 @@ void APIServerImpl::RegisterQuery() {
                        // TODO(hw): if sql is not a query, it may be a ddl, we use ExecuteSQL to execute it before we
                        //  supports ddl http api. It's useful for api server tests(We can create table when we only
                        //  connect to the api server).
-                       sql_router_->ExecuteSQL(db, sql, ctx.is_online, ctx.is_sync, ctx.job_timeout, &status);
-                       writer << resp.Set(status.code, status.msg);
+                       auto rs = sql_router_->ExecuteSQL(db, sql, ctx.is_online, ctx.is_sync, ctx.job_timeout, &status);
                        if (!status.IsOK()) {
+                           writer << resp.Set(status.code, status.msg);
                            LOG(WARNING) << "failed at: code " << status.code << ", msg " << status.msg;
+                           return;
                        }
+
+                       QueryResp query_resp;
+                       query_resp.rs = rs;
+                       writer << query_resp;
                    });
 }
 
@@ -946,6 +951,28 @@ JsonWriter& operator&(JsonWriter& ar, std::shared_ptr<::openmldb::nameserver::Ta
     ar.EndArray();
 
     ar.Member("schema_versions") & info->schema_versions();
+
+    return ar.EndObject();
+}
+
+JsonWriter& operator&(JsonWriter& ar, QueryResp& s) {  // NOLINT
+    ar.StartObject();
+    ar.Member("code") & s.code;
+    ar.Member("msg") & s.msg;
+
+    ar.Member("data");
+    ar.StartArray();
+    auto& rs = s.rs;
+    rs->Reset();
+    auto& schema = *rs->GetSchema();
+    while (rs->Next()) {
+        ar.StartArray();
+        for (decltype(schema.GetColumnCnt()) i = 0; i < schema.GetColumnCnt(); i++) {
+            WriteValue(ar, rs, i);
+        }
+        ar.EndArray();
+    }
+    ar.EndArray();
 
     return ar.EndObject();
 }

--- a/src/apiserver/api_server_impl.h
+++ b/src/apiserver/api_server_impl.h
@@ -131,6 +131,15 @@ JsonWriter& operator&(JsonWriter& ar,  // NOLINT
 
 JsonWriter& operator&(JsonWriter& ar, std::shared_ptr<::openmldb::nameserver::TableInfo> info);  // NOLINT
 
+struct QueryResp {
+    QueryResp() = default;
+    int code = 0;
+    std::string msg = "ok";
+    std::shared_ptr<hybridse::sdk::ResultSet> rs;
+};
+
+JsonWriter& operator&(JsonWriter& ar, QueryResp& s); // NOLINT
+
 }  // namespace apiserver
 }  // namespace openmldb
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

close #2127 

* **What is the current behavior?** (You can also link to an open issue here)

`POST /dbs/:db_name` only return "code" and "msg"

* **What is the new behavior (if this is a feature change)?**

return query result like
```json
{ "code": 0, "msg": "ok", "data": [[1, "bb"]] }
```