### PR TITLE
ci: rm thirdparty cache step in `python-sdk-macos` (#2228)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,7 +37,7 @@ jobs:
       TESTING_ENABLE: ON
       SQL_PYSDK_ENABLE: OFF
       SQL_JAVASDK_ENABLE: OFF
-      NPROC: 8
+      NPROC: 2
       BUILD_SHARED_LIBS: ON
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -302,14 +302,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Cache thirdparty
-        uses: actions/cache@v3
-        with:
-          path: |
-            .deps/
-            thirdsrc
-          key: ${{ runner.os }}-thirdparty-${{ hashFiles('third-party/**/CMakeLists.txt', 'third-party/**/*.cmake', 'third-party/**/*.sh') }}
-
       - name: prepare release
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |


### PR DESCRIPTION
- resolve java sdk macos job fail
- resolve coverage job fail
