### PR TITLE
docs: add button to help & use Gitpod for new contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,11 @@ In order to achieve the goal of Development as Deployment, OpenMLDB is designed 
 
 ## 5. Build and Install
 
-:point_right: [Read more](https://openmldb.ai/docs/en/main/deploy/index.html)
+You can directly start working on this repository by clicking on the following button
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/4paradigm/OpenMLDB)
+
+Or, you can :point_right: [Read more](https://openmldb.ai/docs/en/main/deploy/index.html)
 
 ## 6. QuickStart
 

--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ In order to achieve the goal of Development as Deployment, OpenMLDB is designed 
 
 ## 5. Build and Install
 
-You can directly start working on this repository by clicking on the following button
+:point_right: [Read more](https://openmldb.ai/docs/en/main/deploy/index.html)
+
+Or you can directly start working on this repository by clicking on the following button
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/4paradigm/OpenMLDB)
-
-Or, you can :point_right: [Read more](https://openmldb.ai/docs/en/main/deploy/index.html)
 
 ## 6. QuickStart
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
docs

* **What is the current behavior?** (You can also link to an open issue here)
We saw that maintainers already [Gitpodified](https://www.gitpod.io/blog/gitpodify/) this repository to ease out the life of contributors to use [Gitpod](https://gitpod.io) & instead of setting up manual development environments. Just a single button. to get started. But, to make awareness for new contributors. There is missing information about the project, that they can also start building in Gitpod.


* **What is the new behavior (if this is a feature change)?**
Fixed the above missing info. by adding a small button to the required part in `README`
