### PR TITLE
fix: #2235 enable trace

### DIFF
--- a/hybridse/include/sdk/base.h
+++ b/hybridse/include/sdk/base.h
@@ -18,10 +18,14 @@
 #define HYBRIDSE_INCLUDE_SDK_BASE_H_
 
 #include <stdint.h>
+
 #include <memory>
+#include <ostream>
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
+
+#include "absl/strings/string_view.h"
 
 namespace hybridse {
 namespace sdk {
@@ -30,10 +34,13 @@ struct Status {
     Status() : code(0), msg("ok") {}
     Status(int status_code, const std::string& msg_str)
         : code(status_code), msg(msg_str) {}
+    Status(int status_code, absl::string_view msg_str, absl::string_view trace)
+        : code(status_code), msg(msg_str), trace(trace) {}
     bool IsOK() const { return code == 0; }
+
     int code;
-    std::string trace;
     std::string msg;
+    std::string trace;
 };
 
 enum DataType {

--- a/src/cmd/sql_cmd.h
+++ b/src/cmd/sql_cmd.h
@@ -126,7 +126,8 @@ void HandleSQL(const std::string& sql) {
     } else {
         std::cout << "Error: " << status.msg << std::endl;
         if (sr->IsEnableTrace()) {
-            std::cout << status.trace << std::endl;
+            // trace has '\n' already
+            std::cout << status.trace;
         }
     }
 }

--- a/src/cmd/sql_cmd.h
+++ b/src/cmd/sql_cmd.h
@@ -125,6 +125,9 @@ void HandleSQL(const std::string& sql) {
         }
     } else {
         std::cout << "Error: " << status.msg << std::endl;
+        if (sr->IsEnableTrace()) {
+            std::cout << status.trace << std::endl;
+        }
     }
 }
 


### PR DESCRIPTION
close #2235 

when `set @@enable_trace = 'true';`, should work for 
- sql query 
- deploy
- select into

For any other cmd, interface is ready, whether it prints trace depends on implementation, fix it just by putting info into `status.trace`