### PR TITLE
fix: correct go module to its path

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/4paradigm/OpenMLDB/go/openmldb
+module github.com/4paradigm/OpenMLDB/go
 
 go 1.18
 

--- a/go/go_sdk_test.go
+++ b/go/go_sdk_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	// register openmldb driver
-	_ "github.com/4paradigm/OpenMLDB/go/openmldb"
+	_ "github.com/4paradigm/OpenMLDB/go"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Go SDK module is under `github.com/4paradigm/OpenMLDB/go` but declares its path `github.com/4paradigm/OpenMLDB/go/openmldb`

* **What is the new behavior (if this is a feature change)?**

