### PR TITLE
refactor: remove unused code from `sql_cluster_availability`

### DIFF
--- a/src/tablet/sql_cluster_availability_test.cc
+++ b/src/tablet/sql_cluster_availability_test.cc
@@ -35,13 +35,10 @@ DECLARE_string(zk_cluster);
 DECLARE_string(zk_root_path);
 DECLARE_int32(zk_session_timeout);
 DECLARE_int32(request_timeout_ms);
-DECLARE_int32(request_timeout_ms);
-DECLARE_bool(binlog_notify_on_put);
 DECLARE_bool(auto_failover);
 DECLARE_uint32(system_table_replica_num);
 
 using ::openmldb::nameserver::NameServerImpl;
-using ::openmldb::zk::ZkClient;
 
 namespace openmldb {
 namespace tablet {
@@ -49,13 +46,6 @@ namespace tablet {
 inline std::string GenRand() {
     return std::to_string(rand() % 10000000 + 1);  // NOLINT
 }
-
-class MockClosure : public ::google::protobuf::Closure {
- public:
-    MockClosure() {}
-    ~MockClosure() {}
-    void Run() {}
-};
 
 class SqlClusterTest : public ::testing::Test {
  public:


### PR DESCRIPTION
…test

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This change addresses issue #2588 and deletes the listed lines of unused code.

* **What is the current behavior?** (You can also link to an open issue here)

Current behavior is unaffected by these line since they are unused, it was just requested that the lines of code be removed. Issue #2588 

* **What is the new behavior (if this is a feature change)?**
No new behavior.