### PR TITLE
build: various improvements to cpp compile, thirdparty and tests

### DIFF
--- a/cases/function/expression/test_type.yaml
+++ b/cases/function/expression/test_type.yaml
@@ -231,7 +231,6 @@ cases:
       rows:
         - [NULL, NULL, NULL, NULL, NULL, NULL, NULL]
   - id: 12
-    tags: ["TODO", "@chenjing, @baoxinqi: encode处理常量NULL string"]
     desc: SQL标准Cast语法-Cast(NULL as string)
     inputs:
       - columns: ["c1 int", "c2 float", "c5 bigint"]

--- a/cases/query/limit.yaml
+++ b/cases/query/limit.yaml
@@ -14,6 +14,8 @@
 # - where clause
 # - group by
 #
+# limit clause is not supported in online serving mode
+#
 # cases:
 # - limit(table) -> 0
 # - limit(filter) -> 1*
@@ -155,7 +157,7 @@ cases:
         - actionTime timestamp
       data: |
 
-  - id: 2
+  - id: 2-0
     mode: request-unsupport
     desc: |
       limit (window)

--- a/hybridse/CMakeLists.txt
+++ b/hybridse/CMakeLists.txt
@@ -103,7 +103,8 @@ message(STATUS "OpenSSL libraries ${OPENSSL_LIBRARIES}")
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(OS_LIB ${CMAKE_THREAD_LIBS_INIT} rt)
     set(COMMON_LIBS ${Boost_LIBRARIES} ${LEVELDB_LIBRARY} ${Protobuf_LIBRARIES} ${GLOG_LIBRARY} ${UNWIND_LIBRARY} ${Z_LIBRARY} ${SNAPPY_LIBRARY} ${OPENSSL_LIBRARIES} dl)
-    set(BRPC_LIBS ${BRPC_LIBRARY} ${COMMON_LIBS})
+    # TODO(ace): rename BRPC_LIBS, as it not related to brpc
+    set(BRPC_LIBS ${COMMON_LIBS})
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     set(OS_LIB
             ${CMAKE_THREAD_LIBS_INIT}
@@ -117,7 +118,7 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
             "-Wl,-U,_ProfilerStart"
             "-Wl,-U,_ProfilerStop")
     set(COMMON_LIBS ${Boost_LIBRARIES} ${LEVELDB_LIBRARY} ${Protobuf_LIBRARIES} ${GLOG_LIBRARY} ${Z_LIBRARY} ${SNAPPY_LIBRARY} ${OPENSSL_LIBRARIES} dl)
-    set(BRPC_LIBS ${BRPC_LIBRARY} ${COMMON_LIBS})
+    set(BRPC_LIBS ${COMMON_LIBS})
 endif ()
 
 configure_file(

--- a/hybridse/CMakeLists.txt
+++ b/hybridse/CMakeLists.txt
@@ -100,11 +100,10 @@ find_library(SNAPPY_LIBRARY snappy)
 
 message(STATUS "Boost libraries ${Boost_LIBRARIES}")
 message(STATUS "OpenSSL libraries ${OPENSSL_LIBRARIES}")
+
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(OS_LIB ${CMAKE_THREAD_LIBS_INIT} rt)
     set(COMMON_LIBS ${Boost_LIBRARIES} ${LEVELDB_LIBRARY} ${Protobuf_LIBRARIES} ${GLOG_LIBRARY} ${UNWIND_LIBRARY} ${Z_LIBRARY} ${SNAPPY_LIBRARY} ${OPENSSL_LIBRARIES} dl)
-    # TODO(ace): rename BRPC_LIBS, as it not related to brpc
-    set(BRPC_LIBS ${COMMON_LIBS})
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     set(OS_LIB
             ${CMAKE_THREAD_LIBS_INIT}
@@ -118,7 +117,6 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
             "-Wl,-U,_ProfilerStart"
             "-Wl,-U,_ProfilerStop")
     set(COMMON_LIBS ${Boost_LIBRARIES} ${LEVELDB_LIBRARY} ${Protobuf_LIBRARIES} ${GLOG_LIBRARY} ${Z_LIBRARY} ${SNAPPY_LIBRARY} ${OPENSSL_LIBRARIES} dl)
-    set(BRPC_LIBS ${COMMON_LIBS})
 endif ()
 
 configure_file(

--- a/hybridse/examples/toydb/src/CMakeLists.txt
+++ b/hybridse/examples/toydb/src/CMakeLists.txt
@@ -76,7 +76,6 @@ if (TESTING_ENABLE AND EXAMPLES_TESTING_ENABLE)
         endif()
         list(APPEND test_list ${TEST_TARGET_NAME})
     endforeach()
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 endif()
 
 # toy sdk
@@ -87,6 +86,8 @@ add_subdirectory(bm)
 endif()
 
 # toydb bin
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
 add_executable(toydb cmd/toydb.cc)
 target_link_libraries(toydb toydb_sdk toydb_lib hybridse_sdk hybridse_core hybridse_flags hybridse_test_base)
 # engine execution

--- a/hybridse/examples/toydb/src/CMakeLists.txt
+++ b/hybridse/examples/toydb/src/CMakeLists.txt
@@ -45,7 +45,7 @@ string(REPLACE " " ";" TOYDB_SRC_FILE_LIST ${TOYDB_SRC_FILE_LIST_STR})
 add_library(toydb_flags STATIC toydb_flags.cc)
 
 # toydb lib
-set(TOYDB_DEPS_LIBS toydb_flags hybridse_sdk hybridse_core hybridse_flags sqlite3
+set(TOYDB_DEPS_LIBS toydb_flags hybridse_core hybridse_flags sqlite3
     ${yaml_libs} ${Boost_filesystem_LIBRARY} ${VM_LIBS} ${LLVM_LIBS} ${OS_LIB} ${GTEST_LIBRARIES})
 add_library(toydb_lib STATIC ${TOYDB_SRC_FILE_LIST} )
 target_link_libraries(toydb_lib ${TOYDB_DEPS_LIBS})

--- a/hybridse/examples/toydb/src/CMakeLists.txt
+++ b/hybridse/examples/toydb/src/CMakeLists.txt
@@ -70,7 +70,7 @@ if (TESTING_ENABLE AND EXAMPLES_TESTING_ENABLE)
                 --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/${TEST_TARGET_DIR}/${TEST_TARGET_NAME}.xml)
         target_link_libraries(${TEST_TARGET_NAME}
                 toydb_lib toydb_sdk hybridse_flags sqlite3
-                ${GTEST_LIBRARIES} benchmark ${yaml_libs} ${OS_LIBS} ${g_libs})
+                ${GTEST_LIBRARIES} benchmark ${yaml_libs} ${OS_LIB} ${g_libs})
         if (TESTING_ENABLE_STRIP)
             strip_exe(${TEST_TARGET_NAME})
         endif()

--- a/hybridse/examples/toydb/src/bm/CMakeLists.txt
+++ b/hybridse/examples/toydb/src/bm/CMakeLists.txt
@@ -74,7 +74,7 @@ if (TESTING_ENABLE AND EXAMPLES_TESTING_ENABLE)
 
         target_link_libraries(${TEST_TARGET_NAME}
                 toydb_lib toydb_sdk toydb_bm_lib hybridse_sdk hybridse_flags
-                ${GTEST_LIBRARIES} benchmark ${yaml_libs} ${COMMON_LIBS} ${BRPC_LIBRARY} ${OS_LIBS} ${g_libs} sqlite3)
+                ${GTEST_LIBRARIES} benchmark ${yaml_libs} ${COMMON_LIBS} ${BRPC_LIBRARY} ${OS_LIB} ${g_libs} sqlite3)
         list(APPEND test_list ${TEST_TARGET_NAME})
     endforeach()
 endif()

--- a/hybridse/examples/toydb/src/bm/CMakeLists.txt
+++ b/hybridse/examples/toydb/src/bm/CMakeLists.txt
@@ -30,11 +30,13 @@ foreach(SRC_FILE ${BM_FILES})
         list(APPEND BM_LIB_FILE_LIST ${SRC_FILE})
     endif()
 endforeach()
+
+set(BM_LIBS ${ABSL_LIBS} ${yaml_libs} ${g_libs} ${Boost_filesystem_LIBRARY}
+    ${VM_LIBS} ${LLVM_LIBS} ${COMMON_LIBS} ${BRPC_LIBRARY} ${OS_LIB} benchmark gtest)
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    set(BM_LIBS ${ABSL_LIBS} ${yaml_libs} ${g_libs} ${Boost_filesystem_LIBRARY}  ${VM_LIBS} ${LLVM_LIBS} ${BRPC_LIBS} tcmalloc ${OS_LIB} benchmark gtest)
-elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(BM_LIBS ${ABSL_LIBS} ${yaml_libs} ${g_libs} ${Boost_filesystem_LIBRARY} ${VM_LIBS} ${LLVM_LIBS} ${BRPC_LIBS} ${OS_LIB} benchmark gtest)
+    set(BM_LIBS ${BM_LIBS} tcmalloc)
 endif ()
+
 # bm lib
 add_library(toydb_bm_lib STATIC ${BM_LIB_FILE_LIST})
 target_link_libraries(toydb_bm_lib toydb_lib toydb_sdk hybridse_sdk hybridse_flags ${BM_LIIBS})
@@ -72,9 +74,8 @@ if (TESTING_ENABLE AND EXAMPLES_TESTING_ENABLE)
 
         target_link_libraries(${TEST_TARGET_NAME}
                 toydb_lib toydb_sdk toydb_bm_lib hybridse_sdk hybridse_flags
-                ${GTEST_LIBRARIES} benchmark ${yaml_libs} ${BRPC_LIBS} ${OS_LIBS} ${g_libs} sqlite3)
+                ${GTEST_LIBRARIES} benchmark ${yaml_libs} ${COMMON_LIBS} ${BRPC_LIBRARY} ${OS_LIBS} ${g_libs} sqlite3)
         list(APPEND test_list ${TEST_TARGET_NAME})
     endforeach()
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 endif()
 

--- a/hybridse/examples/toydb/src/bm/CMakeLists.txt
+++ b/hybridse/examples/toydb/src/bm/CMakeLists.txt
@@ -32,7 +32,7 @@ foreach(SRC_FILE ${BM_FILES})
 endforeach()
 
 set(BM_LIBS ${ABSL_LIBS} ${yaml_libs} ${g_libs} ${Boost_filesystem_LIBRARY}
-    ${VM_LIBS} ${LLVM_LIBS} ${COMMON_LIBS} ${BRPC_LIBRARY} ${OS_LIB} benchmark gtest)
+    ${LLVM_LIBS} ${COMMON_LIBS} ${BRPC_LIBRARY} ${OS_LIB} benchmark gtest)
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(BM_LIBS ${BM_LIBS} tcmalloc)
 endif ()

--- a/hybridse/examples/toydb/src/sdk/CMakeLists.txt
+++ b/hybridse/examples/toydb/src/sdk/CMakeLists.txt
@@ -18,7 +18,8 @@ include_directories(${INCLUDE_DIRECTORIES}
 		${PROJECT_SOURCE_DIR}/examples/toydb/src)
 
 set(SDK_DEPS_LIBS hybridse_core hybridse_flags hybridse_sdk
-	${yaml_libs} ${Boost_filesystem_LIBRARY} ${VM_LIBS} ${LLVM_LIBS} ${BRPC_LIBS} ${OS_LIB})
+    ${yaml_libs} ${Boost_filesystem_LIBRARY} ${VM_LIBS} ${LLVM_LIBS}
+    ${COMMON_LIBS} ${BRPC_LIBRARY} ${OS_LIB})
 
 # split sdk test and bm
 set(SDK_SRC_FILE_LIST)

--- a/hybridse/examples/toydb/src/sdk/CMakeLists.txt
+++ b/hybridse/examples/toydb/src/sdk/CMakeLists.txt
@@ -15,11 +15,13 @@
 include_directories(${INCLUDE_DIRECTORIES}
         ${PROJECT_SOURCE_DIR}/src
         ${PROJECT_BINARY_DIR}/src
-		${PROJECT_SOURCE_DIR}/examples/toydb/src)
+        ${PROJECT_SOURCE_DIR}/examples/toydb/src)
 
-set(SDK_DEPS_LIBS hybridse_core hybridse_flags hybridse_sdk
-    ${yaml_libs} ${Boost_filesystem_LIBRARY} ${VM_LIBS} ${LLVM_LIBS}
-    ${BRPC_LIBRARY} ${COMMON_LIBS} ${OS_LIB})
+set(SDK_DEPS_LIBS
+    hybridse_sdk
+    ${yaml_libs} ${Boost_filesystem_LIBRARY} ${LLVM_LIBS}
+    ${COMMON_LIBS} ${OS_LIB}
+)
 
 # split sdk test and bm
 set(SDK_SRC_FILE_LIST)

--- a/hybridse/examples/toydb/src/sdk/CMakeLists.txt
+++ b/hybridse/examples/toydb/src/sdk/CMakeLists.txt
@@ -19,7 +19,7 @@ include_directories(${INCLUDE_DIRECTORIES}
 
 set(SDK_DEPS_LIBS hybridse_core hybridse_flags hybridse_sdk
     ${yaml_libs} ${Boost_filesystem_LIBRARY} ${VM_LIBS} ${LLVM_LIBS}
-    ${COMMON_LIBS} ${BRPC_LIBRARY} ${OS_LIB})
+    ${BRPC_LIBRARY} ${COMMON_LIBS} ${OS_LIB})
 
 # split sdk test and bm
 set(SDK_SRC_FILE_LIST)

--- a/hybridse/examples/toydb/src/testing/toydb_engine_test.cc
+++ b/hybridse/examples/toydb/src/testing/toydb_engine_test.cc
@@ -24,7 +24,7 @@ using namespace llvm::orc;  // NOLINT (build/namespaces)
 namespace hybridse {
 namespace vm {
 TEST_P(EngineTest, TestRequestEngine) {
-    ParamType sql_case = GetParam();
+    auto& sql_case = GetParam();
     EngineOptions options;
     LOG(INFO) << "ID: " << sql_case.id() << ", DESC: " << sql_case.desc();
     if (!boost::contains(sql_case.mode(), "request-unsupport") &&
@@ -36,7 +36,7 @@ TEST_P(EngineTest, TestRequestEngine) {
     }
 }
 TEST_P(EngineTest, TestBatchEngine) {
-    ParamType sql_case = GetParam();
+    auto& sql_case = GetParam();
     EngineOptions options;
     LOG(INFO) << "ID: " << sql_case.id() << ", DESC: " << sql_case.desc();
     if (!boost::contains(sql_case.mode(), "batch-unsupport") &&
@@ -49,7 +49,7 @@ TEST_P(EngineTest, TestBatchEngine) {
     }
 }
 TEST_P(EngineTest, TestBatchRequestEngineForLastRow) {
-    ParamType sql_case = GetParam();
+    auto& sql_case = GetParam();
     EngineOptions options;
     LOG(INFO) << "ID: " << sql_case.id() << ", DESC: " << sql_case.desc();
     if (!boost::contains(sql_case.mode(), "request-unsupport") &&
@@ -62,7 +62,7 @@ TEST_P(EngineTest, TestBatchRequestEngineForLastRow) {
     }
 }
 TEST_P(EngineTest, TestClusterRequestEngine) {
-    ParamType sql_case = GetParam();
+    auto& sql_case = GetParam();
     EngineOptions options;
     options.SetClusterOptimized(true);
     LOG(INFO) << "ID: " << sql_case.id() << ", DESC: " << sql_case.desc();
@@ -76,7 +76,7 @@ TEST_P(EngineTest, TestClusterRequestEngine) {
     }
 }
 TEST_P(EngineTest, TestClusterBatchRequestEngine) {
-    ParamType sql_case = GetParam();
+    auto& sql_case = GetParam();
     EngineOptions options;
     options.SetClusterOptimized(true);
     LOG(INFO) << "ID: " << sql_case.id() << ", DESC: " << sql_case.desc();
@@ -92,7 +92,7 @@ TEST_P(EngineTest, TestClusterBatchRequestEngine) {
 }
 
 TEST_P(BatchRequestEngineTest, TestBatchRequestEngine) {
-    ParamType sql_case = GetParam();
+    auto& sql_case = GetParam();
     LOG(INFO) << "ID: " << sql_case.id() << ", DESC: " << sql_case.desc();
     EngineOptions options;
     options.SetClusterOptimized(false);
@@ -103,7 +103,7 @@ TEST_P(BatchRequestEngineTest, TestBatchRequestEngine) {
     }
 }
 TEST_P(BatchRequestEngineTest, TestClusterBatchRequestEngine) {
-    ParamType sql_case = GetParam();
+    auto& sql_case = GetParam();
     LOG(INFO) << "ID: " << sql_case.id() << ", DESC: " << sql_case.desc();
     EngineOptions options;
     options.SetClusterOptimized(true);

--- a/hybridse/src/CMakeLists.txt
+++ b/hybridse/src/CMakeLists.txt
@@ -83,7 +83,7 @@ if (TESTING_ENABLE AND HYBRIDSE_TESTING_ENABLE)
 
         add_executable(${TEST_TARGET_NAME} ${TEST_SCRIPT} testing/engine_test_base.cc testing/test_base.cc)
         target_link_libraries(${TEST_TARGET_NAME} ${GTEST_LIBRARIES} ${HYBRIDSE_CORE_LIBS} hybridse_flags
-                ${yaml_libs} ${ZETASQL_LIBS} ${BRPC_LIBS})
+                              ${yaml_libs} ${ZETASQL_LIBS} ${COMMON_LIBS})
         set_target_properties(${TEST_TARGET_NAME} PROPERTIES
             RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${TEST_TARGET_DIR})
         add_test(${TEST_TARGET_NAME}

--- a/hybridse/src/benchmark/CMakeLists.txt
+++ b/hybridse/src/benchmark/CMakeLists.txt
@@ -31,9 +31,9 @@ foreach(SRC_FILE ${BENCHMARK_FILES})
     endif()
 endforeach()
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    set(BENCHMARK_LIBS ${ABSL_LIBS} ${yaml_libs} ${g_libs} ${Boost_filesystem_LIBRARY} ${VM_LIBS} ${LLVM_LIBS} ${BRPC_LIBS} tcmalloc ${OS_LIB} benchmark ${GTEST_LIBRARIES})
+    set(BENCHMARK_LIBS ${ABSL_LIBS} ${yaml_libs} ${g_libs} ${Boost_filesystem_LIBRARY} ${VM_LIBS} ${LLVM_LIBS} ${COMMON_LIBS} tcmalloc ${OS_LIB} benchmark ${GTEST_LIBRARIES})
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(BENCHMARK_LIBS ${ABSL_LIBS} ${yaml_libs} ${g_libs} ${Boost_filesystem_LIBRARY} ${VM_LIBS} ${LLVM_LIBS} ${BRPC_LIBS} ${OS_LIB} benchmark ${GTEST_LIBRARIES})
+    set(BENCHMARK_LIBS ${ABSL_LIBS} ${yaml_libs} ${g_libs} ${Boost_filesystem_LIBRARY} ${VM_LIBS} ${LLVM_LIBS} ${COMMON_LIBS} ${OS_LIB} benchmark ${GTEST_LIBRARIES})
 endif ()
 # bm lib
 add_library(hybridse_bm_lib STATIC ${BENCHMARK_LIB_FILE_LIST})
@@ -70,7 +70,7 @@ if (TESTING_ENABLE AND HYBRIDSE_TESTING_ENABLE)
 
         target_link_libraries(${TEST_TARGET_NAME}
             hybridse_bm_lib hybridse_sdk hybridse_flags
-            ${GTEST_LIBRARIES} benchmark ${yaml_libs} ${BRPC_LIBS} ${OS_LIBS} ${g_libs})
+            ${GTEST_LIBRARIES} benchmark ${yaml_libs} ${COMMON_LIBS} ${OS_LIBS} ${g_libs})
         list(APPEND test_list ${TEST_TARGET_NAME})
     endforeach()
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/hybridse/src/benchmark/CMakeLists.txt
+++ b/hybridse/src/benchmark/CMakeLists.txt
@@ -70,7 +70,7 @@ if (TESTING_ENABLE AND HYBRIDSE_TESTING_ENABLE)
 
         target_link_libraries(${TEST_TARGET_NAME}
             hybridse_bm_lib hybridse_sdk hybridse_flags
-            ${GTEST_LIBRARIES} benchmark ${yaml_libs} ${COMMON_LIBS} ${OS_LIBS} ${g_libs})
+            ${GTEST_LIBRARIES} benchmark ${yaml_libs} ${COMMON_LIBS} ${OS_LIB} ${g_libs})
         list(APPEND test_list ${TEST_TARGET_NAME})
     endforeach()
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/hybridse/src/codegen/CMakeLists.txt
+++ b/hybridse/src/codegen/CMakeLists.txt
@@ -42,7 +42,7 @@ add_library(hybridse_codegen STATIC
         context.cc memery_ir_builder.h memory_ir_builder.cc)
 if (TESTING_ENABLE)
 set(vm_deps_libs
-        hybridse_case ${Boost_date_time_LIBRARY} ${Boost_filesystem_LIBRARY} ${yaml_libs} ${VM_LIBS} hybridse_flags ${LLVM_LIBS} ${BRPC_LIBS} ${OS_LIB})
+        hybridse_case ${Boost_date_time_LIBRARY} ${Boost_filesystem_LIBRARY} ${yaml_libs} ${VM_LIBS} hybridse_flags ${LLVM_LIBS} ${COMMON_LIBS} ${OS_LIB})
 
 add_executable(ir_base_builder_test ir_base_builder_test.cc)
 target_link_libraries(ir_base_builder_test ${GTEST_LIBRARIES} ${vm_deps_libs})

--- a/hybridse/src/sdk/CMakeLists.txt
+++ b/hybridse/src/sdk/CMakeLists.txt
@@ -18,7 +18,7 @@ include_directories(${INCLUDE_DIRECTORIES}
 
 
 set(SDK_DEPS_LIBS hybridse_core hybridse_flags
-		${yaml_libs} ${Boost_filesystem_LIBRARY} ${LLVM_LIBS} ${ZETASQL_LIBS} ${BRPC_LIBS} ${OS_LIB} )
+    ${yaml_libs} ${Boost_filesystem_LIBRARY} ${LLVM_LIBS} ${ZETASQL_LIBS} ${COMMON_LIBS} ${OS_LIB} )
 
 # split sdk test and bm
 set(SDK_SRC_FILE_LIST)

--- a/hybridse/src/sdk/CMakeLists.txt
+++ b/hybridse/src/sdk/CMakeLists.txt
@@ -18,7 +18,8 @@ include_directories(${INCLUDE_DIRECTORIES}
 
 
 set(SDK_DEPS_LIBS hybridse_core hybridse_flags
-    ${yaml_libs} ${Boost_filesystem_LIBRARY} ${LLVM_LIBS} ${ZETASQL_LIBS} ${COMMON_LIBS} ${OS_LIB} )
+    ${yaml_libs} ${Boost_filesystem_LIBRARY} ${LLVM_LIBS} ${ZETASQL_LIBS}
+    ${BRPC_LIBRARY} ${COMMON_LIBS} ${OS_LIB} )
 
 # split sdk test and bm
 set(SDK_SRC_FILE_LIST)

--- a/hybridse/src/udf/udf.cc
+++ b/hybridse/src/udf/udf.cc
@@ -80,10 +80,11 @@ void unhex(StringRef *str, StringRef *output, bool* is_null) {
         }
     }
     // use lambda function to convert the char to uint8
-    auto convert = [](char a) {
+    auto convert = [](char a) -> int {
         if (a <= 'F' && a >= 'A') { return a - 'A' + 10; }
         if (a <= 'f' && a >= 'a') { return a - 'a' + 10; }
         if (a <= '9' && a >= '0') { return a - '0'; }
+        return 0;
     };
 
     if (!*is_null) {    // every character is valid hex character

--- a/third-party/cmake/FetchBoost.cmake
+++ b/third-party/cmake/FetchBoost.cmake
@@ -30,5 +30,5 @@ ExternalProject_Add(
   INSTALL_DIR ${DEPS_INSTALL_DIR}
   BUILD_IN_SOURCE True
   CONFIGURE_COMMAND ./bootstrap.sh ${BOOST_FLAGS}
-  BUILD_COMMAND ./b2 link=static cxxflags=-fPIC cflags=-fPIC release install --prefix=<INSTALL_DIR>
+  BUILD_COMMAND ./b2 link=static cxxflags=-fPIC cflags=-fPIC --without-python release install --prefix=<INSTALL_DIR>
   INSTALL_COMMAND "")


### PR DESCRIPTION
# Whats changes

- thirdparty(boost): add `--without-python` flag, this avoid the python dependency requirement for third-party buiild, which might error prone with python 3.10 
- build: remove brpc dependency for most targets in hybridse
  - this fixes the dump error when debugging `toydb_run_engine` with lldb, it fails fast in brpc
- test: turn on a 'TODO` case 
