### PR TITLE
refactor: remove unused import in `StatementTest`

### DIFF
--- a/java/openmldb-jdbc/src/test/java/com/_4paradigm/openmldb/jdbc/StatementTest.java
+++ b/java/openmldb-jdbc/src/test/java/com/_4paradigm/openmldb/jdbc/StatementTest.java
@@ -2,7 +2,6 @@ package com._4paradigm.openmldb.jdbc;
 
 import com._4paradigm.openmldb.sdk.SdkOption;
 import com._4paradigm.openmldb.sdk.SqlExecutor;
-import com._4paradigm.openmldb.sdk.impl.DeletePreparedStatementImpl;
 import com._4paradigm.openmldb.sdk.impl.SqlClusterExecutor;
 import org.testng.Assert;
 import org.testng.annotations.Test;


### PR DESCRIPTION
Unused Import **com._4paradigm.openmldb.sdk.impl.DeletePreparedStatementImpl** has been removed from the StatementTest.java. 

Please verify.