### PR TITLE
refactor: removed unused function `RecordCntIncr` from storage/mem_table.h

### DIFF
--- a/src/storage/mem_table.h
+++ b/src/storage/mem_table.h
@@ -128,10 +128,6 @@ class MemTable : public Table {
 
     inline bool GetExpireStatus() { return enable_gc_.load(std::memory_order_relaxed); }
 
-    inline void RecordCntIncr() { record_cnt_.fetch_add(1, std::memory_order_relaxed); }
-
-    inline void RecordCntIncr(uint32_t cnt) { record_cnt_.fetch_add(cnt, std::memory_order_relaxed); }
-
     inline uint32_t GetKeyEntryHeight() const { return key_entry_max_height_; }
 
     bool DeleteIndex(const std::string& idx_name) override;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Removed unused function

* **What is the current behavior?** (You can also link to an open issue here)

Issue #2657


* **What is the new behavior (if this is a feature change)?**

