### PR TITLE
fix: format checking for parquet format

### DIFF
--- a/src/cmd/sql_cmd_test.cc
+++ b/src/cmd/sql_cmd_test.cc
@@ -521,7 +521,7 @@ TEST_P(DBSDKTest, LoadDataError) {
         "LOAD DATA INFILE 'not_exist.csv' INTO TABLE trans options(format='parquet', load_mode='local', thread=60);";
     sr->ExecuteSQL(load_sql, &status);
     ASSERT_FALSE(status.IsOK()) << status.msg;
-    ASSERT_EQ(status.msg, "ERROR: parse option format failed");
+    ASSERT_EQ(status.msg, "local data load only supports 'csv' format");
 
     load_sql =
         "LOAD DATA INFILE 'not_exist.csv' INTO TABLE trans options(load_mode='local', thread=0);";
@@ -536,6 +536,12 @@ TEST_P(DBSDKTest, LoadDataError) {
     if (cs->IsClusterMode()) {
         ASSERT_FALSE(status.IsOK()) << status.msg;
         ASSERT_EQ(status.msg, "local load only supports loading data to online storage");
+
+        load_sql =
+            "LOAD DATA INFILE 'not_exist.csv' INTO TABLE trans options(format='parquet', load_mode='cluster');";
+        sr->ExecuteSQL(load_sql, &status);
+        ASSERT_FALSE(status.IsOK()) << status.msg;
+        ASSERT_EQ(status.msg, "Fail to get TaskManager client");
     } else {
         ASSERT_TRUE(status.IsOK()) << status.msg;
     }

--- a/src/sdk/file_option_parser.h
+++ b/src/sdk/file_option_parser.h
@@ -102,7 +102,8 @@ class FileOptionsParser {
     std::function<bool(const hybridse::node::ConstNode* node)> CheckFormat() {
         return [this](const hybridse::node::ConstNode* node) {
             format_ = node->GetAsString();
-            if (format_ != "csv") {
+            boost::to_lower(format_);
+            if (format_ != "csv" && format_ != "parquet") {
                 return false;
             }
             return true;
@@ -148,6 +149,7 @@ class FileOptionsParser {
     std::function<bool(const hybridse::node::ConstNode* node)> CheckMode() {
         return [this](const hybridse::node::ConstNode* node) {
             mode_ = node->GetAsString();
+            boost::to_lower(mode_);
             if (mode_ != "error_if_exists" && mode_ != "overwrite" && mode_ != "append") {
                 return false;
             }
@@ -168,6 +170,7 @@ class ReadFileOptionsParser : public FileOptionsParser {
     const std::string& GetLoadMode() const { return load_mode_; }
     int GetThread() const { return thread_; }
     void SetThread(int thread) { thread_ = thread; }
+    bool GetDeepCopy() const { return deep_copy_; }
 
  private:
     std::string load_mode_ = "cluster";


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
allow passing `parquet` format checking in the client