### PR TITLE
fix: add `tid` and `pid` to `RollWLogFile` log message

### DIFF
--- a/src/replica/log_replicator.cc
+++ b/src/replica/log_replicator.cc
@@ -477,7 +477,7 @@ bool LogReplicator::RollWLogFile() {
     uint64_t offset = log_offset_.load(std::memory_order_relaxed);
     logs_->Insert(binlog_index_.load(std::memory_order_relaxed), offset);
     binlog_index_.fetch_add(1, std::memory_order_relaxed);
-    PDLOG(INFO, "roll write log for name %s and start offset %lld", name.c_str(), offset);
+    PDLOG(INFO, "roll write log for name %s and start offset %lld. tid %u pid %u", name.c_str(), offset, tid_, pid_);
     wh_ = new WriteHandle("off", name, fd);
     return true;
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
* Added tid and pid to RollWLogFile log message.

* **What is the current behavior?** (You can also link to an open issue here)
* it won't log the It the tid And pid 

* **What is the new behavior (if this is a feature change)?**
* It Will Also log the tid And pid 

