### PR TITLE
fix: taskmanager start failed

### DIFF
--- a/demo/init.sh
+++ b/demo/init.sh
@@ -29,6 +29,7 @@ set -e
 rm -rf /tmp/openmldb_offline_storage/*
 rm -rf /work/openmldb/logs*
 rm -rf /work/openmldb/db*
+rm -rf /work/openmldb/taskmanager/bin/logs
 sleep 2
 echo "Starting openmldb in $MODE mode..."
 if [[ "$MODE" = "standalone" ]]; then

--- a/release/bin/start.sh
+++ b/release/bin/start.sh
@@ -95,6 +95,7 @@ case $OP in
                 cp ./conf/taskmanager.properties ./taskmanager/conf/taskmanager.properties
             fi
             pushd ./taskmanager/bin/ > /dev/null
+            mkdir -p logs
             sh ./taskmanager.sh > logs/taskmanager.out 2>&1 &
             PID=$!
             popd > /dev/null 


### PR DESCRIPTION
`TaskManager` start failed because there is no `logs` dirs when execute startup command