### PR TITLE
fix(#2505): refine `select *` expansion 

### DIFF
--- a/cases/plan/having_query.yaml
+++ b/cases/plan/having_query.yaml
@@ -110,16 +110,16 @@ cases:
           |  |    |    +-column_name: COL1
           |  |    +-name: <nil>
           |  +-1:
-          |     +-node[kResTarget]
-          |       +-val:
-          |       |  +-expr[function]
-          |       |    +-function:
-          |       |    |  [Unresolved](sum)
-          |       |    +-arg[0]:
-          |       |      +-expr[column ref]
-          |       |        +-relation_name: <nil>
-          |       |        +-column_name: COL3
-          |       +-name: col3sum
+          |    +-node[kResTarget]
+          |      +-val:
+          |      |  +-expr[function]
+          |      |    +-function:
+          |      |    |  [Unresolved](sum)
+          |      |    +-arg[0]:
+          |      |      +-expr[column ref]
+          |      |        +-relation_name: <nil>
+          |      |        +-column_name: COL3
+          |      +-name: col3sum
           +-tableref_list[list]:
           |  +-0:
           |    +-node[kTableRef]: kTable

--- a/cases/plan/having_query.yaml
+++ b/cases/plan/having_query.yaml
@@ -64,7 +64,7 @@ cases:
   - id: 4
     desc: 先过滤再分组聚合再过滤
     mode: request-unsupport
-    sql: SELECT COL1, sum(COL3) as col3sum, * FROM t1 where COL2 > 10 group by COL1 having sum(COL3) > 0;
+    sql: SELECT COL1, sum(COL3) as col3sum FROM t1 where COL2 > 10 group by COL1 having sum(COL3) > 0;
     expect:
       node_tree_str: |
         +-node[kQuery]: kQuerySelect
@@ -110,21 +110,16 @@ cases:
           |  |    |    +-column_name: COL1
           |  |    +-name: <nil>
           |  +-1:
-          |  |  +-node[kResTarget]
-          |  |    +-val:
-          |  |    |  +-expr[function]
-          |  |    |    +-function:
-          |  |    |    |  [Unresolved](sum)
-          |  |    |    +-arg[0]:
-          |  |    |      +-expr[column ref]
-          |  |    |        +-relation_name: <nil>
-          |  |    |        +-column_name: COL3
-          |  |    +-name: col3sum
-          |  +-2:
-          |    +-node[kResTarget]
-          |      +-val:
-          |      |  +-expr[all]
-          |      +-name: <nil>
+          |     +-node[kResTarget]
+          |       +-val:
+          |       |  +-expr[function]
+          |       |    +-function:
+          |       |    |  [Unresolved](sum)
+          |       |    +-arg[0]:
+          |       |      +-expr[column ref]
+          |       |        +-relation_name: <nil>
+          |       |        +-column_name: COL3
+          |       +-name: col3sum
           +-tableref_list[list]:
           |  +-0:
           |    +-node[kTableRef]: kTable

--- a/cases/query/simple_query.yaml
+++ b/cases/query/simple_query.yaml
@@ -798,12 +798,11 @@ cases:
         partition by id order by ts rows between 2 preceding and current row),
       w2 as (
         partition by b order by ts rows_range between 2s preceding and current row)
-    # TODO(ace): t1.col -> t1.col is redundant as output name
     cluster_request_plan: |
-      SIMPLE_PROJECT(sources=(id, t1.id -> t1.id, t1.b -> t1.b, t1.ts -> t1.ts, b, cnt1, cnt2))
+      SIMPLE_PROJECT(sources=(id, t1.id, t1.b, t1.ts, b, cnt1, cnt2))
         REQUEST_JOIN(type=kJoinTypeConcat)
           REQUEST_JOIN(type=kJoinTypeConcat)
-            SIMPLE_PROJECT(sources=(id, t1.id -> t1.id, t1.b -> t1.b, t1.ts -> t1.ts, b))
+            SIMPLE_PROJECT(sources=(id, t1.id, t1.b, t1.ts, b))
               DATA_PROVIDER(request=t1)
             PROJECT(type=Aggregation)
               REQUEST_UNION(partition_keys=(), orders=(ASC), rows=(ts, 2 PRECEDING, 0 CURRENT), index_keys=(id))
@@ -814,7 +813,7 @@ cases:
               DATA_PROVIDER(request=t1)
               DATA_PROVIDER(type=Partition, table=t1, index=idx2)
     expect:
-      columns: ["id int32", "t1.id int32", "t1.b int32", "t1.ts int64", "b int32", "cnt1 int64", "cnt2 int64"]
+      columns: ["id int32", "id int32", "b int32", "ts int64", "b int32", "cnt1 int64", "cnt2 int64"]
       order: id
       data: |
           1, 1, 10, 1000, 10, 1, 1

--- a/cases/query/simple_query.yaml
+++ b/cases/query/simple_query.yaml
@@ -714,7 +714,7 @@ cases:
         aaa, bbb, ccc
 
   # =============================================================#
-  # 100-104: Output schema correctness for SQL query that contains All('*')
+  # 100-105: Output schema correctness for SQL query that contains All('*')
   #   refer issue https://github.com/4paradigm/OpenMLDB/issues/2505
   # =============================================================
   - id: 100
@@ -733,7 +733,7 @@ cases:
       window w as (
         partition by id order by ts rows between 2 preceding and current row);
     cluster_request_plan: |
-      SIMPLE_PROJECT(sources=(id, b, ts, cnt))
+      SIMPLE_PROJECT(sources=(t1.id, t1.b, t1.ts, cnt))
         REQUEST_JOIN(type=kJoinTypeConcat)
           DATA_PROVIDER(request=t1)
           PROJECT(type=Aggregation)
@@ -758,14 +758,14 @@ cases:
           1, 10, 1000
           2, 30, 2000
     sql: |
-      select b,  *, count(id) over w as cnt
+      select b, *, count(id) over w as cnt
       from t1
       window w as (
         partition by id order by ts rows between 2 preceding and current row);
     cluster_request_plan: |
-      SIMPLE_PROJECT(sources=(b, id, b, ts, cnt))
+      SIMPLE_PROJECT(sources=(b, t1.id, t1.b, t1.ts, cnt))
         REQUEST_JOIN(type=kJoinTypeConcat)
-          SIMPLE_PROJECT(sources=(b, id, b, ts))
+          SIMPLE_PROJECT(sources=(b, t1.id, t1.b, t1.ts))
             DATA_PROVIDER(request=t1)
           PROJECT(type=Aggregation)
             REQUEST_UNION(partition_keys=(), orders=(ASC), rows=(ts, 2 PRECEDING, 0 CURRENT), index_keys=(id))
@@ -840,10 +840,10 @@ cases:
       w2 as (
         partition by b order by ts rows_range between 2s preceding and current row);
     cluster_request_plan: |
-      SIMPLE_PROJECT(sources=(cnt1, id, id, b, ts, b, cnt2))
+      SIMPLE_PROJECT(sources=(cnt1, id, t1.id, t1.b, t1.ts, b, cnt2))
         REQUEST_JOIN(type=kJoinTypeConcat)
           REQUEST_JOIN(type=kJoinTypeConcat)
-            SIMPLE_PROJECT(sources=(id, id, b, ts, b))
+            SIMPLE_PROJECT(sources=(id, t1.id, t1.b, t1.ts, b))
               DATA_PROVIDER(request=t1)
             PROJECT(type=Aggregation)
               REQUEST_UNION(partition_keys=(), orders=(ASC), rows=(ts, 2 PRECEDING, 0 CURRENT), index_keys=(id))
@@ -885,11 +885,11 @@ cases:
       w3 as (
         partition by b order by ts rows_range between 2s preceding and current row exclude current_row);
     cluster_request_plan: |
-      SIMPLE_PROJECT(sources=(cnt1, id, id, b, ts, cnt2, b, cnt3))
+      SIMPLE_PROJECT(sources=(cnt1, id, t1.id, t1.b, t1.ts, cnt2, b, cnt3))
         REQUEST_JOIN(type=kJoinTypeConcat)
           REQUEST_JOIN(type=kJoinTypeConcat)
             REQUEST_JOIN(type=kJoinTypeConcat)
-              SIMPLE_PROJECT(sources=(id, id, b, ts, b))
+              SIMPLE_PROJECT(sources=(id, t1.id, t1.b, t1.ts, b))
                 DATA_PROVIDER(request=t1)
               PROJECT(type=Aggregation)
                 REQUEST_UNION(partition_keys=(), orders=(ASC), rows=(ts, 2 PRECEDING, 0 CURRENT), index_keys=(id))
@@ -909,3 +909,52 @@ cases:
       data: |
           1, 1, 1, 10, 1000, 1, 10, 0
           1, 2, 2, 30, 2000, 1, 30, 0
+  - id: 105
+    desc: |
+      simple select(*) over last join (multiple input source)
+    inputs:
+      - name: t1
+        columns: ["id int32", "b int32", "ts int64"]
+        indexs: ["idx1:id:ts", "idx2:b:ts"]
+        data: |
+          1, 10, 1000
+          2, 30, 2000
+      - name: t2
+        columns: ["id int32", "b int32", "ts int64"]
+        indexs: ["idx1:id:ts", "idx2:b:ts"]
+        data: |
+          3, 10, 1000
+          4, 30, 2000
+    sql: |
+      select * from t1 last join t2 on t1.b = t2.b;
+    expect:
+      columns: ["id int32", "b int32", "ts int64", "id int32", "b int32", "ts int64"]
+      order: id
+      data: |
+        1, 10, 1000, 3, 10, 1000
+        2, 30, 2000, 4, 30, 2000
+
+  - id: 106
+    desc: |
+      select(t1.*) over last join (multiple input source)
+    inputs:
+      - name: t1
+        columns: ["id int32", "b int32", "ts int64"]
+        indexs: ["idx1:id:ts", "idx2:b:ts"]
+        data: |
+          1, 10, 1000
+          2, 30, 2000
+      - name: t2
+        columns: ["id int32", "b int32", "ts int64"]
+        indexs: ["idx1:id:ts", "idx2:b:ts"]
+        data: |
+          3, 10, 1000
+          4, 30, 2000
+    sql: |
+      select t1.* from t1 last join t2 on t1.b = t2.b;
+    expect:
+      columns: ["id int32", "b int32", "ts int64"]
+      order: id
+      data: |
+        1, 10, 1000
+        2, 30, 2000

--- a/cases/query/simple_query.yaml
+++ b/cases/query/simple_query.yaml
@@ -714,8 +714,8 @@ cases:
         aaa, bbb, ccc
 
   # =============================================================#
-  #
-  #
+  # 100-103: test correct physical plan is generated for all project in cluster request mode
+  #   refer issue https://github.com/4paradigm/OpenMLDB/issues/2505
   # =============================================================
   - id: 100
     desc: |
@@ -733,7 +733,7 @@ cases:
       window w as (
         partition by id order by ts rows between 2 preceding and current row)
     cluster_request_plan: |
-      SIMPLE_PROJECT(sources=(t1.id, t1.b, t1.ts, cnt))
+      SIMPLE_PROJECT(sources=(id, b, ts, cnt))
         REQUEST_JOIN(type=kJoinTypeConcat)
           DATA_PROVIDER(request=t1)
           PROJECT(type=Aggregation)
@@ -765,7 +765,7 @@ cases:
     cluster_request_plan: |
       SIMPLE_PROJECT(sources=(b, id, b, ts, cnt))
         REQUEST_JOIN(type=kJoinTypeConcat)
-          SIMPLE_PROJECT(sources=(b, t1.id, t1.b, t1.ts))
+          SIMPLE_PROJECT(sources=(b, id, b, ts))
             DATA_PROVIDER(request=t1)
           PROJECT(type=Aggregation)
             REQUEST_UNION(partition_keys=(), orders=(ASC), rows=(ts, 2 PRECEDING, 0 CURRENT), index_keys=(id))
@@ -790,7 +790,7 @@ cases:
           2, 30, 2000
     sql: |
       select
-        id, *, b,
+        id, t1.*, b,
         count(id) over w1 as cnt1,
         count(id) over w2 as cnt2
       from t1
@@ -798,11 +798,12 @@ cases:
         partition by id order by ts rows between 2 preceding and current row),
       w2 as (
         partition by b order by ts rows_range between 2s preceding and current row)
+    # TODO(ace): t1.col -> t1.col is redundant as output name
     cluster_request_plan: |
-      SIMPLE_PROJECT(sources=(id, id, b, ts, b, cnt1, cnt2))
+      SIMPLE_PROJECT(sources=(id, t1.id -> t1.id, t1.b -> t1.b, t1.ts -> t1.ts, b, cnt1, cnt2))
         REQUEST_JOIN(type=kJoinTypeConcat)
           REQUEST_JOIN(type=kJoinTypeConcat)
-            SIMPLE_PROJECT(sources=(id, t1.id, t1.b, t1.ts, b))
+            SIMPLE_PROJECT(sources=(id, t1.id -> t1.id, t1.b -> t1.b, t1.ts -> t1.ts, b))
               DATA_PROVIDER(request=t1)
             PROJECT(type=Aggregation)
               REQUEST_UNION(partition_keys=(), orders=(ASC), rows=(ts, 2 PRECEDING, 0 CURRENT), index_keys=(id))
@@ -813,7 +814,7 @@ cases:
               DATA_PROVIDER(request=t1)
               DATA_PROVIDER(type=Partition, table=t1, index=idx2)
     expect:
-      columns: ["id int32", "id int32", "b int32", "ts int64", "b int32", "cnt1 int64", "cnt2 int64"]
+      columns: ["id int32", "t1.id int32", "t1.b int32", "t1.ts int64", "b int32", "cnt1 int64", "cnt2 int64"]
       order: id
       data: |
           1, 1, 10, 1000, 10, 1, 1
@@ -838,20 +839,20 @@ cases:
         partition by id order by ts rows between 2 preceding and current row),
       w2 as (
         partition by b order by ts rows_range between 2s preceding and current row)
-    # cluster_request_plan: |
-    #   SIMPLE_PROJECT(sources=(id, id, b, ts, b, cnt1, cnt2))
-    #     REQUEST_JOIN(type=kJoinTypeConcat)
-    #       REQUEST_JOIN(type=kJoinTypeConcat)
-    #         SIMPLE_PROJECT(sources=(id, t1.id, t1.b, t1.ts, b))
-    #           DATA_PROVIDER(request=t1)
-    #         PROJECT(type=Aggregation)
-    #           REQUEST_UNION(partition_keys=(), orders=(ASC), rows=(ts, 2 PRECEDING, 0 CURRENT), index_keys=(id))
-    #             DATA_PROVIDER(request=t1)
-    #             DATA_PROVIDER(type=Partition, table=t1, index=idx1)
-    #       PROJECT(type=Aggregation)
-    #         REQUEST_UNION(partition_keys=(), orders=(ASC), range=(ts, 2000 PRECEDING, 0 CURRENT), index_keys=(b))
-    #           DATA_PROVIDER(request=t1)
-    #           DATA_PROVIDER(type=Partition, table=t1, index=idx2)
+    cluster_request_plan: |
+      SIMPLE_PROJECT(sources=(cnt1, id, id, b, ts, b, cnt2))
+        REQUEST_JOIN(type=kJoinTypeConcat)
+          REQUEST_JOIN(type=kJoinTypeConcat)
+            SIMPLE_PROJECT(sources=(id, id, b, ts, b))
+              DATA_PROVIDER(request=t1)
+            PROJECT(type=Aggregation)
+              REQUEST_UNION(partition_keys=(), orders=(ASC), rows=(ts, 2 PRECEDING, 0 CURRENT), index_keys=(id))
+                DATA_PROVIDER(request=t1)
+                DATA_PROVIDER(type=Partition, table=t1, index=idx1)
+          PROJECT(type=Aggregation)
+            REQUEST_UNION(partition_keys=(), orders=(ASC), range=(ts, 2000 PRECEDING, 0 CURRENT), index_keys=(b))
+              DATA_PROVIDER(request=t1)
+              DATA_PROVIDER(type=Partition, table=t1, index=idx2)
     expect:
       columns: ["cnt1 int64", "id int32", "id int32", "b int32", "ts int64", "b int32", "cnt2 int64"]
       order: id

--- a/cases/query/simple_query.yaml
+++ b/cases/query/simple_query.yaml
@@ -712,3 +712,25 @@ cases:
       columns: ["a string", "b string", "c string"]
       data: |
         aaa, bbb, ccc
+
+  - id: 100
+    desc: |
+      simple select(*) + column ref
+    inputs:
+      - name: t1
+        columns: ["id int32", "b int32", "ts int64"]
+        indexs: ["idx:id:ts"]
+        data: |
+          1, 10, 1000
+          2, 30, 2000
+    sql: |
+      select *, count(id) over w as cnt
+      from t1
+      window w as (
+      partition by id order by ts rows between 2 preceding and current row)
+    expect:
+      columns: ["id int32", "b int32", "ts int64", "cnt int64"]
+      order: id
+      data: |
+          1, 10, 1000, 1
+          2, 30, 2000, 1

--- a/cases/query/simple_query.yaml
+++ b/cases/query/simple_query.yaml
@@ -714,7 +714,7 @@ cases:
         aaa, bbb, ccc
 
   # =============================================================#
-  # 100-103: test correct physical plan is generated for all project in cluster request mode
+  # 100-104: Output schema correctness for SQL query that contains All('*')
   #   refer issue https://github.com/4paradigm/OpenMLDB/issues/2505
   # =============================================================
   - id: 100
@@ -731,7 +731,7 @@ cases:
       select *, count(id) over w as cnt
       from t1
       window w as (
-        partition by id order by ts rows between 2 preceding and current row)
+        partition by id order by ts rows between 2 preceding and current row);
     cluster_request_plan: |
       SIMPLE_PROJECT(sources=(id, b, ts, cnt))
         REQUEST_JOIN(type=kJoinTypeConcat)
@@ -761,7 +761,7 @@ cases:
       select b,  *, count(id) over w as cnt
       from t1
       window w as (
-        partition by id order by ts rows between 2 preceding and current row)
+        partition by id order by ts rows between 2 preceding and current row);
     cluster_request_plan: |
       SIMPLE_PROJECT(sources=(b, id, b, ts, cnt))
         REQUEST_JOIN(type=kJoinTypeConcat)
@@ -797,7 +797,7 @@ cases:
       window w1 as (
         partition by id order by ts rows between 2 preceding and current row),
       w2 as (
-        partition by b order by ts rows_range between 2s preceding and current row)
+        partition by b order by ts rows_range between 2s preceding and current row);
     cluster_request_plan: |
       SIMPLE_PROJECT(sources=(id, t1.id, t1.b, t1.ts, b, cnt1, cnt2))
         REQUEST_JOIN(type=kJoinTypeConcat)
@@ -818,6 +818,7 @@ cases:
       data: |
           1, 1, 10, 1000, 10, 1, 1
           2, 2, 30, 2000, 30, 1, 1
+
   - id: 103
     desc: |
       simple select(*) + agg project * multiple window
@@ -837,7 +838,7 @@ cases:
       window w1 as (
         partition by id order by ts rows between 2 preceding and current row),
       w2 as (
-        partition by b order by ts rows_range between 2s preceding and current row)
+        partition by b order by ts rows_range between 2s preceding and current row);
     cluster_request_plan: |
       SIMPLE_PROJECT(sources=(cnt1, id, id, b, ts, b, cnt2))
         REQUEST_JOIN(type=kJoinTypeConcat)
@@ -858,3 +859,53 @@ cases:
       data: |
           1, 1, 1, 10, 1000, 10, 1
           1, 2, 2, 30, 2000, 30, 1
+
+  - id: 104
+    desc: |
+      simple select(*) + agg project * multiple window
+    inputs:
+      - name: t1
+        columns: ["id int32", "b int32", "ts int64"]
+        indexs: ["idx1:id:ts", "idx2:b:ts"]
+        data: |
+          1, 10, 1000
+          2, 30, 2000
+    sql: |
+      select
+        count(id) over w1 as cnt1,
+        id, *,
+        count(id) over w2 as cnt2,
+        b,
+        count(id) over w3 as cnt3
+      from t1
+      window w1 as (
+        partition by id order by ts rows between 2 preceding and current row),
+      w2 as (
+        partition by b order by ts rows_range between 2s preceding and current row),
+      w3 as (
+        partition by b order by ts rows_range between 2s preceding and current row exclude current_row);
+    cluster_request_plan: |
+      SIMPLE_PROJECT(sources=(cnt1, id, id, b, ts, cnt2, b, cnt3))
+        REQUEST_JOIN(type=kJoinTypeConcat)
+          REQUEST_JOIN(type=kJoinTypeConcat)
+            REQUEST_JOIN(type=kJoinTypeConcat)
+              SIMPLE_PROJECT(sources=(id, id, b, ts, b))
+                DATA_PROVIDER(request=t1)
+              PROJECT(type=Aggregation)
+                REQUEST_UNION(partition_keys=(), orders=(ASC), rows=(ts, 2 PRECEDING, 0 CURRENT), index_keys=(id))
+                  DATA_PROVIDER(request=t1)
+                  DATA_PROVIDER(type=Partition, table=t1, index=idx1)
+            PROJECT(type=Aggregation)
+              REQUEST_UNION(partition_keys=(), orders=(ASC), range=(ts, 2000 PRECEDING, 0 CURRENT), index_keys=(b))
+                DATA_PROVIDER(request=t1)
+                DATA_PROVIDER(type=Partition, table=t1, index=idx2)
+          PROJECT(type=Aggregation)
+            REQUEST_UNION(EXCLUDE_CURRENT_ROW, partition_keys=(), orders=(ASC), range=(ts, 2000 PRECEDING, 0 CURRENT), index_keys=(b))
+              DATA_PROVIDER(request=t1)
+              DATA_PROVIDER(type=Partition, table=t1, index=idx2)
+    expect:
+      columns: ["cnt1 int64", "id int32", "id int32", "b int32", "ts int64",  "cnt2 int64", "b int32", "cnt3 int64"]
+      order: id
+      data: |
+          1, 1, 1, 10, 1000, 1, 10, 0
+          1, 2, 2, 30, 2000, 1, 30, 0

--- a/cases/query/simple_query.yaml
+++ b/cases/query/simple_query.yaml
@@ -713,9 +713,13 @@ cases:
       data: |
         aaa, bbb, ccc
 
+  # =============================================================#
+  #
+  #
+  # =============================================================
   - id: 100
     desc: |
-      simple select(*) + column ref
+      simple select(*) + agg project
     inputs:
       - name: t1
         columns: ["id int32", "b int32", "ts int64"]
@@ -727,10 +731,130 @@ cases:
       select *, count(id) over w as cnt
       from t1
       window w as (
-      partition by id order by ts rows between 2 preceding and current row)
+        partition by id order by ts rows between 2 preceding and current row)
+    cluster_request_plan: |
+      SIMPLE_PROJECT(sources=(t1.id, t1.b, t1.ts, cnt))
+        REQUEST_JOIN(type=kJoinTypeConcat)
+          DATA_PROVIDER(request=t1)
+          PROJECT(type=Aggregation)
+            REQUEST_UNION(partition_keys=(), orders=(ASC), rows=(ts, 2 PRECEDING, 0 CURRENT), index_keys=(id))
+              DATA_PROVIDER(request=t1)
+              DATA_PROVIDER(type=Partition, table=t1, index=idx)
     expect:
       columns: ["id int32", "b int32", "ts int64", "cnt int64"]
       order: id
       data: |
           1, 10, 1000, 1
           2, 30, 2000, 1
+
+  - id: 101
+    desc: |
+      simple select(*) + column ref + agg project
+    inputs:
+      - name: t1
+        columns: ["id int32", "b int32", "ts int64"]
+        indexs: ["idx:id:ts"]
+        data: |
+          1, 10, 1000
+          2, 30, 2000
+    sql: |
+      select b,  *, count(id) over w as cnt
+      from t1
+      window w as (
+        partition by id order by ts rows between 2 preceding and current row)
+    cluster_request_plan: |
+      SIMPLE_PROJECT(sources=(b, id, b, ts, cnt))
+        REQUEST_JOIN(type=kJoinTypeConcat)
+          SIMPLE_PROJECT(sources=(b, t1.id, t1.b, t1.ts))
+            DATA_PROVIDER(request=t1)
+          PROJECT(type=Aggregation)
+            REQUEST_UNION(partition_keys=(), orders=(ASC), rows=(ts, 2 PRECEDING, 0 CURRENT), index_keys=(id))
+              DATA_PROVIDER(request=t1)
+              DATA_PROVIDER(type=Partition, table=t1, index=idx)
+    expect:
+      columns: ["b int32", "id int32", "b int32", "ts int64", "cnt int64"]
+      order: id
+      data: |
+          10, 1, 10, 1000, 1
+          30, 2, 30, 2000, 1
+
+  - id: 102
+    desc: |
+      simple select(*) + agg project * multiple window
+    inputs:
+      - name: t1
+        columns: ["id int32", "b int32", "ts int64"]
+        indexs: ["idx1:id:ts", "idx2:b:ts"]
+        data: |
+          1, 10, 1000
+          2, 30, 2000
+    sql: |
+      select
+        id, *, b,
+        count(id) over w1 as cnt1,
+        count(id) over w2 as cnt2
+      from t1
+      window w1 as (
+        partition by id order by ts rows between 2 preceding and current row),
+      w2 as (
+        partition by b order by ts rows_range between 2s preceding and current row)
+    cluster_request_plan: |
+      SIMPLE_PROJECT(sources=(id, id, b, ts, b, cnt1, cnt2))
+        REQUEST_JOIN(type=kJoinTypeConcat)
+          REQUEST_JOIN(type=kJoinTypeConcat)
+            SIMPLE_PROJECT(sources=(id, t1.id, t1.b, t1.ts, b))
+              DATA_PROVIDER(request=t1)
+            PROJECT(type=Aggregation)
+              REQUEST_UNION(partition_keys=(), orders=(ASC), rows=(ts, 2 PRECEDING, 0 CURRENT), index_keys=(id))
+                DATA_PROVIDER(request=t1)
+                DATA_PROVIDER(type=Partition, table=t1, index=idx1)
+          PROJECT(type=Aggregation)
+            REQUEST_UNION(partition_keys=(), orders=(ASC), range=(ts, 2000 PRECEDING, 0 CURRENT), index_keys=(b))
+              DATA_PROVIDER(request=t1)
+              DATA_PROVIDER(type=Partition, table=t1, index=idx2)
+    expect:
+      columns: ["id int32", "id int32", "b int32", "ts int64", "b int32", "cnt1 int64", "cnt2 int64"]
+      order: id
+      data: |
+          1, 1, 10, 1000, 10, 1, 1
+          2, 2, 30, 2000, 30, 1, 1
+  - id: 103
+    desc: |
+      simple select(*) + agg project * multiple window
+    inputs:
+      - name: t1
+        columns: ["id int32", "b int32", "ts int64"]
+        indexs: ["idx1:id:ts", "idx2:b:ts"]
+        data: |
+          1, 10, 1000
+          2, 30, 2000
+    sql: |
+      select
+        count(id) over w1 as cnt1,
+        id, *, b,
+        count(id) over w2 as cnt2
+      from t1
+      window w1 as (
+        partition by id order by ts rows between 2 preceding and current row),
+      w2 as (
+        partition by b order by ts rows_range between 2s preceding and current row)
+    # cluster_request_plan: |
+    #   SIMPLE_PROJECT(sources=(id, id, b, ts, b, cnt1, cnt2))
+    #     REQUEST_JOIN(type=kJoinTypeConcat)
+    #       REQUEST_JOIN(type=kJoinTypeConcat)
+    #         SIMPLE_PROJECT(sources=(id, t1.id, t1.b, t1.ts, b))
+    #           DATA_PROVIDER(request=t1)
+    #         PROJECT(type=Aggregation)
+    #           REQUEST_UNION(partition_keys=(), orders=(ASC), rows=(ts, 2 PRECEDING, 0 CURRENT), index_keys=(id))
+    #             DATA_PROVIDER(request=t1)
+    #             DATA_PROVIDER(type=Partition, table=t1, index=idx1)
+    #       PROJECT(type=Aggregation)
+    #         REQUEST_UNION(partition_keys=(), orders=(ASC), range=(ts, 2000 PRECEDING, 0 CURRENT), index_keys=(b))
+    #           DATA_PROVIDER(request=t1)
+    #           DATA_PROVIDER(type=Partition, table=t1, index=idx2)
+    expect:
+      columns: ["cnt1 int64", "id int32", "id int32", "b int32", "ts int64", "b int32", "cnt2 int64"]
+      order: id
+      data: |
+          1, 1, 1, 10, 1000, 10, 1
+          1, 2, 2, 30, 2000, 30, 1

--- a/hybridse/include/node/plan_node.h
+++ b/hybridse/include/node/plan_node.h
@@ -357,6 +357,7 @@ class ProjectPlanNode : public UnaryPlanNode {
 
     const std::string table_;
     const PlanNodeList project_list_vec_;
+    // final output column index -> (index of of project_list_vec_, index of project of that project list node)
     const std::vector<std::pair<uint32_t, uint32_t>> pos_mapping_;
     bool IsSimpleProjectPlan();
 };

--- a/hybridse/include/node/sql_node.h
+++ b/hybridse/include/node/sql_node.h
@@ -1421,8 +1421,8 @@ class AllNode : public ExprNode {
         : ExprNode(kExprAll), relation_name_(relation_name), db_name_(db_name) {}
 
     ~AllNode() {}
-    std::string GetRelationName() const { return relation_name_; }
-    std::string GetDBName() const { return db_name_; }
+    const std::string& GetRelationName() const { return relation_name_; }
+    const std::string& GetDBName() const { return db_name_; }
 
     void SetRelationName(const std::string &relation_name) { relation_name_ = relation_name; }
     const std::string GetExprString() const;

--- a/hybridse/include/vm/physical_op.h
+++ b/hybridse/include/vm/physical_op.h
@@ -756,7 +756,7 @@ class PhysicalSimpleProjectNode : public PhysicalUnaryNode {
     }
 
     virtual ~PhysicalSimpleProjectNode() {}
-    virtual void Print(std::ostream &output, const std::string &tab) const;
+    void Print(std::ostream &output, const std::string &tab) const override;
     static PhysicalSimpleProjectNode *CastFrom(PhysicalOpNode *node);
 
     const ColumnProjects &project() const { return project_; }
@@ -1327,7 +1327,7 @@ class PhysicalRequestJoinNode : public PhysicalBinaryNode {
         fn_infos_.push_back(&join_.right_key_.fn_info());
         fn_infos_.push_back(&join_.index_key_.fn_info());
     }
-    virtual void Print(std::ostream &output, const std::string &tab) const;
+    void Print(std::ostream &output, const std::string &tab) const override;
     const Join &join() const { return join_; }
     const bool output_right_only() const { return output_right_only_; }
     const SchemasContext *joined_schemas_ctx() const {

--- a/hybridse/include/vm/schemas_context.h
+++ b/hybridse/include/vm/schemas_context.h
@@ -206,6 +206,8 @@ class SchemasContext {
      * Set the defautl database name
      */
     void SetDefaultDBName(const std::string& default_db_name);
+
+    const std::string& GetDefaultDBName() const { return default_db_name_; }
     /**
      * Add new schema source and return the mutable instance of added source.
      */

--- a/hybridse/src/codegen/fn_let_ir_builder_test.h
+++ b/hybridse/src/codegen/fn_let_ir_builder_test.h
@@ -84,15 +84,10 @@ node::ProjectListNode* GetPlanNodeList(node::PlanNodeList trees) {
     return pp_node_ptr;
 }
 
-
-
-void CheckFnLetBuilderWithParameterRow(::hybridse::node::NodeManager* manager,
-                       vm::SchemasContext* schemas_ctx,
-                                       const codec::Schema* parameter_types,
-                                       std::string udf_str,
-                       std::string sql, int8_t* row_ptr, int8_t* window_ptr,
-                                    int8_t * parameter_row_ptr,
-                       vm::Schema* output_schema, int8_t** output) {
+void CheckFnLetBuilderWithParameterRow(::hybridse::node::NodeManager* manager, vm::SchemasContext* schemas_ctx,
+                                       const codec::Schema* parameter_types, std::string udf_str, std::string sql,
+                                       int8_t* row_ptr, int8_t* window_ptr, int8_t* parameter_row_ptr,
+                                       vm::Schema* output_schema, int8_t** output) {
     // Create an LLJIT instance.
     auto ctx = llvm::make_unique<LLVMContext>();
     auto m = make_unique<Module>("test_project", *ctx);

--- a/hybridse/src/vm/transform.h
+++ b/hybridse/src/vm/transform.h
@@ -278,13 +278,10 @@ class RequestModeTransformer : public BatchModeTransformer {
 
  protected:
     void ApplyPasses(PhysicalOpNode* node, PhysicalOpNode** output) override;
-    Status TransformProjectOp(node::ProjectListNode* node,
-                                      PhysicalOpNode* depend, bool append_input,
-                                      PhysicalOpNode** output) override;
-    Status TransformProjectPlanOp(const node::ProjectPlanNode* node,
-                                          PhysicalOpNode** output) override;
-    Status TransformJoinOp(const node::JoinPlanNode* node,
-                                   PhysicalOpNode** output) override;
+    Status TransformProjectPlanOp(const node::ProjectPlanNode* node, PhysicalOpNode** output) override;
+    Status TransformProjectOp(node::ProjectListNode* node, PhysicalOpNode* depend, bool append_input,
+                              PhysicalOpNode** output) override;
+    Status TransformJoinOp(const node::JoinPlanNode* node, PhysicalOpNode** output) override;
     Status TransformScanOp(const node::TablePlanNode* node, PhysicalOpNode** output) override;
     Status TransformGroupOp(const node::GroupPlanNode* node, PhysicalOpNode** output) override;
 

--- a/hybridse/src/vm/transform.h
+++ b/hybridse/src/vm/transform.h
@@ -233,15 +233,16 @@ class BatchModeTransformer {
     Status CheckPartitionColumn(const node::ExprListNode* partition, const SchemasContext* ctx);
 
     base::Status ExtractGroupKeys(vm::PhysicalOpNode* depend, const node::ExprListNode** keys);
+    Status CompleteProjectList(const node::ProjectPlanNode* project_node, PhysicalOpNode* depend) const;
+
     node::NodeManager* node_manager_;
     const std::string db_;
     const std::shared_ptr<Catalog> catalog_;
 
  private:
-    virtual Status TransformProjectPlanOpWithWindowParallel(
-        const node::ProjectPlanNode* node, PhysicalOpNode** output);
-    virtual Status TransformProjectPlanOpWindowSerial(
-        const node::ProjectPlanNode* node, PhysicalOpNode** output);
+    virtual Status TransformProjectPlanOpWithWindowParallel(const node::ProjectPlanNode* node, PhysicalOpNode** output);
+    virtual Status TransformProjectPlanOpWindowSerial(const node::ProjectPlanNode* node, PhysicalOpNode** output);
+
     ::llvm::Module* module_;
     uint32_t id_;
     // window partition and order should be optimized under


### PR DESCRIPTION
`select * ...` query may result inconsistent output schema in many cases. This PR correct the behavior for it. Notably a few rules list below:

- `select * from <sources>` ->  all rows from `<sources>`
   - `<sources>` might be multiple sources, e.g `t1 last join t2`
- `select <source1>.* from <sources>` -> all rows from `<source1>`, this will correctly handling e.g `select t1.* from t1 last t2 ...`

This will close #2505 
