### PR TITLE
feat: reduce one memory copy for unsaferow window project

### DIFF
--- a/hybridse/src/vm/core_api.cc
+++ b/hybridse/src/vm/core_api.cc
@@ -355,9 +355,8 @@ hybridse::codec::Row CoreAPI::UnsafeWindowProjectBytes(
         hybridse::vm::ByteArrayPtr unsaferowBytes,
         const int unsaferowSize, const bool is_instance, size_t append_slices,
         WindowInterface* window) {
-
     auto actualRowSize = unsaferowSize + codec::HEADER_LENGTH;
-    int8_t* newRowPtr = (int8_t*) malloc(actualRowSize);
+    int8_t* newRowPtr = reinterpret_cast<int8_t*>(malloc(actualRowSize));
 
     // Write the row size
     *reinterpret_cast<uint32_t *>(newRowPtr) = actualRowSize;

--- a/hybridse/src/vm/core_api.cc
+++ b/hybridse/src/vm/core_api.cc
@@ -350,6 +350,26 @@ hybridse::codec::Row CoreAPI::UnsafeWindowProjectDirect(
                                  window->GetWindow());
 }
 
+hybridse::codec::Row CoreAPI::UnsafeWindowProjectBytes(
+        const RawPtrHandle fn, const uint64_t key,
+        hybridse::vm::ByteArrayPtr unsaferowBytes,
+        const int unsaferowSize, const bool is_instance, size_t append_slices,
+        WindowInterface* window) {
+
+    auto actualRowSize = unsaferowSize + codec::HEADER_LENGTH;
+    int8_t* newRowPtr = (int8_t*) malloc(actualRowSize);
+
+    // Write the row size
+    *reinterpret_cast<uint32_t *>(newRowPtr) = actualRowSize;
+
+    // Write the UnsafeRow bytes
+    memcpy(newRowPtr + codec::HEADER_LENGTH, unsaferowBytes, unsaferowSize);
+    auto row = Row(base::RefCountedSlice::CreateManaged(newRowPtr, actualRowSize));
+
+    return Runner::WindowProject(fn, key, row, Row(), is_instance, append_slices,
+                                 window->GetWindow());
+}
+
 hybridse::codec::Row CoreAPI::GroupbyProject(
     const RawPtrHandle fn, hybridse::vm::GroupbyInterface* groupby_interface) {
     return Runner::GroupbyProject(fn, Row(), groupby_interface->GetTableHandler());

--- a/hybridse/src/vm/core_api.h
+++ b/hybridse/src/vm/core_api.h
@@ -170,6 +170,12 @@ class CoreAPI {
             const int inputRowSizeInBytes, const bool is_instance,
             size_t append_slices, WindowInterface* window);
 
+    static hybridse::codec::Row UnsafeWindowProjectBytes(
+            const hybridse::vm::RawPtrHandle fn, const uint64_t key,
+            hybridse::vm::ByteArrayPtr unsaferowBytes,
+            const int unsaferowSize, const bool is_instance,
+            size_t append_slices, WindowInterface* window);
+
     static hybridse::codec::Row WindowProject(
         const hybridse::vm::RawPtrHandle fn, const uint64_t key, const Row& row,
         WindowInterface* window);

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/window/WindowComputer.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/window/WindowComputer.scala
@@ -152,12 +152,17 @@ class WindowComputer(config: WindowAggConfig, jit: HybridSeJitWrapper, keepIndex
     //  CoreAPI.UnsafeWindowProject(fn, key, hybridseRowBytes, hybridseRowBytes.length, true, appendSlices, window)
 
     // Create native method input from Spark InternalRow
-    val hybridseRowBytes = UnsafeRowUtil.internalRowToHybridseByteBuffer(internalRow)
-    val byteBufferSize = UnsafeRowUtil.getHybridseByteBufferSize(internalRow)
+    //val hybridseRowBytes = UnsafeRowUtil.internalRowToHybridseByteBuffer(internalRow)
+    //val byteBufferSize = UnsafeRowUtil.getHybridseByteBufferSize(internalRow)
+    // Call native method to compute which will copy the byte array again
+    //val outputHybridseRow  =
+    //  CoreAPI.UnsafeWindowProjectDirect(fn, key, hybridseRowBytes, byteBufferSize, true, appendSlices, window)
 
-    // Call native method to compute
+    // Pass the UnsafeRow bytes directly and copy bytes in C API
+    val inputRowBytes = inputUnsaferow.getBytes
+    val inputRowSize = inputRowBytes.size
     val outputHybridseRow  =
-      CoreAPI.UnsafeWindowProjectDirect(fn, key, hybridseRowBytes, byteBufferSize, true, appendSlices, window)
+      CoreAPI.UnsafeWindowProjectBytes(fn, key, inputRowBytes, inputRowSize, true, appendSlices, window)
 
     // TODO: Support append slice in JIT function instead of merge in offline
     val outputInternalRowWithAppend =  if (appendSlices > 0 && enableUnsafeRowFormat) {


### PR DESCRIPTION
* Resolve https://github.com/4paradigm/OpenMLDB/issues/2303 and improve performance by reducing one memory copy.