### PR TITLE
ci: rm thirdparty cache step in `python-sdk-macos`

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,7 +37,7 @@ jobs:
       TESTING_ENABLE: ON
       SQL_PYSDK_ENABLE: OFF
       SQL_JAVASDK_ENABLE: OFF
-      NPROC: 8
+      NPROC: 2
       BUILD_SHARED_LIBS: ON
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -143,7 +143,7 @@ jobs:
     # mac job for java sdk. steps are almost same with job 'java-sdk'
     # except mvn deploy won't target all modules, just hybridse-native & openmldb-native
     # the job only run on tag push or manual workflow dispatch due to no test runs
-    runs-on: macos-12
+    runs-on: macos-latest
     needs:
       - java-sdk
     if: github.event_name == 'push'
@@ -293,14 +293,6 @@ jobs:
       OPENMLDB_BUILD_TARGET: 'cp_python_sdk_so openmldb'
     steps:
       - uses: actions/checkout@v3
-
-      - name: Cache thirdparty
-        uses: actions/cache@v3
-        with:
-          path: |
-            .deps/
-            thirdsrc
-          key: ${{ runner.os }}-thirdparty-${{ hashFiles('third-party/**/CMakeLists.txt', 'third-party/**/*.cmake', 'third-party/**/*.sh') }}
 
       - name: prepare release
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -143,7 +143,7 @@ jobs:
     # mac job for java sdk. steps are almost same with job 'java-sdk'
     # except mvn deploy won't target all modules, just hybridse-native & openmldb-native
     # the job only run on tag push or manual workflow dispatch due to no test runs
-    runs-on: macos-latest
+    runs-on: macos-12
     needs:
       - java-sdk
     if: github.event_name == 'push'


### PR DESCRIPTION
release workflow will fail between `java-sdk-macos` and `python-sdk-macos` job, refer https://github.com/4paradigm/OpenMLDB/actions/runs/2716694385/attempts/10. 

The reason is the thirdparty macos cache which was cached both in `java-sdk-macos` and `python-sdk-macos` with exact same key, is actually from different macos version ( macos-11 vs macs-12). The two system have different toolsets like gcc version, thirdparty cache also include CMakeCache.txt ( with the gcc path). So build fail to due gcc path not found.

```

CMake Error at CMakeLists.txt:16 (project):
  The CMAKE_C_COMPILER:
    /Applications/Xcode_13.4.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc
  is not a full path to an existing compiler tool.
  Tell CMake where to find the compiler by setting either the environment
  variable "CC" or the CMake cache entry CMAKE_C_COMPILER to the full path to
  the compiler, or to the compiler name if it is in the PATH.
CMake Error at CMakeLists.txt:16 (project):
  The CMAKE_CXX_COMPILER:
    /Applications/Xcode_13.4.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++
  is not a full path to an existing compiler tool.
  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.
```

## The solution

Since `python-sdk-macos` job only runs over release workflow, cache is not useful so much. I just remove the cache step.