### PR TITLE
feat: use local[*] as default value of spark.master in taskmanager

### DIFF
--- a/java/openmldb-taskmanager/src/main/resources/taskmanager.properties
+++ b/java/openmldb-taskmanager/src/main/resources/taskmanager.properties
@@ -21,7 +21,7 @@ zookeeper.max_connect_waitTime=30000
 
 # Spark Config
 spark.home=
-spark.master=local
+spark.master=local[*]
 spark.yarn.jars=
 spark.default.conf=
 spark.eventLog.dir=

--- a/release/conf/taskmanager.properties
+++ b/release/conf/taskmanager.properties
@@ -9,6 +9,6 @@ zookeeper.root_path=/openmldb
 
 # Spark Config
 spark.home=
-spark.master=local
+spark.master=local[*]
 offline.data.prefix=file:///tmp/openmldb_offline_storage/
 spark.default.conf=spark.driver.extraJavaOptions=-Dfile.encoding=utf-8;spark.executor.extraJavaOptions=-Dfile.encoding=utf-8


### PR DESCRIPTION
* Use `local[*]` by default