### PR TITLE
fix: run `start.sh` failed if has not installed `curl`

### DIFF
--- a/demo/JD-recommendation/README.md
+++ b/demo/JD-recommendation/README.md
@@ -20,14 +20,14 @@ conda activate oneflow
 
 cd openmldb_process
 ##pass in directory of openmldb results
-sh process_JD_out_full.sh $demodir/out/1
+bash process_JD_out_full.sh $demodir/out/1
 ##output data in $demodir/openmldb_process/out
 ##note output information, table_size_array
 
 3. Launch oneflow deepfm model training:
 cd oneflow_process/
 ##modify directory, sample size, table_size_array information in train_deepfm.sh accordingly
-sh train_deepfm.sh $demodir
+bash train_deepfm.sh $demodir
 
 
 #Model Serving

--- a/docs/en/deploy/install_deploy.md
+++ b/docs/en/deploy/install_deploy.md
@@ -100,7 +100,7 @@ cd openmldb-tablet-0.6.2
 #### 3. Start the Service
 
 ```
-sh bin/start.sh start standalone_tablet
+bash bin/start.sh start standalone_tablet
 ```
 
 **Notice**: After the service is started, the standalone_tablet.pid file will be generated in the bin directory, and the process number at startup will be saved in it. If the pid inside the file is running, the startup will fail.
@@ -131,7 +131,7 @@ cd openmldb-ns-0.6.2
 #### 3. Start the Service
 
 ```
-sh bin/start.sh start standalone_nameserver
+bash bin/start.sh start standalone_nameserver
 ```
 
 #### 4. Verify the Running Status of the Service
@@ -176,7 +176,7 @@ cd openmldb-apiserver-0.6.2
 #### 3. Start the Service
 
 ```
-sh bin/start.sh start standalone_apiserver
+bash bin/start.sh start standalone_apiserver
 ```
 
 ## Deploy Cluster Version
@@ -210,7 +210,7 @@ clientPort=7181
 #### 3. Start Zookeeper
 
 ```
-sh bin/zkServer.sh start
+bash bin/zkServer.sh start
 ```
 
 Deploy the Zookeeper cluster [refer to here](https://zookeeper.apache.org/doc/r3.4.14/zookeeperStarted.html#sc_RunningReplicatedZooKeeper).
@@ -250,7 +250,7 @@ cd openmldb-tablet-0.6.2
 #### 3. Start the Service
 
 ```
-sh bin/start.sh start tablet
+bash bin/start.sh start tablet
 ```
 
 Repeat the above steps to deploy multiple tablets.
@@ -290,7 +290,7 @@ cd openmldb-ns-0.6.2
 #### 3. Start the Service
 
 ```
-sh bin/start.sh start nameserver
+bash bin/start.sh start nameserver
 ```
 
 Repeat the above steps to deploy multiple nameservers.
@@ -340,7 +340,7 @@ cd openmldb-apiserver-0.6.2
 #### 3. Start the Service
 
 ```
-sh bin/start.sh start apiserver
+bash bin/start.sh start apiserver
 ```
 
 **Notice:** If the program crashes when starting the nameserver/tablet/apiserver using the OpenMLDB release package, it is very likely that the instruction set is incompatible, and you need to compile OpenMLDB through the source code. For source code compilation, please refer to [here](./compile.md), you need to use method 3 to compile the complete source code.
@@ -383,7 +383,7 @@ spark.home=
 #### 3. Start the Service
 
 ```bash
-bin/start.sh start taskmanager
+bash bin/start.sh start taskmanager
 ```
 
 #### 4. Verify the Running Status of the Service

--- a/docs/en/maintain/scale.md
+++ b/docs/en/maintain/scale.md
@@ -12,7 +12,7 @@ You need to first start a new tablet node as following steps, please refer to th
 - Modify the configuration file: conf/tablet.flags
 - Start a new tablet
   ```bash
-    sh bin/start.sh start tablet
+    bash bin/start.sh start tablet
   ```
 
 After startup, you need to check whether the new node has joined the cluster. If the `showtablet` command is executed and the new node endpoint is listed, it means that it has joined the cluster
@@ -74,10 +74,10 @@ Scaling in your cluster is to reduce the number of nodes in the cluster.
 ### Step 3. Making the targeted node offline
 - Execute `stop` command
 ```bash
-sh bin/start.sh stop tablet
+bash bin/start.sh stop tablet
 ```
 - If nameserver is deployed on the node, you need to disable the nameserver.
 ```bash
-sh bin/start.sh stop nameserver
+bash bin/start.sh stop nameserver
 ```
 Note that, at least two Nameserver nodes are required to maintain high availability

--- a/docs/en/maintain/upgrade.md
+++ b/docs/en/maintain/upgrade.md
@@ -8,14 +8,14 @@ Here is the impact when upgrading OpenMLDB:
 
 * Stop nameserver
     ```bash
-    sh bin/start.sh stop nameserver
+    bash bin/start.sh stop nameserver
     ```
 * Backup the old versions directories `bin` and `conf`
 * Download new version bin and conf
 * Compare the configuration file diff and modify the necessary configuration, such as endpoint, zk_cluster, etc
 * Start nameserver
     ```bash
-    sh bin/start.sh start nameserver
+    bash bin/start.sh start nameserver
     ```
 * Repeat the above steps for the remaining nameservers
 
@@ -25,14 +25,14 @@ Here is the impact when upgrading OpenMLDB:
 
 * Stop tablet
     ```bash
-        sh bin/start.sh stop tablet
+        bash bin/start.sh stop tablet
     ```
 * Backup the old versions directories `bin` and `conf`
 * Download new version bin and conf
 * Compare the configuration file diff and modify the necessary configuration, such as endpoint, zk_cluster, etc
 * Start nameserver
     ```bash
-    sh bin/start.sh start tablet
+    bash bin/start.sh start tablet
     ```
 * If auto_failover is closed, you must connect to the ns client and perform the following operations to restore data. **The endpoint after the command is the endpoint of the restarted node**
   * offlineendpoint endpoint 

--- a/docs/en/use_case/JD_recommendation_en.md
+++ b/docs/en/use_case/JD_recommendation_en.md
@@ -226,7 +226,7 @@ According to [DeepFM paper](https://arxiv.org/abs/1703.04247), we treat both cat
 Change directory to demo directory and execute the following commands to process the data set.
 ```bash
 cd $demodir/openmldb_process/
-sh process_JD_out_full.sh $demodir/out/1
+bash process_JD_out_full.sh $demodir/out/1
 ```
 The generated dataset will be placed at `$demodir/openmldb_process/out`. After generating parquet dataset, dataset information will also be printed. It contains the information about the number of samples and table size array, which is needed when training.
 >train samples = 4007924

--- a/docs/zh/deploy/install_deploy.md
+++ b/docs/zh/deploy/install_deploy.md
@@ -91,7 +91,7 @@ cd openmldb-tablet-0.6.2
 * 如果此处使用的域名, 所有使用openmldb的client所在的机器都得配上对应的host. 不然会访问不到
 #### 3 启动服务
 ```
-sh bin/start.sh start standalone_tablet
+bash bin/start.sh start standalone_tablet
 ```
 **注: 服务启动后会在bin目录下产生standalone_tablet.pid文件, 里边保存启动时的进程号。如果该文件内的pid正在运行则会启动失败**
 
@@ -113,7 +113,7 @@ cd openmldb-ns-0.6.2
 **注: endpoint不能用0.0.0.0和127.0.0.1**
 #### 3 启动服务
 ```
-sh bin/start.sh start  standalone_nameserver
+bash bin/start.sh start  standalone_nameserver
 ```
 #### 4 检查服务是否启动
 ```bash
@@ -156,7 +156,7 @@ cd openmldb-apiserver-0.6.2
 #### 3 启动服务
 
 ```
-sh bin/start.sh start standalone_apiserver
+bash bin/start.sh start standalone_apiserver
 ```
 
 ## 部署集群版
@@ -184,7 +184,7 @@ clientPort=7181
 
 #### 3. 启动Zookeeper
 ```
-sh bin/zkServer.sh start
+bash bin/zkServer.sh start
 ```
 部署zookeeper集群[参考这里](https://zookeeper.apache.org/doc/r3.4.14/zookeeperStarted.html#sc_RunningReplicatedZooKeeper)
 
@@ -215,7 +215,7 @@ cd openmldb-tablet-0.6.2
 * zk_cluster和zk_root_path配置和nameserver的保持一致
 #### 3 启动服务
 ```
-sh bin/start.sh start tablet
+bash bin/start.sh start tablet
 ```
 重复以上步骤部署多个tablet
 
@@ -245,7 +245,7 @@ cd openmldb-ns-0.6.2
 **注: endpoint不能用0.0.0.0和127.0.0.1**
 #### 3 启动服务
 ```
-sh bin/start.sh start nameserver
+bash bin/start.sh start nameserver
 ```
 重复上述步骤部署多个nameserver
 
@@ -294,7 +294,7 @@ cd openmldb-apiserver-0.6.2
 #### 3 启动服务
 
 ```
-sh bin/start.sh start apiserver
+bash bin/start.sh start apiserver
 ```
 
 **注**: 如果在linux平台通过发布包启动nameserver/tablet/apiserver时core掉，很可能时指令集不兼容问题，需要通过源码编译openmldb。源码编译参考[这里](./compile.md), 需要采用方式三完整源代码编译。
@@ -334,7 +334,7 @@ spark.home=
 
 #### 3 启动服务
 ```
-bin/start.sh start taskmanager
+bash bin/start.sh start taskmanager
 ```
 #### 4 检查服务是否启动
 ```bash

--- a/docs/zh/maintain/scale.md
+++ b/docs/zh/maintain/scale.md
@@ -11,7 +11,7 @@
 - 修改conf/tablet.flags配置文件，zk_cluster和zk_root_path和集群中其他节点保持一致。修改endpoint。
 - 启动tablet
   ```bash
-    sh bin/start.sh start tablet
+    bash bin/start.sh start tablet
   ```
 启动后查看新增节点是否加入集群。如果执行showtablet命令列出了新节点endpoint说明已经加入到集群中
 
@@ -72,10 +72,10 @@ $ ./bin/openmldb --zk_cluster=172.27.128.31:8090,172.27.128.32:8090,172.27.128.3
 ### 3 下线节点
 执行停止命令
 ```bash
-sh bin/start.sh stop tablet
+bash bin/start.sh stop tablet
 ```
 如果该节点部署有nameserver也需要把nameserver停掉
 ```bash
-sh bin/start.sh stop nameserver
+bash bin/start.sh stop nameserver
 ```
 **注**：保持高可用至少需要两个nameserver节点

--- a/docs/zh/maintain/upgrade.md
+++ b/docs/zh/maintain/upgrade.md
@@ -8,14 +8,14 @@
 
 * 停止nameserver 
     ```bash
-    sh bin/start.sh stop nameserver
+    bash bin/start.sh stop nameserver
     ```
 * 备份旧版本bin和conf目录
 * 下载新版本bin和conf
 * 对比配置文件diff并修改必要的配置，如endpoint、zk\_cluster等
 * 启动nameserver
     ```bash
-    sh bin/start.sh start nameserver
+    bash bin/start.sh start nameserver
     ```
 * 对剩余nameserver重复以上步骤
 
@@ -23,14 +23,14 @@
 
 * 停止tablet
     ```bash
-    sh bin/start.sh stop tablet
+    bash bin/start.sh stop tablet
     ```
 * 备份旧版本bin和conf目录
 * 下载新版本bin和conf
 * 对比配置文件diff并修改必要的配置，如endpoint、zk\_cluster等
 * 启动tablet
     ```bash
-    sh bin/start.sh start tablet
+    bash bin/start.sh start tablet
     ```
 * 如果auto\_failover关闭时得连上ns client执行如下操作恢复数据。其中**命令后面的endpoint为重启节点的endpoint**
   * offlineendpoint endpoint 

--- a/docs/zh/use_case/JD_recommendation.md
+++ b/docs/zh/use_case/JD_recommendation.md
@@ -224,7 +224,7 @@ INTO OUTFILE '/root/project/out/1';
 进入demo文件夹，运行以下指令进行数据处理
 ```bash
 cd $demodir/openmldb_process/
-sh process_JD_out_full.sh $demodir/out/1
+bash process_JD_out_full.sh $demodir/out/1
 ```
 对应生成parquet数据集将生成在 `$demodir/openmldb_process/out`。数据信息将被打印如下，该信息将被输入为训练的配置文件。
 >train samples = 4007924

--- a/release/bin/start.sh
+++ b/release/bin/start.sh
@@ -72,7 +72,7 @@ case $OP in
         fi
 
         if [ "$COMPONENT" != "taskmanager" ]; then
-            ./bin/openmldb --flagfile=./conf/"$COMPONENT".flags --enable_status_service=true >> "$LOG_DIR"."$COMPONENT".log 2>&1 &
+            ./bin/openmldb --flagfile=./conf/"$COMPONENT".flags --enable_status_service=true >> "$LOG_DIR"/"$COMPONENT".log 2>&1 &
             PID=$!
             if [ -x "$(command -v curl)" ]; then
                 sleep 3
@@ -100,6 +100,7 @@ case $OP in
                     exit 0
                 fi
             fi
+            echo -e "${RED}Start ${COMPONENT} failed! Please check log in ${LOG_DIR}/${COMPONENT}.log${RES}"
         else
             if [ -f "./conf/taskmanager.properties" ]; then
                 cp ./conf/taskmanager.properties ./taskmanager/conf/taskmanager.properties
@@ -115,8 +116,8 @@ case $OP in
                 echo "Start ${COMPONENT} success"
                 exit 0
             fi
+            echo -e "${RED}Start ${COMPONENT} failed!${RES}"
         fi
-        echo -e "${RED}Start ${COMPONENT} failed!${RES}"
         ;;
     stop)
         echo "Stopping $COMPONENT ... "

--- a/release/bin/start.sh
+++ b/release/bin/start.sh
@@ -92,7 +92,7 @@ case $OP in
                     fi
                 done
             else
-                echo "no curl, sleep 10s then check the process running status"
+                echo "no curl, sleep 10s and then check the process running status"
                 sleep 10
                 if kill -0 "$PID" > /dev/null 2>&1; then
                     echo $PID > "$OPENMLDB_PID_FILE"

--- a/release/bin/start.sh
+++ b/release/bin/start.sh
@@ -45,8 +45,8 @@ do
 done
 
 if [ "$HAS_COMPONENT" = "false" ]; then
-    echo "No component named $COMPONENT in [$COMPONENTS]";
-    exit 1;
+    echo "No component named $COMPONENT in [$COMPONENTS]"
+    exit 1
 fi
 
 OPENMLDB_PID_FILE="./bin/$COMPONENT.pid"
@@ -72,10 +72,10 @@ case $OP in
         fi
 
         if [ "$COMPONENT" != "taskmanager" ]; then
-            ./bin/openmldb --flagfile=./conf/"$COMPONENT".flags --enable_status_service=true >>  "$LOG_DIR"."$COMPONENT".log 2>&1 &
+            ./bin/openmldb --flagfile=./conf/"$COMPONENT".flags --enable_status_service=true >> "$LOG_DIR"."$COMPONENT".log 2>&1 &
             PID=$!
-            sleep 3
             if [ -x "$(command -v curl)" ]; then
+                sleep 3
                 ENDPOINT=$(grep '\--endpoint' ./conf/"$COMPONENT".flags | awk -F '=' '{print $2}')
                 COUNT=1
                 while [ $COUNT -lt 12 ]
@@ -92,7 +92,8 @@ case $OP in
                     fi
                 done
             else
-                sleep 2
+                echo "no curl, sleep 10s then check the process running status"
+                sleep 10
                 if kill -0 "$PID" > /dev/null 2>&1; then
                     echo $PID > "$OPENMLDB_PID_FILE"
                     echo "Start ${COMPONENT} success"

--- a/release/bin/start.sh
+++ b/release/bin/start.sh
@@ -100,7 +100,7 @@ case $OP in
                     exit 0
                 fi
             fi
-            echo -e "${RED}Start ${COMPONENT} failed! Please check log in ${LOG_DIR}/${COMPONENT}.log${RES}"
+            echo -e "${RED}Start ${COMPONENT} failed! Please check log in ${LOG_DIR}/${COMPONENT}.log and ${LOG_DIR}/${COMPONENT}.INFO ${RES}"
         else
             if [ -f "./conf/taskmanager.properties" ]; then
                 cp ./conf/taskmanager.properties ./taskmanager/conf/taskmanager.properties


### PR DESCRIPTION
- run `start.sh` failed if has not installed `curl`
- update `sh` to `bash` in documents