### PR TITLE
feat: update Memtable::RecordIdxCnt & Memtable::RecordIdxByteSize

### DIFF
--- a/src/storage/mem_table.cc
+++ b/src/storage/mem_table.cc
@@ -493,19 +493,24 @@ uint64_t MemTable::GetRecordIdxByteSize() {
 
 uint64_t MemTable::GetRecordIdxCnt() {
     uint64_t record_idx_cnt = 0;
-    auto inner_indexs = table_index_.GetAllInnerIndex();
-    for (size_t i = 0; i < inner_indexs->size(); i++) {
-        bool is_valid = false;
-        for (const auto& index_def : inner_indexs->at(i)->GetIndex()) {
-            if (index_def && index_def->IsReady()) {
-                is_valid = true;
-                break;
-            }
-        }
-        if (is_valid) {
-            for (uint32_t j = 0; j < seg_cnt_; j++) {
-                record_idx_cnt += segments_[i][j]->GetIdxCnt();
-            }
+    std::shared_ptr<IndexDef> index_def = table_index_.GetIndex(0);
+    if (!index_def || !index_def->IsReady()) {
+        return record_idx_cnt;
+    }
+    uint32_t inner_idx = index_def->GetInnerPos();
+    auto inner_index = table_index_.GetInnerIndex(inner_idx);
+    int32_t ts_col_id = -1;
+    auto ts_col = index_def->GetTsColumn();
+    if (ts_col) {
+        ts_col_id = ts_col->GetId();
+    }
+    for (uint32_t j = 0; j < seg_cnt_; j++) {
+        if (inner_index->GetIndex().size() > 1 && ts_col_id >= 0) {
+            uint64_t record_cnt = 0;
+            segments_[inner_idx][j]->GetIdxCnt(ts_col_id, record_cnt);
+            record_idx_cnt += record_cnt;
+        } else {
+            record_idx_cnt += segments_[inner_idx][j]->GetIdxCnt();
         }
     }
     return record_idx_cnt;

--- a/src/storage/segment.cc
+++ b/src/storage/segment.cc
@@ -132,7 +132,6 @@ uint64_t Segment::Release() {
     entry_free_list_->Clear();
     idx_cnt_vec_.clear();
     idx_byte_size_vec_.clear();
-    pk_cnt_vec_.clear();
     return cnt;
 }
 

--- a/src/storage/segment.cc
+++ b/src/storage/segment.cc
@@ -290,11 +290,11 @@ bool Segment::Delete(const Slice& key) {
 }
 
 void Segment::FreeList(::openmldb::base::Node<uint64_t, DataBlock*>* node, uint64_t& gc_idx_cnt,
-                       uint64_t& gc_record_cnt, uint64_t& gc_record_byte_size, uint64_t& idx_bytes/*=idx_byte_size_*/) {
+                       uint64_t& gc_record_cnt, uint64_t& gc_record_byte_size, uint64_t* idx_bytes/*=&idx_byte_size_*/) {
     while (node != NULL) {
         gc_idx_cnt++;
         ::openmldb::base::Node<uint64_t, DataBlock*>* tmp = node;
-        idx_byte_size_.fetch_sub(GetRecordTsIdxSize(tmp->Height()));
+        idx_bytes->fetch_sub(GetRecordTsIdxSize(tmp->Height()));
         node = node->GetNextNoBarrier(0);
         DEBUGLOG("delete key %lu with height %u", tmp->GetKey(), tmp->Height());
         if (tmp->GetValue()->dim_cnt_down > 1) {
@@ -564,7 +564,7 @@ void Segment::GcAllType(const std::map<uint32_t, TTLSt>& ttl_st_map, uint64_t& g
                 continue;
             }
             uint64_t entry_gc_idx_cnt = 0;
-            FreeList(node, entry_gc_idx_cnt, gc_record_cnt, gc_record_byte_size, idx_byte_cnt_vec_[pos->second]);
+            FreeList(node, entry_gc_idx_cnt, gc_record_cnt, gc_record_byte_size, &(idx_byte_size_vec_[pos->second]));
             entry->count_.fetch_sub(entry_gc_idx_cnt, std::memory_order_relaxed);
             idx_cnt_vec_[pos->second]->fetch_sub(entry_gc_idx_cnt, std::memory_order_relaxed);
             gc_idx_cnt += entry_gc_idx_cnt;

--- a/src/storage/segment.cc
+++ b/src/storage/segment.cc
@@ -221,7 +221,7 @@ void Segment::BulkLoadPut(unsigned int key_entry_id, const Slice& key, uint64_t 
         ((KeyEntry**)key_entry_or_list)[key_entry_id]->count_.fetch_add(  // NOLINT
             1, std::memory_order_relaxed);
         byte_size += GetRecordTsIdxSize(height);
-        idx_byte_size_vec_[key_entry_id].fetch_add(byte_size, std::memory_order_relaxed);
+        idx_byte_size_vec_[key_entry_id]->fetch_add(byte_size, std::memory_order_relaxed);
         idx_cnt_vec_[key_entry_id]->fetch_add(1, std::memory_order_relaxed);
     }
 }
@@ -267,7 +267,7 @@ void Segment::Put(const Slice& key, const std::map<int32_t, uint64_t>& ts_map, D
         ((KeyEntry**)entry_arr)[pos->second]->count_.fetch_add(  // NOLINT
             1, std::memory_order_relaxed);
         byte_size += GetRecordTsIdxSize(height);
-        idx_byte_size_vec_[pos->second].fetch_add(byte_size, std::memory_order_relaxed);
+        idx_byte_size_vec_[pos->second]->fetch_add(byte_size, std::memory_order_relaxed);
         idx_cnt_vec_[pos->second]->fetch_add(1, std::memory_order_relaxed);
     }
 }
@@ -566,7 +566,7 @@ void Segment::GcAllType(const std::map<uint32_t, TTLSt>& ttl_st_map, uint64_t& g
                 continue;
             }
             uint64_t entry_gc_idx_cnt = 0;
-            FreeList(node, entry_gc_idx_cnt, gc_record_cnt, gc_record_byte_size, &(idx_byte_size_vec_[pos->second]));
+            FreeList(node, entry_gc_idx_cnt, gc_record_cnt, gc_record_byte_size, idx_byte_size_vec_[pos->second]);
             entry->count_.fetch_sub(entry_gc_idx_cnt, std::memory_order_relaxed);
             idx_cnt_vec_[pos->second]->fetch_sub(entry_gc_idx_cnt, std::memory_order_relaxed);
             gc_idx_cnt += entry_gc_idx_cnt;

--- a/src/storage/segment.cc
+++ b/src/storage/segment.cc
@@ -158,7 +158,7 @@ void Segment::ReleaseAndCount(uint64_t& gc_idx_cnt, uint64_t& gc_record_cnt, uin
     Release();
 }
 
-void Segment::Put(const Slice& key, uint64_t time, const char* data, uint32_t size, bool is_pi/*=0*/) {
+void Segment::Put(const Slice& key, uint64_t time, const char* data, uint32_t size) {
     if (ts_cnt_ > 1) {
         return;
     }

--- a/src/storage/segment.cc
+++ b/src/storage/segment.cc
@@ -338,7 +338,7 @@ void Segment::FreeEntry(::openmldb::base::Node<Slice, void*>* entry_node, uint64
         uint64_t byte_size =
             GetRecordPkMultiIdxSize(entry_node->Height(), entry_node->GetKey().size(), key_entry_max_height_, 1);
         for (uint32_t i = 0; i < ts_cnt_; i++) {
-            idx_byte_size_vec_[i].fetch_sub(byte_size, std::memory_order_relaxed);
+            idx_byte_size_vec_[i]->fetch_sub(byte_size, std::memory_order_relaxed);
         }
     } else {
         uint64_t old = gc_idx_cnt;

--- a/src/storage/segment.h
+++ b/src/storage/segment.h
@@ -253,7 +253,7 @@ class Segment {
  private:
     void FreeList(::openmldb::base::Node<uint64_t, DataBlock*>* node, uint64_t& gc_idx_cnt,  // NOLINT
                   uint64_t& gc_record_cnt,         // NOLINT
-                  uint64_t& gc_record_byte_size
+                  uint64_t& gc_record_byte_size,
 				  uint64_t& idx_bytes = idx_byte_size_);  // NOLINT
     void SplitList(KeyEntry* entry, uint64_t ts, ::openmldb::base::Node<uint64_t, DataBlock*>** node);
 

--- a/src/storage/segment.h
+++ b/src/storage/segment.h
@@ -254,7 +254,7 @@ class Segment {
     void FreeList(::openmldb::base::Node<uint64_t, DataBlock*>* node, uint64_t& gc_idx_cnt,  // NOLINT
                   uint64_t& gc_record_cnt,         // NOLINT
                   uint64_t& gc_record_byte_size,
-				  uint64_t* idx_bytes = &idx_byte_size_);  // NOLINT
+				  std::shared_ptr<std::atomic<uint64_t>> idx_bytes = NULL);
     void SplitList(KeyEntry* entry, uint64_t ts, ::openmldb::base::Node<uint64_t, DataBlock*>** node);
 
     void GcEntryFreeList(uint64_t version, uint64_t& gc_idx_cnt,  // NOLINT

--- a/src/storage/segment.h
+++ b/src/storage/segment.h
@@ -243,7 +243,8 @@ class Segment {
  private:
     void FreeList(::openmldb::base::Node<uint64_t, DataBlock*>* node, uint64_t& gc_idx_cnt,  // NOLINT
                   uint64_t& gc_record_cnt,         // NOLINT
-                  uint64_t& gc_record_byte_size);  // NOLINT
+                  uint64_t& gc_record_byte_size
+				  uint64_t& idx_bytes = idx_byte_size_);  // NOLINT
     void SplitList(KeyEntry* entry, uint64_t ts, ::openmldb::base::Node<uint64_t, DataBlock*>** node);
 
     void GcEntryFreeList(uint64_t version, uint64_t& gc_idx_cnt,  // NOLINT
@@ -267,6 +268,7 @@ class Segment {
     std::atomic<uint64_t> gc_version_;
     std::map<uint32_t, uint32_t> ts_idx_map_;
     std::vector<std::shared_ptr<std::atomic<uint64_t>>> idx_cnt_vec_;
+    std::vector<std::shared_ptr<std::atomic<uint64_t>>> idx_byte_size_vec_;
     uint64_t ttl_offset_;
 };
 

--- a/src/storage/segment.h
+++ b/src/storage/segment.h
@@ -197,7 +197,7 @@ class Segment {
         return ts_cnt_ > 1 ? idx_cnt_vec_[0]->load(std::memory_order_relaxed)
                            : idx_cnt_.load(std::memory_order_relaxed);
     }
-    uint64_t GetIdxCnt(uint32_t ts_idx, uint64_t& ts_cnt) {  // NOLINT
+    int GetIdxCnt(uint32_t ts_idx, uint64_t& ts_cnt) {  // NOLINT
         uint32_t real_idx = 0;
         if (GetTsIdx(ts_idx, real_idx) < 0) {
             return -1;
@@ -210,7 +210,7 @@ class Segment {
         return ts_cnt_ > 1 ? idx_byte_size_vec_[0]->load(std::memory_order_relaxed)
                            : idx_byte_size_.load(std::memory_order_relaxed);
     }
-    uint64_t GetIdxByteSize(uint32_t ts_idx, uint64_t& ts_cnt) {  // NOLINT
+    int GetIdxByteSize(uint32_t ts_idx, uint64_t& ts_cnt) {  // NOLINT
         uint32_t real_idx = 0;
         if (GetTsIdx(ts_idx, real_idx) < 0) {
             return -1;

--- a/src/storage/segment.h
+++ b/src/storage/segment.h
@@ -254,7 +254,7 @@ class Segment {
     void FreeList(::openmldb::base::Node<uint64_t, DataBlock*>* node, uint64_t& gc_idx_cnt,  // NOLINT
                   uint64_t& gc_record_cnt,         // NOLINT
                   uint64_t& gc_record_byte_size,
-				  uint64_t& idx_bytes = idx_byte_size_);  // NOLINT
+				  uint64_t* idx_bytes = &idx_byte_size_);  // NOLINT
     void SplitList(KeyEntry* entry, uint64_t ts, ::openmldb::base::Node<uint64_t, DataBlock*>** node);
 
     void GcEntryFreeList(uint64_t version, uint64_t& gc_idx_cnt,  // NOLINT

--- a/src/storage/segment.h
+++ b/src/storage/segment.h
@@ -197,13 +197,25 @@ class Segment {
         return ts_cnt_ > 1 ? idx_cnt_vec_[0]->load(std::memory_order_relaxed)
                            : idx_cnt_.load(std::memory_order_relaxed);
     }
-
-    int GetIdxCnt(uint32_t ts_idx, uint64_t& ts_cnt) {  // NOLINT
+    uint64_t GetIdxCnt(uint32_t ts_idx, uint64_t& ts_cnt) {  // NOLINT
         uint32_t real_idx = 0;
         if (GetTsIdx(ts_idx, real_idx) < 0) {
             return -1;
         }
         ts_cnt = idx_cnt_vec_[real_idx]->load(std::memory_order_relaxed);
+        return 0;
+    }
+
+	inline uint64_t GetIdxByteSize() {
+        return ts_cnt_ > 1 ? idx_byte_size_vec_[0]->load(std::memory_order_relaxed)
+                           : idx_byte_size_.load(std::memory_order_relaxed);
+    }
+    uint64_t GetIdxByteSize(uint32_t ts_idx, uint64_t& ts_cnt) {  // NOLINT
+        uint32_t real_idx = 0;
+        if (GetTsIdx(ts_idx, real_idx) < 0) {
+            return -1;
+        }
+        ts_cnt = idx_byte_size_vec_[real_idx]->load(std::memory_order_relaxed);
         return 0;
     }
 
@@ -220,8 +232,6 @@ class Segment {
     }
 
     const std::map<uint32_t, uint32_t>& GetTsIdxMap() const { return ts_idx_map_; }
-
-    inline uint64_t GetIdxByteSize() { return idx_byte_size_.load(std::memory_order_relaxed); }
 
     inline uint64_t GetPkCnt() { return pk_cnt_.load(std::memory_order_relaxed); }
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
`Memtable::RecordIdxCnt` `Memtable::RecordIdxByteSize` now give information about the **first** index (index0)

* **What is the current behavior?** (You can also link to an open issue here)
this pr is an extension of pr #2668 


* **What is the new behavior (if this is a feature change)?**

