### PR TITLE
docs: fixed duplicate table name and the link at the last part of use_db clause

### DIFF
--- a/docs/zh/reference/sql/ddl/USE_DATABASE_STATEMENT.md
+++ b/docs/zh/reference/sql/ddl/USE_DATABASE_STATEMENT.md
@@ -24,10 +24,10 @@ USE database_name;
 
 ```sql
 CREATE DATABASE db1;
--- SUCCEED: Create database successfully
+-- SUCCEED
 
 CREATE DATABASE db2;
--- SUCCEED: Create database successfully
+-- SUCCEED
 ```
 
 然后选择`db1`作为当前数据库：
@@ -41,18 +41,20 @@ USE db1;
 
 ```sql
 CREATE TABLE t1(col0 string);
--- SUCCEED: Create successfully
+-- SUCCEED
 
-CREATE TABLE t1(col0 string);
--- SUCCEED: Create successfully
+CREATE TABLE t2(col0 string);
+-- SUCCEED
 
 SHOW TABLES;
- -------- 
-  Tables  
- -------- 
-  t1      
-  t2      
- -------- 
+ --------
+  Tables
+ --------
+  t1
+  t2
+ --------
+
+2 rows in set
 ```
 
 然后选择`db2`作为当前数据库，并查看当前库下的表：
@@ -72,6 +74,6 @@ SHOW TABLES;
 
 [DROP DATABASE](./DROP_DATABASE_STATEMENT.md)
 
-[SHOW DATABASES](./SHOW_STATEMENT.md#show-databases)
+[SHOW DATABASES](./SHOW_DATABASES_STATEMENT.md)
 
-[SHOW TABLES](./SHOW_STATEMENT.md#show-tables)
+[SHOW TABLES](./SHOW_TABLES_STATEMENT.md)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
docs


* **What is the current behavior?** (You can also link to an open issue here)
the table name on line 46 are duplicate, which will cause error when running this command
two links at the last part of this doc didn't work 
* **What is the new behavior (if this is a feature change)?**
fixed above problems
and update newest execution results
