### PR TITLE
Add the delete interface with the specified timestamp to the tablet

### DIFF
--- a/src/client/tablet_client.cc
+++ b/src/client/tablet_client.cc
@@ -833,6 +833,30 @@ bool TabletClient::Delete(uint32_t tid, uint32_t pid, const std::string& pk, con
     request.set_tid(tid);
     request.set_pid(pid);
     request.set_key(pk);
+    request.set_ts(0);
+    if (!idx_name.empty()) {
+        request.set_idx_name(idx_name);
+    }
+    bool ok = client_.SendRequest(&::openmldb::api::TabletServer_Stub::Delete, &request, &response,
+                                  FLAGS_request_timeout_ms, 1);
+    if (response.has_msg()) {
+        msg = response.msg();
+    }
+    if (!ok || response.code() != 0) {
+        return false;
+    }
+    return true;
+}
+
+bool TabletClient::Delete(uint32_t tid, uint32_t pid, const std::string& pk, const std::string& idx_name,
+                          uint64_t& ts,
+                          std::string& msg) {
+    ::openmldb::api::DeleteRequest request;
+    ::openmldb::api::GeneralResponse response;
+    request.set_tid(tid);
+    request.set_pid(pid);
+    request.set_key(pk);
+    request.set_ts(ts);
     if (!idx_name.empty()) {
         request.set_idx_name(idx_name);
     }

--- a/src/client/tablet_client.h
+++ b/src/client/tablet_client.h
@@ -95,6 +95,10 @@ class TabletClient : public Client {
     bool Delete(uint32_t tid, uint32_t pid, const std::string& pk, const std::string& idx_name,
                 std::string& msg);  // NOLINT
 
+    bool Delete(uint32_t tid, uint32_t pid, const std::string& pk, const std::string& idx_name,
+                uint64_t& ts,           // NOLINT
+                std::string& msg);      // NOLINT
+
     bool Count(uint32_t tid, uint32_t pid, const std::string& pk, const std::string& idx_name, bool filter_expired_data,
                uint64_t& value, std::string& msg);  // NOLINT
 

--- a/src/proto/tablet.proto
+++ b/src/proto/tablet.proto
@@ -195,6 +195,7 @@ message DeleteRequest {
     optional uint32 pid = 2;
     optional string key = 3;
     optional string idx_name = 4;
+    optional uint64 ts = 5;
 }
 
 message ExecuteGcRequest {

--- a/src/proto/tablet.proto
+++ b/src/proto/tablet.proto
@@ -195,7 +195,7 @@ message DeleteRequest {
     optional uint32 pid = 2;
     optional string key = 3;
     optional string idx_name = 4;
-    optional uint64 ts = 5;
+    optional uint64 ts = 5 [default = 0];   // 0 for all records of key
 }
 
 message ExecuteGcRequest {

--- a/src/storage/disk_table.cc
+++ b/src/storage/disk_table.cc
@@ -299,6 +299,44 @@ bool DiskTable::Delete(const std::string& pk, uint32_t idx) {
     }
 }
 
+bool DiskTable::Delete(const std::string& pk, uint32_t idx, uint64_t time) {
+    rocksdb::WriteBatch batch;
+    std::shared_ptr<IndexDef> index_def = table_index_.GetIndex(idx);
+    if (!index_def) {
+        return false;
+    }
+    auto inner_index = table_index_.GetInnerIndex(index_def->GetInnerPos());
+    if (inner_index && inner_index->GetIndex().size() > 1) {
+        const auto& indexs = inner_index->GetIndex();
+        for (const auto& index : indexs) {
+            auto ts_col = index->GetTsColumn();
+            if (!ts_col) {
+                return false;
+            }
+            uint64_t ts = 0;
+            std::string combine_key;
+            if (inner_index->GetIndex().size() > 1) {
+                combine_key = CombineKeyTs(pk, ts, ts_col->GetId());
+            } else {
+                combine_key = CombineKeyTs(pk, ts);
+            }
+            rocksdb::Slice spk = rocksdb::Slice(combine_key);
+            batch.Delete(cf_hs_[idx + 1], spk);
+        }
+    } else {
+        std::string combine_key = CombineKeyTs(pk, time);
+        batch.Delete(cf_hs_[idx + 1], rocksdb::Slice(combine_key));
+    }
+    rocksdb::Status s = db_->Write(write_opts_, &batch);
+    if (s.ok()) {
+        offset_.fetch_add(1, std::memory_order_relaxed);
+        return true;
+    } else {
+        DEBUGLOG("Delete failed. tid %u pid %u time %lu msg %s", id_, pid_, time, s.ToString().c_str());
+        return false;
+    }
+}
+
 bool DiskTable::Get(uint32_t idx, const std::string& pk, uint64_t ts, std::string& value) {
     Ticket ticket;
     auto it = NewIterator(idx, pk, ticket);

--- a/src/storage/disk_table.h
+++ b/src/storage/disk_table.h
@@ -376,6 +376,8 @@ class DiskTable : public Table {
 
     bool Delete(const std::string& pk, uint32_t idx) override;
 
+    bool Delete(const std::string& pk, uint32_t idx, uint64_t time) override;
+
     uint64_t GetExpireTime(const TTLSt& ttl_st) override;
 
     uint64_t GetRecordCnt() const override {

--- a/src/storage/mem_table.cc
+++ b/src/storage/mem_table.cc
@@ -234,6 +234,21 @@ bool MemTable::Delete(const std::string& pk, uint32_t idx) {
     return segment->Delete(spk);
 }
 
+bool MemTable::Delete(const std::string& pk, uint32_t idx, uint64_t ts) {
+    std::shared_ptr<IndexDef> index_def = GetIndex(idx);
+    if (!index_def || !index_def->IsReady()) {
+        return false;
+    }
+    Slice spk(pk);
+    uint32_t seg_idx = 0;
+    if (seg_cnt_ > 1) {
+        seg_idx = ::openmldb::base::hash(spk.data(), spk.size(), SEED) % seg_cnt_;
+    }
+    uint32_t real_idx = index_def->GetInnerPos();
+    Segment* segment = segments_[real_idx][seg_idx];
+    return segment->Delete(pk, idx, ts);
+}
+
 uint64_t MemTable::Release() {
     if (segment_released_) {
         return 0;

--- a/src/storage/mem_table.cc
+++ b/src/storage/mem_table.cc
@@ -235,6 +235,9 @@ bool MemTable::Delete(const std::string& pk, uint32_t idx) {
 }
 
 bool MemTable::Delete(const std::string& pk, uint32_t idx, uint64_t ts) {
+    if (ts == 0) {
+        return Delete(pk, idx);
+    }
     std::shared_ptr<IndexDef> index_def = GetIndex(idx);
     if (!index_def || !index_def->IsReady()) {
         return false;

--- a/src/storage/mem_table.h
+++ b/src/storage/mem_table.h
@@ -169,6 +169,8 @@ class MemTable : public Table {
 
     bool Delete(const std::string& pk, uint32_t idx) override;
 
+    bool Delete(const std::string& pk, uint32_t idx, uint64_t time) override;
+
     // use the first demission
     TableIterator* NewIterator(const std::string& pk, Ticket& ticket) override;
 

--- a/src/storage/segment.cc
+++ b/src/storage/segment.cc
@@ -447,7 +447,7 @@ void Segment::FreeEntry(::openmldb::base::Node<Slice, void*>* entry_node,
     if (ts_entry_node != NULL) {
         delete ts_entry_node->GetValue();
         uint64_t byte_size = GetRecordPkIdxSize(ts_entry_node->Height(), sizeof(uint64_t), key_entry_max_height_);
-        idx_byte_size_.fetch_sub(byte_size, std::memory_order_relaxed);
+        //idx_byte_size_.fetch_sub(byte_size, std::memory_order_relaxed);
     }
 }
 

--- a/src/storage/segment.h
+++ b/src/storage/segment.h
@@ -170,6 +170,10 @@ class Segment {
 
     bool Delete(const Slice& key);
 
+    bool Delete(const Slice& key, uint64_t time, DataBlock** block);
+
+    bool Delete(const Slice& key, uint32_t idx, const uint64_t time);
+
     uint64_t Release();
 
     void ExecuteGc(const TTLSt& ttl_st, uint64_t& gc_idx_cnt,                          // NOLINT

--- a/src/storage/segment.h
+++ b/src/storage/segment.h
@@ -144,6 +144,7 @@ struct SliceComparator {
 
 typedef ::openmldb::base::Skiplist<::openmldb::base::Slice, void*, SliceComparator> KeyEntries;
 typedef ::openmldb::base::Skiplist<uint64_t, ::openmldb::base::Node<Slice, void*>*, TimeComparator> KeyEntryNodeList;
+typedef ::openmldb::base::Skiplist<uint64_t, ::openmldb::base::Node<uint64_t, DataBlock*>*, TimeComparator> KeyTsEntryNodeList;
 
 class Segment {
  public:
@@ -258,7 +259,9 @@ class Segment {
     void GcEntryFreeList(uint64_t version, uint64_t& gc_idx_cnt,  // NOLINT
                          uint64_t& gc_record_cnt,                 // NOLINT
                          uint64_t& gc_record_byte_size);          // NOLINT
-    void FreeEntry(::openmldb::base::Node<Slice, void*>* entry_node, uint64_t& gc_idx_cnt,  // NOLINT
+    void FreeEntry(::openmldb::base::Node<Slice, void*>* entry_node,  // NOLINT
+                   ::openmldb::base::Node<uint64_t, DataBlock*>* ts_entry_node,             // NOLINT
+                   uint64_t& gc_idx_cnt,            // NOLINT
                    uint64_t& gc_record_cnt,         // NOLINT
                    uint64_t& gc_record_byte_size);  // NOLINT
 
@@ -272,6 +275,7 @@ class Segment {
     std::atomic<uint64_t> pk_cnt_;
     uint8_t key_entry_max_height_;
     KeyEntryNodeList* entry_free_list_;
+    KeyTsEntryNodeList* ts_entry_free_list_;
     uint32_t ts_cnt_;
     std::atomic<uint64_t> gc_version_;
     std::map<uint32_t, uint32_t> ts_idx_map_;

--- a/src/storage/table.h
+++ b/src/storage/table.h
@@ -59,6 +59,8 @@ class Table {
 
     virtual bool Delete(const std::string& pk, uint32_t idx) = 0;
 
+    virtual bool Delete(const std::string& pk, uint32_t idx, uint64_t time) = 0;
+
     virtual TableIterator* NewIterator(const std::string& pk,
                                        Ticket& ticket) = 0;  // NOLINT
 

--- a/src/tablet/tablet_impl.cc
+++ b/src/tablet/tablet_impl.cc
@@ -1546,7 +1546,7 @@ void TabletImpl::Delete(RpcController* controller, const ::openmldb::api::Delete
         }
         idx = index_def->GetId();
     }
-    if (table->Delete(request->key(), idx)) {
+    if (table->Delete(request->key(), idx, request->ts())) {
         response->set_code(::openmldb::base::ReturnCode::kOk);
         response->set_msg("ok");
         DEBUGLOG("delete ok. tid %u, pid %u, key %s", request->tid(), request->pid(), request->key().c_str());


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
In the distributed scenario, write failure will lead to inconsistent data on different tablets


* **What is the new behavior (if this is a feature change)?**
All tablets can roll back the data that failed to be written to ensure that the data of each tablet is consistent
