### PR TITLE
fix: do not handle zk diconnect event for taskmanager

### DIFF
--- a/java/openmldb-taskmanager/src/main/java/com/_4paradigm/openmldb/taskmanager/zk/FailoverWatcher.java
+++ b/java/openmldb-taskmanager/src/main/java/com/_4paradigm/openmldb/taskmanager/zk/FailoverWatcher.java
@@ -154,6 +154,7 @@ public class FailoverWatcher implements Watcher {
         System.exit(0);
       } 
       break;
+    /*
     case Disconnected: // be triggered when kill the server or the leader of zk cluster 
       LOG.warn(hostPort.getHostPort() + " received disconnected from ZooKeeper");
 
@@ -162,6 +163,7 @@ public class FailoverWatcher implements Watcher {
         System.exit(0);
       }
       break;
+    */
     case AuthFailed:
       LOG.fatal(hostPort.getHostPort() + " auth fail, exit immediately");
       System.exit(0);


### PR DESCRIPTION
* Comment out the code of handling zk disconnect event
* Resolve the issues of restarting taskmanager when restarting zk 