### PR TITLE
feat(engine): support subquery(last join) as producer of window node in request node

### DIFF
--- a/cases/query/last_join_window_query.yaml
+++ b/cases/query/last_join_window_query.yaml
@@ -171,16 +171,16 @@ cases:
     inputs:
       - name: actions
         columns:
-          - userId string
+          - userId int
           - itemId int
           - actionTime timestamp
         indexs:
           - index2:itemId:actionTime
         data: |
-          a, 1, 1000
-          a, 2, 2000
-          b, 3, 3000
-          b, 3, 3000
+          1, 1, 1000
+          2, 2, 2000
+          3, 3, 3000
+          4, 3, 4000
 
       - name: items
         columns:
@@ -195,12 +195,13 @@ cases:
           2, 199, 3000
           3, 399, 5000
     # userid, itemid, actionTime, id, price, tm
-    #    a,     1,     1000,       1, 599,   4000
-    #    a,     2,     2000,       2, 199,   3000
-    #    b,     3,     3000,       3, 399,   5000
-    #    b,     3,     3000,       3, 399,   5000
+    #    1,     1,     1000,       1, 599,   4000
+    #    2,     2,     2000,       2, 199,   3000
+    #    3,     3,     3000,       3, 399,   5000
+    #    4,     3,     4000,       3, 399,   5000
     sql: |
       select
+       userId,
         itemId,
         count(itemId) over w1 as count_1,
         sum(price) over w1 as total,
@@ -222,14 +223,15 @@ cases:
             DATA_PROVIDER(type=Partition, table=actions, index=index2)
           DATA_PROVIDER(type=Partition, table=items, index=idx)
     expect:
-      order: itemId
+      order: userId
       columns:
+        - userId int
         - itemId int
         - count_1 int64
         - total float
         - actionTime timestamp
       data: |
-        1, 1, 599, 1000
-        2, 1, 199, 2000
-        3, 1, 399, 3000
-        3, 2, 798, 3000
+        1, 1, 1, 599, 1000
+        2, 2, 1, 199, 2000
+        3, 3, 1, 399, 3000
+        4, 3, 2, 798, 4000

--- a/cases/query/last_join_window_query.yaml
+++ b/cases/query/last_join_window_query.yaml
@@ -164,3 +164,72 @@ cases:
         3, 55, 1590115420001, 1590115420001, CCC, 3
         4, 55, 1590115420002, 1590115420002, DDDD, 7
         5, 55, 1590115420003, 1590115420002, FFFFFF, 12
+
+  - id: 4
+    desc: |
+      window with a last join subquery
+    inputs:
+      - name: actions
+        columns:
+          - userId string
+          - itemId int
+          - actionTime timestamp
+        indexs:
+          - index2:itemId:actionTime
+        data: |
+          a, 1, 1000
+          a, 2, 2000
+          b, 3, 3000
+          b, 3, 3000
+
+      - name: items
+        columns:
+          - id int
+          - price float
+          - tm timestamp
+        indexs:
+          - idx:id:tm
+        data: |
+          1, 99,  1000
+          1, 599, 4000
+          2, 199, 3000
+          3, 399, 5000
+    # userid, itemid, actionTime, id, price, tm
+    #    a,     1,     1000,       1, 599,   4000
+    #    a,     2,     2000,       2, 199,   3000
+    #    b,     3,     3000,       3, 399,   5000
+    #    b,     3,     3000,       3, 399,   5000
+    sql: |
+      select
+        itemId,
+        count(itemId) over w1 as count_1,
+        sum(price) over w1 as total,
+        actionTime
+      from (
+        select * from actions
+        last join items order by tm
+        on actions.itemId = items.id and actionTime <= tm
+      ) window w1 as (
+        partition by itemId
+        order by actionTime
+        rows_range between 3000 preceding and current row
+      )
+    request_plan: |
+      PROJECT(type=Aggregation)
+        JOIN(type=LastJoin, right_sort=(ASC), condition=actionTime <= tm, left_keys=(), right_keys=(), index_keys=(actions.itemId))
+          REQUEST_UNION(partition_keys=(), orders=(ASC), range=(actionTime, 3000 PRECEDING, 0 CURRENT), index_keys=(itemId))
+            DATA_PROVIDER(request=actions)
+            DATA_PROVIDER(type=Partition, table=actions, index=index2)
+          DATA_PROVIDER(type=Partition, table=items, index=idx)
+    expect:
+      order: itemId
+      columns:
+        - itemId int
+        - count_1 int64
+        - total float
+        - actionTime timestamp
+      data: |
+        1, 1, 599, 1000
+        2, 1, 199, 2000
+        3, 1, 399, 3000
+        3, 2, 798, 3000

--- a/cases/query/last_join_window_query.yaml
+++ b/cases/query/last_join_window_query.yaml
@@ -213,7 +213,7 @@ cases:
         partition by itemId
         order by actionTime
         rows_range between 3000 preceding and current row
-      )
+      );
     request_plan: |
       PROJECT(type=Aggregation)
         JOIN(type=LastJoin, right_sort=(ASC), condition=actionTime <= tm, left_keys=(), right_keys=(), index_keys=(actions.itemId))

--- a/hybridse/src/passes/physical/simple_project_optimized.h
+++ b/hybridse/src/passes/physical/simple_project_optimized.h
@@ -21,6 +21,14 @@
 namespace hybridse {
 namespace passes {
 
+// Transform PhysicalSimpleProjectNode
+// Rule 1, merge consecutive simple projects:
+//   SimpleProject(project_list1)
+//     SimpleProject(project_list2)
+//       ...
+//   ->
+//   SimpleProject(merged_prject_list)
+//     ...
 class SimpleProjectOptimized : public TransformUpPysicalPass {
  public:
     explicit SimpleProjectOptimized(PhysicalPlanContext* plan_ctx)

--- a/hybridse/src/vm/transform.cc
+++ b/hybridse/src/vm/transform.cc
@@ -516,7 +516,6 @@ static bool CheckUnionAvailable(const PhysicalOpNode* left,
     return true;
 }
 
-// TODO: read this
 Status BatchModeTransformer::CreateRequestUnionNode(
     PhysicalOpNode* request, PhysicalOpNode* right,
     const std::string& db_name,
@@ -578,15 +577,13 @@ Status BatchModeTransformer::CreateRequestUnionNode(
     return Status::OK();
 }
 
-Status BatchModeTransformer::TransformWindowOp(PhysicalOpNode* depend,
+Status RequestModeTransformer::TransformWindowOp(PhysicalOpNode* depend,
                                                const node::WindowPlanNode* w_ptr,
                                                PhysicalOpNode** output) {
     // sanity check
     CHECK_TRUE(depend != nullptr && output != nullptr, kPlanError,
                "Depend node or output node is null");
     CHECK_STATUS(CheckWindow(w_ptr, depend->schemas_ctx()));
-    const node::OrderByNode* orders = w_ptr->GetOrders();
-    const node::ExprListNode* groups = w_ptr->GetKeys();
 
     switch (depend->GetOpType()) {
         case kPhysicalOpRename: {
@@ -641,89 +638,33 @@ Status BatchModeTransformer::TransformWindowOp(PhysicalOpNode* depend,
             break;
         }
         case kPhysicalOpRequestJoin: {
-            auto join_op = dynamic_cast<PhysicalRequestJoinNode*>(depend);
-            switch (join_op->join().join_type()) {
-                case node::kJoinTypeLeft:
-                case node::kJoinTypeLast: {
-                    auto child_schemas_ctx =
-                        join_op->GetProducer(0)->schemas_ctx();
-                    if (!node::ExprListNullOrEmpty(groups)) {
-                        CHECK_STATUS(passes::CheckExprDependOnChildOnly(
-                                         groups, child_schemas_ctx),
-                                     "Fail to handle window: group "
-                                     "expression should belong to left table");
-                    }
-                    if (nullptr != orders &&
-                        !node::ExprListNullOrEmpty(orders->order_expressions_)) {
-                        CHECK_STATUS(passes::CheckExprDependOnChildOnly(
-                                         orders->order_expressions_, child_schemas_ctx),
-                                     "Fail to handle window: group "
-                                     "expression should belong to left table");
-                    }
-                    CHECK_TRUE(join_op->producers()[0]->GetOpType() ==
-                                   kPhysicalOpDataProvider,
-                               kPlanError,
-                               "Fail to handler window with request last "
-                               "join, left isn't a table provider")
-                    auto request_op = dynamic_cast<PhysicalDataProviderNode*>(
-                        join_op->producers()[0]);
-                    auto name = request_op->table_handler_->GetName();
-                    auto db_name = request_op->table_handler_->GetDatabase();
-                    if (db_name.empty()) {
-                        db_name = db_;
-                    }
-                    auto table = catalog_->GetTable(db_name, name);
-                    CHECK_TRUE(table != nullptr, kPlanError,
-                               "Fail to transform data provider op: table " +
-                                   name + "not exists");
-                    PhysicalTableProviderNode* right = nullptr;
-                    CHECK_STATUS(
-                        CreateOp<PhysicalTableProviderNode>(&right, table));
-
-                    PhysicalRequestUnionNode* request_union_op = nullptr;
-                    CHECK_STATUS(CreateRequestUnionNode(
-                        request_op, right, db_name, name, table->GetSchema(), nullptr,
-                        w_ptr, &request_union_op));
-                    if (!w_ptr->union_tables().empty()) {
-                        for (auto iter = w_ptr->union_tables().cbegin();
-                             iter != w_ptr->union_tables().cend(); iter++) {
-                            PhysicalOpNode* union_table_op;
-                            CHECK_STATUS(
-                                TransformPlanOp(*iter, &union_table_op));
-                            PhysicalRenameNode* rename_union_op = nullptr;
-                            CHECK_STATUS(CreateOp<PhysicalRenameNode>(&rename_union_op, union_table_op,
-                                                                      depend->schemas_ctx()->GetName()));
-                            CHECK_TRUE(
-                                request_union_op->AddWindowUnion(
-                                    rename_union_op),
-                                kPlanError,
-                                "Fail to add request window union table");
-                        }
-                    }
-                    PhysicalJoinNode* join_output = nullptr;
-                    CHECK_STATUS(CreateOp<PhysicalJoinNode>(
-                        &join_output, request_union_op, join_op->producers()[1],
-                        join_op->join_));
-                    *output = join_output;
-                    break;
-                }
-                default: {
-                    return Status(kPlanError, "Non-support join type");
-                }
-            }
-            break;
+            auto* join_op = dynamic_cast<PhysicalRequestJoinNode*>(depend);
+            CHECK_TRUE(join_op != nullptr, kPlanError);
+            return OptimizeRequestJoinAsWindowProducer(join_op, w_ptr, output);
         }
         case kPhysicalOpSimpleProject: {
-            auto simple_project =
-                dynamic_cast<PhysicalSimpleProjectNode*>(depend);
-            CHECK_TRUE(
-                depend->GetProducer(0)->GetOpType() == kPhysicalOpDataProvider,
-                kPlanError, "Do not support window on ",
-                depend->GetTreeString());
-            auto data_op =
-                dynamic_cast<PhysicalDataProviderNode*>(depend->GetProducer(0));
-            CHECK_TRUE(data_op->provider_type_ == kProviderTypeRequest,
-                       kPlanError,
+            auto* simple_project = dynamic_cast<PhysicalSimpleProjectNode*>(depend);
+            CHECK_TRUE(simple_project != nullptr, kPlanError);
+            return OptimizeSimpleProjectAsWindowProducer(simple_project, w_ptr, output);
+        }
+        default: {
+            FAIL_STATUS(kPlanError, "Do not support window on\n" + depend->GetTreeString());
+        }
+    }
+    return Status::OK();
+}
+
+Status RequestModeTransformer::OptimizeSimpleProjectAsWindowProducer(PhysicalSimpleProjectNode* depend,
+                                                                     const node::WindowPlanNode* w_ptr,
+                                                                     PhysicalOpNode** output) {
+    // - SimpleProject(DataProvider) -> RequestUnion(Request, DataSource)
+    // - SimpleProject(RequestJoin) -> Join(RequestUnion, DataSource)
+    auto op_type = depend->GetProducer(0)->GetOpType();
+    switch (op_type) {
+        case kPhysicalOpDataProvider: {
+            auto data_op = dynamic_cast<PhysicalDataProviderNode*>(depend->GetProducer(0));
+            CHECK_TRUE(data_op != nullptr, kPlanError, "not PhysicalDataProviderNode");
+            CHECK_TRUE(data_op->provider_type_ == kProviderTypeRequest, kPlanError,
                        "Do not support window on non-request input");
 
             auto name = data_op->table_handler_->GetName();
@@ -731,42 +672,112 @@ Status BatchModeTransformer::TransformWindowOp(PhysicalOpNode* depend,
             db_name = db_name.empty() ? db_ : db_name;
             auto table = catalog_->GetTable(db_name, name);
             CHECK_TRUE(table != nullptr, kPlanError,
-                       "Fail to transform data provider op: table " + name +
-                           "not exists");
+                       "Fail to transform data provider op: table " + name + "not exists");
 
             PhysicalTableProviderNode* right = nullptr;
             CHECK_STATUS(CreateOp<PhysicalTableProviderNode>(&right, table));
 
             // right side simple project
             PhysicalSimpleProjectNode* right_simple_project = nullptr;
-            CHECK_STATUS(CreateOp<PhysicalSimpleProjectNode>(
-                &right_simple_project, right, simple_project->project()));
+            CHECK_STATUS(CreateOp<PhysicalSimpleProjectNode>(&right_simple_project, right, depend->project()));
 
             // request union
             PhysicalRequestUnionNode* request_union_op = nullptr;
-            CHECK_STATUS(CreateRequestUnionNode(
-                depend, right_simple_project, table->GetDatabase(), table->GetName(),
-                table->GetSchema(), nullptr, w_ptr, &request_union_op));
+            CHECK_STATUS(CreateRequestUnionNode(depend, right_simple_project, table->GetDatabase(), table->GetName(),
+                                                table->GetSchema(), nullptr, w_ptr, &request_union_op));
             if (!w_ptr->union_tables().empty()) {
-                for (auto iter = w_ptr->union_tables().cbegin();
-                     iter != w_ptr->union_tables().cend(); iter++) {
+                for (auto iter = w_ptr->union_tables().cbegin(); iter != w_ptr->union_tables().cend(); iter++) {
                     PhysicalOpNode* union_table_op;
                     CHECK_STATUS(TransformPlanOp(*iter, &union_table_op));
                     PhysicalRenameNode* rename_union_op = nullptr;
                     CHECK_STATUS(CreateOp<PhysicalRenameNode>(&rename_union_op, union_table_op,
                                                               depend->schemas_ctx()->GetName()));
-                    CHECK_TRUE(request_union_op->AddWindowUnion(rename_union_op),
-                               kPlanError,
+                    CHECK_TRUE(request_union_op->AddWindowUnion(rename_union_op), kPlanError,
                                "Fail to add request window union table");
                 }
             }
             *output = request_union_op;
             break;
         }
+        case kPhysicalOpRequestJoin: {
+            auto join_op = dynamic_cast<PhysicalRequestJoinNode*>(depend->GetProducer(0));
+            CHECK_TRUE(join_op != nullptr, kPlanError, "not PhysicalRequestJoinNode");
+            return OptimizeRequestJoinAsWindowProducer(join_op, w_ptr, output);
+        }
         default: {
-            FAIL_STATUS(kPlanError, "Do not support window on " + depend->GetTreeString());
+            FAIL_STATUS(kPlanError, "Do not support window on\n", depend->GetTreeString());
         }
     }
+    return Status::OK();
+}
+
+Status RequestModeTransformer::OptimizeRequestJoinAsWindowProducer(PhysicalRequestJoinNode* join_op,
+                                                                   const node::WindowPlanNode* w_ptr,
+                                                                   PhysicalOpNode** output) {
+    // Optimize
+    //   RequestJoin(Request(left_table), DataSource(right_table))
+    // ->
+    //   Join
+    //     RequestUnion
+    //       Request
+    //       DataSource(left_table)
+    //     DataSource(right_table)
+    switch (join_op->join().join_type()) {
+        case node::kJoinTypeLeft:
+        case node::kJoinTypeLast: {
+            const node::OrderByNode* orders = w_ptr->GetOrders();
+            const node::ExprListNode* groups = w_ptr->GetKeys();
+            auto child_schemas_ctx = join_op->GetProducer(0)->schemas_ctx();
+            if (!node::ExprListNullOrEmpty(groups)) {
+                CHECK_STATUS(passes::CheckExprDependOnChildOnly(groups, child_schemas_ctx),
+                             "Fail to handle window: group "
+                             "expression should belong to left table");
+            }
+            if (nullptr != orders && !node::ExprListNullOrEmpty(orders->order_expressions_)) {
+                CHECK_STATUS(passes::CheckExprDependOnChildOnly(orders->order_expressions_, child_schemas_ctx),
+                             "Fail to handle window: group "
+                             "expression should belong to left table");
+            }
+            CHECK_TRUE(join_op->producers()[0]->GetOpType() == kPhysicalOpDataProvider, kPlanError,
+                       "Fail to handler window with request last "
+                       "join, left isn't a table provider")
+            auto request_op = dynamic_cast<PhysicalDataProviderNode*>(join_op->producers()[0]);
+            auto name = request_op->table_handler_->GetName();
+            auto db_name = request_op->table_handler_->GetDatabase();
+            if (db_name.empty()) {
+                db_name = db_;
+            }
+            auto table = catalog_->GetTable(db_name, name);
+            CHECK_TRUE(table != nullptr, kPlanError,
+                       "Fail to transform data provider op: table " + name + "not exists");
+            PhysicalTableProviderNode* right = nullptr;
+            CHECK_STATUS(CreateOp<PhysicalTableProviderNode>(&right, table));
+
+            PhysicalRequestUnionNode* request_union_op = nullptr;
+            CHECK_STATUS(CreateRequestUnionNode(request_op, right, db_name, name, table->GetSchema(), nullptr, w_ptr,
+                                                &request_union_op));
+            if (!w_ptr->union_tables().empty()) {
+                for (auto iter = w_ptr->union_tables().cbegin(); iter != w_ptr->union_tables().cend(); iter++) {
+                    PhysicalOpNode* union_table_op;
+                    CHECK_STATUS(TransformPlanOp(*iter, &union_table_op));
+                    PhysicalRenameNode* rename_union_op = nullptr;
+                    CHECK_STATUS(CreateOp<PhysicalRenameNode>(&rename_union_op, union_table_op,
+                                                              join_op->schemas_ctx()->GetName()));
+                    CHECK_TRUE(request_union_op->AddWindowUnion(rename_union_op), kPlanError,
+                               "Fail to add request window union table");
+                }
+            }
+            PhysicalJoinNode* join_output = nullptr;
+            CHECK_STATUS(
+                CreateOp<PhysicalJoinNode>(&join_output, request_union_op, join_op->producers()[1], join_op->join_));
+            *output = join_output;
+            break;
+        }
+        default: {
+            return Status(kPlanError, "Non-support join type");
+        }
+    }
+
     return Status::OK();
 }
 
@@ -2284,8 +2295,7 @@ Status RequestModeTransformer::TransformProjectOp(
     bool append_input, PhysicalOpNode** output) {
     PhysicalOpNode* new_depend = depend;
     if (nullptr != project_list->GetW()) {
-        CHECK_STATUS(
-            TransformWindowOp(depend, project_list->GetW(), &new_depend));
+        CHECK_STATUS(TransformWindowOp(depend, project_list->GetW(), &new_depend));
     }
     switch (new_depend->GetOutputType()) {
         case kSchemaTypeRow:

--- a/hybridse/src/vm/transform.cc
+++ b/hybridse/src/vm/transform.cc
@@ -516,6 +516,7 @@ static bool CheckUnionAvailable(const PhysicalOpNode* left,
     return true;
 }
 
+// TODO: read this
 Status BatchModeTransformer::CreateRequestUnionNode(
     PhysicalOpNode* request, PhysicalOpNode* right,
     const std::string& db_name,
@@ -763,8 +764,7 @@ Status BatchModeTransformer::TransformWindowOp(PhysicalOpNode* depend,
             break;
         }
         default: {
-            return Status(kPlanError, "Do not support window on " +
-                                          depend->GetTreeString());
+            FAIL_STATUS(kPlanError, "Do not support window on " + depend->GetTreeString());
         }
     }
     return Status::OK();

--- a/hybridse/src/vm/transform.h
+++ b/hybridse/src/vm/transform.h
@@ -159,9 +159,6 @@ class BatchModeTransformer {
                                     PhysicalOpNode** output);
     virtual Status TransformProjectPlanOp(const node::ProjectPlanNode* node,
                                           PhysicalOpNode** output);
-    virtual Status TransformWindowOp(PhysicalOpNode* depend,
-                                     const node::WindowPlanNode* w_ptr,
-                                     PhysicalOpNode** output);
     virtual Status TransformJoinOp(const node::JoinPlanNode* node,
                                    PhysicalOpNode** output);
     virtual Status TransformGroupOp(const node::GroupPlanNode* node,
@@ -292,6 +289,15 @@ class RequestModeTransformer : public BatchModeTransformer {
     Status TransformGroupOp(const node::GroupPlanNode* node, PhysicalOpNode** output) override;
 
     Status TransformLoadDataOp(const node::LoadDataPlanNode* node, PhysicalOpNode** output) override;
+
+    Status TransformWindowOp(PhysicalOpNode* depend, const node::WindowPlanNode* w_ptr, PhysicalOpNode** output);
+
+ private:
+    // Optimize simple project node which is the producer of window project
+    Status OptimizeSimpleProjectAsWindowProducer(PhysicalSimpleProjectNode* depend, const node::WindowPlanNode* w_ptr,
+                                                 PhysicalOpNode** output);
+    Status OptimizeRequestJoinAsWindowProducer(PhysicalRequestJoinNode* depend, const node::WindowPlanNode* w_ptr,
+                                               PhysicalOpNode** output);
 
  private:
     bool enable_batch_request_opt_;


### PR DESCRIPTION
this kind of sql will supported in request mode:
```sql
select id, agg_func(col) over w
from (select * from t1 last join t2 on ...) 
window w as (...)
```

will treat exactly same as 
```sql
select id, agg_func(col) over w 
from t1 last join t2 on ....
window w as (...)
```

as long as the subquery is simple project