### PR TITLE
fix: type problem of index in get_parameter_row() and get_request_row…

### DIFF
--- a/src/sdk/openmldb_api.cc
+++ b/src/sdk/openmldb_api.cc
@@ -57,7 +57,7 @@ ParameterRow::ParameterRow(const OpenmldbHandler* handler) : handler_(handler) {
 std::shared_ptr<openmldb::sdk::SQLRequestRow> ParameterRow::get_parameter_row() const {
     sql_parameter_row_ = ::openmldb::sdk::SQLRequestRow::CreateSQLRequestRowFromColumnTypes(parameter_types_);
     sql_parameter_row_->Init(str_length_);
-    for (int i = 0; i < record_.size(); ++i) {
+    for (size_t i = 0; i < record_.size(); ++i) {
         auto type = parameter_types_->GetColumnType(i);
         switch (type) {
             case ::hybridse::sdk::kTypeBool:
@@ -185,7 +185,7 @@ RequestRow::RequestRow(OpenmldbHandler* handler, const std::string& db, const st
 std::shared_ptr<openmldb::sdk::SQLRequestRow> RequestRow::get_request_row() const {
     sql_request_row_ = (handler_->get_router())->GetRequestRow(db_, sql_, handler_->get_status());
     sql_request_row_->Init(str_length_);
-    for (int i = 0; i < record_.size(); ++i) {
+    for (size_t i = 0; i < record_.size(); ++i) {
         auto type = parameter_types_->GetColumnType(i);
         switch (type) {
             case ::hybridse::sdk::kTypeBool:


### PR DESCRIPTION
…(), within file /openmldb/src/sdk/openmldb_api.cc

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
When calling method get_parameter_row() or get_request_row(), it would raise a warning "warning: comparison of integer expressions of different signedness". Referring to the warning information, I found that the exact problem was not proper type assignment of for-loop index. Indeed it should be unsigned long but for int, and I modified for-loop index type from int to unsigned long both in get_parameter_row() and get_request_row().


* **What is the current behavior?** (You can also link to an open issue here)
Resolve comparison of integer expressions warning in src/sdk/openmldb_api.cc https://github.com/4paradigm/OpenMLDB/issues/2673


* **What is the new behavior (if this is a feature change)?**

