### PR TITLE
refactor: use empty insteadof size in dist_lock.cc

### DIFF
--- a/java/openmldb-jdbc/src/test/java/com/_4paradigm/openmldb/jdbc/StatementTest.java
+++ b/java/openmldb-jdbc/src/test/java/com/_4paradigm/openmldb/jdbc/StatementTest.java
@@ -2,7 +2,6 @@ package com._4paradigm.openmldb.jdbc;
 
 import com._4paradigm.openmldb.sdk.SdkOption;
 import com._4paradigm.openmldb.sdk.SqlExecutor;
-import com._4paradigm.openmldb.sdk.impl.DeletePreparedStatementImpl;
 import com._4paradigm.openmldb.sdk.impl.SqlClusterExecutor;
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/src/zk/dist_lock.cc
+++ b/src/zk/dist_lock.cc
@@ -84,7 +84,7 @@ void DistLock::HandleChildrenChanged(const std::vector<std::string>& children) {
         return;
     }
     current_lock_node_ = "";
-    if (children.size() > 0) {
+    if (!children.empty()) {
         current_lock_node_ = root_path_ + "/" + children[0];
     }
     PDLOG(INFO, "first child %s", current_lock_node_.c_str());


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Changed the use of size function to empty in dist_lock.cc

* **What is the current behavior?** (You can also link to an open issue here)

Issue #2512


* **What is the new behavior (if this is a feature change)?**

