### PR TITLE
fix: fixed different signedness

### DIFF
--- a/hybridse/examples/toydb/src/sdk/tablet_sdk.cc
+++ b/hybridse/examples/toydb/src/sdk/tablet_sdk.cc
@@ -297,7 +297,7 @@ void TabletSdkImpl::BuildInsertRequest(const std::string& db,
     request->set_db(db);
 
     std::unordered_set<std::string> column_set;
-    for (size_t i = 0; i < schema.columns().size(); i++) {
+    for (int i = 0; i < schema.columns().size(); i++) {
         column_set.insert(schema.columns(i).name());
     }
     std::map<std::string, node::ConstNode*> column_value_map;


### PR DESCRIPTION
I tried to fix the issue different sightedness that was causing the warning message for issue #2109. I noticed that on line 333 you used int instead of size_t when dealing with both schema.columns().size()



