### PR TITLE
chore: fix onebox scripts

### DIFF
--- a/onebox/start_onebox.sh
+++ b/onebox/start_onebox.sh
@@ -62,7 +62,7 @@ cluster_start_component() {
 
     mkdir -p "$log_dir"
 
-    local extra_opts=()
+    local extra_opts=(--enable_status_service=true)
     if [[ $role = 'tablet' ]]; then
         [ -d "$binlog_dir" ] && rm -r "$binlog_dir"
         mkdir -p "$binlog_dir"
@@ -72,7 +72,7 @@ cluster_start_component() {
 
         extra_opts+=(
             --binlog_notify_on_put=true
-            --zk_keep_alive_check_interval=100000000
+            --zk_keep_alive_check_interval=60000
             --db_root_path="$binlog_dir"
             --recycle_bin_root_path="$recycle_bin_dir"
         )

--- a/onebox/stop_all.sh
+++ b/onebox/stop_all.sh
@@ -16,5 +16,5 @@
 
 set -x -e
 
-pkill -9 openmldb
+pkill -x -e -9 openmldb
 


### PR DESCRIPTION
Main changes:

- set tablet zk_keep_alive_check_interval to 60s
- stop_all.sh: use `-e` as exact match, avoid kill unrelated tasks

This effectively resolve #1641 