### PR TITLE
fix(#2211): disable window merge for rows/rows_range window if both

### DIFF
--- a/cases/function/window/window_attributes.yaml
+++ b/cases/function/window/window_attributes.yaml
@@ -531,3 +531,31 @@ cases:
          7, 2, 99, 0, 99
          8, 3, 99, 0, 56
          9, 3, 99, 52, 52
+  - id: 10
+    desc: rows and rows_range window won't merge if both exclude_current_row
+    inputs:
+      - columns: [ "c1 string","c3 int","c4 bigint","c5 float","c6 double","c7 timestamp","c8 date" ]
+        indexs: [ "index1:c1:c7" ]
+        rows:
+          - [ "aa",20,30,1.1,2.1,1590738990000,"2020-05-01" ]
+          - [ "aa",21,31,1.2,2.2,1590738991000,"2020-05-02" ]
+          - [ "aa",22,32,1.3,2.3,1590738992000,"2020-05-03" ]
+          - [ "aa",23,33,1.4,2.4,1590738993000,"2020-05-04" ]
+          - [ "bb",24,34,1.5,2.5,1590738994000,"2020-05-05" ]
+    sql: |
+      SELECT
+        c1, c3,
+        sum(c4) OVER w1 as w1_c4_sum,
+        count(c5) OVER w2 as w2_c5_count FROM {0}
+      WINDOW
+        w1 AS (PARTITION BY {0}.c1 ORDER BY {0}.c7 ROWS BETWEEN 2 PRECEDING AND CURRENT ROW EXCLUDE CURRENT_ROW),
+        w2 AS (PARTITION BY {0}.c1 ORDER BY {0}.c7 ROWS_RANGE BETWEEN 2s PRECEDING AND CURRENT ROW EXCLUDE CURRENT_ROW);
+    expect:
+      order: c3
+      columns: [ "c1 string","c3 int","w1_c4_sum bigint","w2_c5_count bigint" ]
+      rows:
+        - [ "aa",20,null,0 ]
+        - [ "aa",21,30,1 ]
+        - [ "aa",22,61,2 ]
+        - [ "aa",23,63,2 ]
+        - [ "bb",24,null,0 ]


### PR DESCRIPTION
close #2211

## Root cause

rows window and rows_range window can be merged in a query, result in a inner only window type ( `RowsMergeRowsRange` window), this type of window for `exclude current_row` is not handled in physical plan, neither by codegen or runner.

## Solution

I'm not going to fix it in runner and codegen yet, so this resolve the correctness issue by disable window merge for the too window, if both set `exclude current_row`