### PR TITLE
fix: parquet check schema in load data

### DIFF
--- a/docs/zh/developer/sdk_develop.md
+++ b/docs/zh/developer/sdk_develop.md
@@ -66,7 +66,7 @@ mvn install -DskipTests=true -Dscalatest.skip=true -Dwagon.skip=true -Dmaven.tes
 ```
 然后再
 ```
-mvn test -pl openmldb-spark-connector -Dsuites=com._4paradigm.openmldb.spark.TestWrite
+mvn test -pl openmldb-spark-connector -Dsuites="com._4paradigm.openmldb.spark.TestWrite local"
 ```
 P.S. 如果你实时改动了代码，由于install到本地仓库存在之前的代码编译的jar包，会导致无法测试最新代码。请谨慎使用`-pl`的写法。
 

--- a/docs/zh/developer/sdk_develop.md
+++ b/docs/zh/developer/sdk_develop.md
@@ -59,8 +59,8 @@ DBSDK有分为Cluster和Standalone两种，因此也可连接两种OpenMLDB服�
 
 如果希望只在submodule中测试，可能会需要其他submodule依赖，比如openmldb-spark-connector依赖openmldb-jdbc。你需要先install编译好的包
 ```
+# make jsdk.so and mvn package
 make SQL_JAVASDK_ENABLE=ON
-# 或者
 cd java
 mvn install -DskipTests=true -Dscalatest.skip=true -Dwagon.skip=true -Dmaven.test.skip=true -Dgpg.skip
 ```

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/utils/HybridseUtil.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/utils/HybridseUtil.scala
@@ -299,7 +299,7 @@ object HybridseUtil {
       // ref https://spark.apache.org/docs/3.2.1/sql-data-sources-parquet.html
       df = reader.format(format).load(file)
       require(checkSchemaIgnoreNullable(df.schema, oriSchema),
-        s"(ignore nullable) loaded ${df.schema}!= table $oriSchema, check $file")
+        s"schema mismatch(ignore nullable), loaded ${df.schema}!= table $oriSchema, check $file")
       // reset nullable
       df = df.sqlContext.createDataFrame(df.rdd, oriSchema)
     } else{
@@ -325,7 +325,7 @@ object HybridseUtil {
       }
     }
 
-    require(df.schema == oriSchema, s"source loaded schema ${df.schema} != table schema $oriSchema, check $file")
+    require(df.schema == oriSchema, s"schema mismatch, loaded ${df.schema} != table $oriSchema, check $file")
     if (logger.isDebugEnabled()) {
       logger.debug("read dataframe count: {}", df.count())
       df.show(10)

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/utils/HybridseUtil.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/utils/HybridseUtil.scala
@@ -306,7 +306,7 @@ object HybridseUtil {
       // use string to read, then infer the format by the first non-null value of the ts column
       val longTsCols = HybridseUtil.parseLongTsCols(reader, readSchema, tsCols, file)
       logger.info(s"read schema: $readSchema, file $file")
-      var df = reader.schema(readSchema).load(file)
+      df = reader.schema(readSchema).load(file)
       if (longTsCols.nonEmpty) {
         // convert long type to timestamp type
         for (tsCol <- longTsCols) {
@@ -322,7 +322,7 @@ object HybridseUtil {
       }
     }
 
-    require(df.schema == oriSchema, "source schema must == table schema")
+    require(df.schema == oriSchema, s"source schema ${df.schema} != table schema $oriSchema")
     debugDf(df)
     df
   }

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/TestLoadDataPlan.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/TestLoadDataPlan.scala
@@ -84,11 +84,8 @@ class TestLoadDataPlan extends SparkTestSuite with Matchers {
     val originInfo = getLatestTableInfo(db, table)
     assert(!originInfo.hasOfflineTableInfo, s"shouldn't have offline info before the offline test, $originInfo")
     // P.S.
-    // When the src **csv** files have header, and the col names are different with table schema:
-    // 1. If soft-copy, we don't read data, can't do schema check. When we load files in registering offline table,
-    // we use autoLoad(use the table schema to read, header in csv will be ignored.).
-    // 2. If deep-copy, use autoLoad to read.
-    // TODO(hw): do restrict schema check even when soft-copy?
+    // When the src **csv** files have header, and the col names are different with table schema,
+    // use the table schema to read, header in csv will be ignored.
     val testFileWithHeader = "file://" + getClass.getResource("/load_data_test_src/test_with_any_header.csv").getPath
 
     println("no offline table info now, soft load data with any mode")

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/utils/HybridseUtilTest.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/utils/HybridseUtilTest.scala
@@ -48,10 +48,11 @@ class HybridseUtilTest extends SparkTestSuite with Matchers {
     cols.add(col)
     // but the source col 'ts' is timestamp
     val testFile = "file://" + getClass.getResource("/load_data_test_src/timestamp.parquet").getPath
-    the[IllegalArgumentException] thrownBy {
+    val thrown = the[IllegalArgumentException] thrownBy {
       val df = autoLoad(getSparkSession, testFile, "parquet", Map(("header", "true"), ("nullValue", "null")), cols)
       fail("unreachable")
-    } should have message "requirement failed: source schema must == table schema"
+    }
+    thrown.getMessage should startWith ("requirement failed: source schema")
   }
 
   test("Test AutoLoad Type Timestamp") {

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/utils/HybridseUtilTest.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/utils/HybridseUtilTest.scala
@@ -52,7 +52,7 @@ class HybridseUtilTest extends SparkTestSuite with Matchers {
       val df = autoLoad(getSparkSession, testFile, "parquet", Map(("header", "true"), ("nullValue", "null")), cols)
       fail("unreachable")
     }
-    thrown.getMessage should startWith ("requirement failed: source schema")
+    thrown.getMessage should startWith ("requirement failed: schema mismatch")
   }
 
   test("Test AutoLoad Type Timestamp") {

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/utils/HybridseUtilTest.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/utils/HybridseUtilTest.scala
@@ -20,9 +20,9 @@ import com._4paradigm.openmldb.batch.SparkTestSuite
 import com._4paradigm.openmldb.batch.utils.HybridseUtil.autoLoad
 import com._4paradigm.openmldb.proto.{Common, Type}
 import org.apache.spark.sql.DataFrame
-import org.scalatest.Matchers.{convertToAnyShouldWrapper, equal}
+import org.scalatest.Matchers
 
-class HybridseUtilTest extends SparkTestSuite {
+class HybridseUtilTest extends SparkTestSuite with Matchers {
 
   def checkTsColResult(df: DataFrame, expected: String): Unit = {
     df.show()
@@ -30,7 +30,7 @@ class HybridseUtilTest extends SparkTestSuite {
     l.toString() should equal(expected)
   }
 
-  test("Test AutoLoad") {
+  test("Test AutoLoad Csv") {
     val col = Common.ColumnDesc.newBuilder().setName("ts").setDataType(Type.DataType.kTimestamp).build()
     val cols = new java.util.ArrayList[Common.ColumnDesc]
     cols.add(col)
@@ -39,6 +39,19 @@ class HybridseUtilTest extends SparkTestSuite {
     // test format with upper case
     val df = autoLoad(getSparkSession, testFile, "Csv", Map(("header", "true"), ("nullValue", "null")), cols)
     checkTsColResult(df, "List(null, 1970-01-01 00:00:00.0, null, null, 2022-02-01 09:00:00.0)")
+  }
+
+  test("Test AutoLoad Parquet") {
+    // expect ts string
+    val col = Common.ColumnDesc.newBuilder().setName("ts").setDataType(Type.DataType.kVarchar).build()
+    val cols = new java.util.ArrayList[Common.ColumnDesc]
+    cols.add(col)
+    // but the source col 'ts' is timestamp
+    val testFile = "file://" + getClass.getResource("/load_data_test_src/timestamp.parquet").getPath
+    the[IllegalArgumentException] thrownBy {
+      val df = autoLoad(getSparkSession, testFile, "parquet", Map(("header", "true"), ("nullValue", "null")), cols)
+      fail("unreachable")
+    } should have message "requirement failed: source schema must == table schema"
   }
 
   test("Test AutoLoad Type Timestamp") {


### PR DESCRIPTION
Closes #1211,  closes #2647

Check the source schema even in soft copy. spark.read won't cost a lot, lazy.