### PR TITLE
refactor: removed duplicated compile_proto

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,7 +88,6 @@ function(compile_test DIR)
 endfunction(compile_test)
 
 compile_proto(type ${PROJECT_SOURCE_DIR})
-compile_proto(name_server ${PROJECT_SOURCE_DIR})
 compile_proto(common ${PROJECT_SOURCE_DIR})
 compile_proto(tablet ${PROJECT_SOURCE_DIR})
 compile_proto(name_server ${PROJECT_SOURCE_DIR})


### PR DESCRIPTION
## Removed duplicated compile_proto from src/CMakeLists.txt

<img width="489" alt="image" src="https://user-images.githubusercontent.com/72253920/186240620-2c8452d1-8205-48d7-bf2d-1f0f0108771a.png">

Deleted line number 91