### PR TITLE
docs: add more common configs for spark.conf

### DIFF
--- a/docs/en/reference/client_config/client_spark_config.md
+++ b/docs/en/reference/client_config/client_spark_config.md
@@ -2,7 +2,7 @@
 
 ## Set Spark Parameters For CLI
 
-The offline jobs of OpenMLDB are submitted as Spark jobs. Users can set default Spark parameters in TaskManager or set Spark parameters for each submission.
+The offline jobs of OpenMLDB are submitted as Spark jobs. Users can set default Spark parameters in TaskManager or set Spark parameters for each submission, and refer to [Spark Configuration](https://spark.apache.org/docs/latest/configuration.html) for more detailed configurations.
 
 If we want to set Spark parameters in SQL CLI, we can create the ini configuration file just like this.
 
@@ -10,6 +10,14 @@ If we want to set Spark parameters in SQL CLI, we can create the ini configurati
 [Spark]
 spark.driver.extraJavaOptions=-Dfile.encoding=utf-8
 spark.executor.extraJavaOptions=-Dfile.encoding=utf-8
+spark.driver.cores=1
+spark.default.parallelism=1
+spark.driver.memory=4g
+spark.driver.memoryOverhead=384
+spark.driver.memoryOverheadFactor=0.10
+spark.shuffle.compress=true
+spark.files.maxPartitionBytes=134217728
+spark.sql.shuffle.partitions=200
 ```
 
 Take this for example if we save the configruation file as `/work/openmldb/bin/spark.conf`, we can start the SQL CLI with the parameter `--spark_conf` just like this.

--- a/docs/zh/reference/client_config/client_spark_config.md
+++ b/docs/zh/reference/client_config/client_spark_config.md
@@ -2,7 +2,7 @@
 
 ## 命令行传递Spark高级参数
 
-OpenMLDB离线任务默认使用Spark执行引擎提交，用户可以在TaskManager配置所有任务的Spark高级参数，也可以在客户端配置单次任务的Spark高级参数。
+OpenMLDB离线任务默认使用Spark执行引擎提交，用户可以在TaskManager配置所有任务的Spark高级参数，也可以在客户端配置单次任务的Spark高级参数，更详细的配置可参考[Spark Configuration](https://spark.apache.org/docs/latest/configuration.html)。
 
 如果需要在SQL命令行修改Spark任务高级参数，可以在本地创建ini格式的配置文件，示例如下。
 
@@ -10,6 +10,14 @@ OpenMLDB离线任务默认使用Spark执行引擎提交，用户可以在TaskMan
 [Spark]
 spark.driver.extraJavaOptions=-Dfile.encoding=utf-8
 spark.executor.extraJavaOptions=-Dfile.encoding=utf-8
+spark.driver.cores=1
+spark.default.parallelism=1
+spark.driver.memory=4g
+spark.driver.memoryOverhead=384
+spark.driver.memoryOverheadFactor=0.10
+spark.shuffle.compress=true
+spark.files.maxPartitionBytes=134217728
+spark.sql.shuffle.partitions=200
 ```
 
 以保存文件成`/work/openmldb/bin/spark.conf`为例，在启动SQL命令行时添加`--spark_conf`参数，示例如下。


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Both the Chinese and English versions of client_spark_config.md, I have added more genneral configs and the link of Spark Configuration page in them.

* **What is the current behavior?** (You can also link to an open issue here)
[docs] add more common configs for spark.conf #2545, the issue link is https://github.com/4paradigm/OpenMLDB/issues/2545


* **What is the new behavior (if this is a feature change)?**

