### PR TITLE
refactor: remove PrintTableIndex function from cmd/display.h

### DIFF
--- a/src/cmd/display.h
+++ b/src/cmd/display.h
@@ -479,49 +479,6 @@ __attribute__((unused)) static void PrintTableOptions(
     stream << t << std::endl;
 }
 
-__attribute__((unused)) static void PrintTableIndex(const ::hybridse::vm::IndexList& index_list,
-        std::ostream& stream) {
-    ::hybridse::base::TextTable t('-', ' ', ' ');
-    t.add("#");
-    t.add("name");
-    t.add("keys");
-    t.add("ts");
-    t.add("ttl");
-    t.add("ttl_type");
-    t.end_of_row();
-    for (int i = 0; i < index_list.size(); i++) {
-        const ::hybridse::type::IndexDef& index = index_list.Get(i);
-        t.add(std::to_string(i + 1));
-        t.add(index.name());
-        t.add(index.first_keys(0));
-        const std::string& ts_name = index.second_key();
-        if (ts_name.empty()) {
-            t.add("-");
-        } else {
-            t.add(index.second_key());
-        }
-        std::ostringstream oss;
-        for (int ttl_idx = 0; ttl_idx < index.ttl_size(); ttl_idx++) {
-            oss << index.ttl(ttl_idx);
-            if (ttl_idx != index.ttl_size() - 1) {
-                oss << "m,";
-            }
-        }
-        t.add(oss.str());
-        if (index.ttl_type() == ::hybridse::type::kTTLTimeLive) {
-            t.add("kAbsolute");
-        } else if (index.ttl_type() == ::hybridse::type::kTTLCountLive) {
-            t.add("kLatest");
-        } else if (index.ttl_type() == ::hybridse::type::kTTLTimeLiveAndCountLive) {
-            t.add("kAbsAndLat");
-        } else {
-            t.add("kAbsOrLat");
-        }
-        t.end_of_row();
-    }
-    stream << t;
-}
-
 __attribute__((unused)) static void PrintTableSchema(const ::hybridse::vm::Schema& schema,
         std::ostream& stream) {
     if (schema.empty()) {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Remove PrintTableIndex function from cmd/display.h


* **What is the current behavior?** (You can also link to an open issue here)
https://github.com/4paradigm/OpenMLDB/issues/2510


* **What is the new behavior (if this is a feature change)?**

