### PR TITLE
fix(request mode): window project over last join subquery 

### DIFF
--- a/cases/query/last_join_window_query.yaml
+++ b/cases/query/last_join_window_query.yaml
@@ -352,3 +352,71 @@ cases:
         - [2,"aa", 2, 20,   4, 20 ]
         - [3,"bb", 2, null, 2, NULL]
         - [4,"cc", 2, 21,   2, 21]
+
+  - id: 7
+    desc: window over subquery(t1 last join t2), aliasing window def with multiple level renames
+    inputs:
+      -
+        name: t0
+        columns : ["id int","c1 string","c3 int","c4 bigint","c5 float","c6 double","c7 timestamp","c8 date"]
+        indexs: ["index1:c1:c7"]
+        rows:
+          - [1,"aa",2,30,1.1,2.1,1590738990000,"2020-05-01"]
+          - [2,"aa",2,30,1.1,2.1,1590738991000,"2020-05-01"]
+          - [3,"bb",2,31,1.2,2.2,1590738991000,"2020-05-02"]
+          - [4,"cc",2,32,1.3,2.3,1590738992000,"2020-05-03"]
+      -
+        name: t1
+        columns: ["id int","c1 string","c3 int","c4 bigint","c5 float","c6 double","c7 timestamp","c8 date"]
+        indexs: ["index1:c1:c7","index2:c3:c7"]
+        rows:
+          - [1,"aa",20,30,1.1,2.1,1606755660000,"2020-05-01"]
+          - [2,"cc",21,32,1.1,2.1,1606755780000,"2020-05-01"]
+    sql: |
+      select
+        idx2, c1a2, c3l2, c3r2,
+        sum(c3l2) OVER w1 as suma,
+        min(c3r2) OVER w1 as sumb,
+      from (
+        select
+          c3l as c3l2,
+          idx as idx2,
+          c3r as c3r2,
+          c1a as c1a2,
+          c7a as c7a2
+        from (
+          select
+            {0}.c3 as c3l,
+            {0}.id as idx,
+            {1}.c3 as c3r,
+            {0}.c1 as c1a,
+            {0}.c7 as c7a
+          from t0 last join t1 on t0.c1=t1.c1
+        )
+      )
+      WINDOW w1 AS (
+        PARTITION BY c1a2 ORDER BY c7a2 ROWS_RANGE BETWEEN 10s PRECEDING AND CURRENT ROW);
+
+    # consecutive simple projects will be optimized into single one
+    request_plan: |
+      PROJECT(type=Aggregation)
+        SIMPLE_PROJECT(sources=(t0.c3 -> c3l2, t0.id -> idx2, t1.c3 -> c3r2, t0.c1 -> c1a2, t0.c7 -> c7a2))
+          JOIN(type=LastJoin, condition=, left_keys=(), right_keys=(), index_keys=(t0.c1))
+            REQUEST_UNION(partition_keys=(), orders=(ASC), range=(c7, 10000 PRECEDING, 0 CURRENT), index_keys=(c1))
+              DATA_PROVIDER(request=t0)
+              DATA_PROVIDER(type=Partition, table=t0, index=index1)
+            DATA_PROVIDER(type=Partition, table=t1, index=index1)
+    expect:
+      order: idx2
+      columns:
+        - idx2 int
+        - c1a2 string
+        - c3l2 int
+        - c3r2 int
+        - suma int
+        - sumb int
+      rows:
+        - [1,"aa", 2, 20,   2, 20 ]
+        - [2,"aa", 2, 20,   4, 20 ]
+        - [3,"bb", 2, null, 2, NULL]
+        - [4,"cc", 2, 21,   2, 21]

--- a/cases/query/last_join_window_query.yaml
+++ b/cases/query/last_join_window_query.yaml
@@ -217,11 +217,12 @@ cases:
       );
     request_plan: |
       PROJECT(type=Aggregation)
-        JOIN(type=LastJoin, right_sort=(ASC), condition=actionTime <= tm, left_keys=(), right_keys=(), index_keys=(actions.itemId))
-          REQUEST_UNION(partition_keys=(), orders=(ASC), range=(actionTime, 3000 PRECEDING, 0 CURRENT), index_keys=(itemId))
-            DATA_PROVIDER(request=actions)
-            DATA_PROVIDER(type=Partition, table=actions, index=index2)
-          DATA_PROVIDER(type=Partition, table=items, index=idx)
+        SIMPLE_PROJECT(sources=(actions.userId, actions.itemId, actions.actionTime, items.id, items.price, items.tm))
+          JOIN(type=LastJoin, right_sort=(ASC), condition=actionTime <= tm, left_keys=(), right_keys=(), index_keys=(actions.itemId))
+            REQUEST_UNION(partition_keys=(), orders=(ASC), range=(actionTime, 3000 PRECEDING, 0 CURRENT), index_keys=(itemId))
+              DATA_PROVIDER(request=actions)
+              DATA_PROVIDER(type=Partition, table=actions, index=index2)
+            DATA_PROVIDER(type=Partition, table=items, index=idx)
     expect:
       order: userId
       columns:
@@ -235,3 +236,42 @@ cases:
         2, 2, 1, 199, 2000
         3, 3, 1, 399, 3000
         4, 3, 2, 798, 4000
+
+  - id: 5
+    desc: window over subquery(t1 last join t2)
+    inputs:
+      -
+        columns : ["id int","c1 string","c3 int","c4 bigint","c5 float","c6 double","c7 timestamp","c8 date"]
+        indexs: ["index1:c1:c7"]
+        rows:
+          - [1,"aa",2,30,1.1,2.1,1590738990000,"2020-05-01"]
+          - [2,"bb",2,31,1.2,2.2,1590738991000,"2020-05-02"]
+          - [3,"cc",2,32,1.3,2.3,1590738992000,"2020-05-03"]
+      -
+        columns: ["id int","c1 string","c3 int","c4 bigint","c5 float","c6 double","c7 timestamp","c8 date"]
+        indexs: ["index1:c1:c7","index2:c3:c7"]
+        rows:
+          - [1,"aa",20,30,1.1,2.1,1606755660000,"2020-05-01"]
+          - [2,"aa",21,31,1.1,2.1,1606755720000,"2020-05-01"]
+          - [3,"cc",21,32,1.1,2.1,1606755780000,"2020-05-01"]
+    sql: |
+      select
+        idx, c1,
+        count(c3) OVER w1 as w1_c3_sum
+      from (
+        select
+          {0}.id as idx,
+          {0}.c1 as c1,
+          {1}.c3 as c3,
+          {0}.c7 as c7
+        from {0} last join {1} on {0}.c1={1}.c1
+      )
+      WINDOW w1 AS (
+        PARTITION BY c1 ORDER BY c7 ROWS_RANGE BETWEEN 1s PRECEDING AND CURRENT ROW);
+    expect:
+      order: idx
+      columns: ["idx int","c1 string","w1_c3_sum int64"]
+      rows:
+        - [1,"aa",1]
+        - [2,"bb",0]
+        - [3,"cc",1]

--- a/cases/query/last_join_window_query.yaml
+++ b/cases/query/last_join_window_query.yaml
@@ -245,33 +245,44 @@ cases:
         indexs: ["index1:c1:c7"]
         rows:
           - [1,"aa",2,30,1.1,2.1,1590738990000,"2020-05-01"]
-          - [2,"bb",2,31,1.2,2.2,1590738991000,"2020-05-02"]
-          - [3,"cc",2,32,1.3,2.3,1590738992000,"2020-05-03"]
+          - [2,"aa",2,30,1.1,2.1,1590738991000,"2020-05-01"]
+          - [3,"bb",2,31,1.2,2.2,1590738991000,"2020-05-02"]
+          - [4,"cc",2,32,1.3,2.3,1590738992000,"2020-05-03"]
       -
         columns: ["id int","c1 string","c3 int","c4 bigint","c5 float","c6 double","c7 timestamp","c8 date"]
         indexs: ["index1:c1:c7","index2:c3:c7"]
         rows:
           - [1,"aa",20,30,1.1,2.1,1606755660000,"2020-05-01"]
-          - [2,"aa",21,31,1.1,2.1,1606755720000,"2020-05-01"]
-          - [3,"cc",21,32,1.1,2.1,1606755780000,"2020-05-01"]
+          - [2,"cc",21,32,1.1,2.1,1606755780000,"2020-05-01"]
     sql: |
       select
         idx, c1,
-        count(c3) OVER w1 as w1_c3_sum
+        sum(c3a) OVER w1 as suma,
+        sum(c3x) OVER w1 as sumb
       from (
         select
           {0}.id as idx,
           {0}.c1 as c1,
-          {1}.c3 as c3,
+          {0}.c3 as c3a,
+          {1}.c3 as c3x,
           {0}.c7 as c7
         from {0} last join {1} on {0}.c1={1}.c1
       )
       WINDOW w1 AS (
-        PARTITION BY c1 ORDER BY c7 ROWS_RANGE BETWEEN 1s PRECEDING AND CURRENT ROW);
+        PARTITION BY c1 ORDER BY c7 ROWS_RANGE BETWEEN 10s PRECEDING AND CURRENT ROW);
+    request_plan: |
+      PROJECT(type=Aggregation)
+        SIMPLE_PROJECT(sources=(auto_t0.id -> idx, auto_t0.c1, auto_t0.c3 -> c3a, auto_t1.c3 -> c3x, auto_t0.c7))
+          JOIN(type=LastJoin, condition=, left_keys=(), right_keys=(), index_keys=(auto_t0.c1))
+            REQUEST_UNION(partition_keys=(), orders=(ASC), range=(c7, 10000 PRECEDING, 0 CURRENT), index_keys=(c1))
+              DATA_PROVIDER(request=auto_t0)
+              DATA_PROVIDER(type=Partition, table=auto_t0, index=index1)
+            DATA_PROVIDER(type=Partition, table=auto_t1, index=index1)
     expect:
       order: idx
-      columns: ["idx int","c1 string","w1_c3_sum int64"]
+      columns: ["idx int","c1 string","suma int", "sumb int"]
       rows:
-        - [1,"aa",1]
-        - [2,"bb",0]
-        - [3,"cc",1]
+        - [1,"aa", 2, 20]
+        - [2,"aa", 4, 40]
+        - [3,"bb", 2, NULL]
+        - [4,"cc", 2, 21]

--- a/cases/query/last_join_window_query.yaml
+++ b/cases/query/last_join_window_query.yaml
@@ -294,3 +294,61 @@ cases:
         - [2,"aa", 2, 20,   4, 20 ]
         - [3,"bb", 2, null, 2, NULL]
         - [4,"cc", 2, 21,   2, 21]
+
+  - id: 6
+    desc: window over subquery(t1 last join t2), aliasing window def as well
+    inputs:
+      -
+        name: t0
+        columns : ["id int","c1 string","c3 int","c4 bigint","c5 float","c6 double","c7 timestamp","c8 date"]
+        indexs: ["index1:c1:c7"]
+        rows:
+          - [1,"aa",2,30,1.1,2.1,1590738990000,"2020-05-01"]
+          - [2,"aa",2,30,1.1,2.1,1590738991000,"2020-05-01"]
+          - [3,"bb",2,31,1.2,2.2,1590738991000,"2020-05-02"]
+          - [4,"cc",2,32,1.3,2.3,1590738992000,"2020-05-03"]
+      -
+        name: t1
+        columns: ["id int","c1 string","c3 int","c4 bigint","c5 float","c6 double","c7 timestamp","c8 date"]
+        indexs: ["index1:c1:c7","index2:c3:c7"]
+        rows:
+          - [1,"aa",20,30,1.1,2.1,1606755660000,"2020-05-01"]
+          - [2,"cc",21,32,1.1,2.1,1606755780000,"2020-05-01"]
+    sql: |
+      select
+        idx, c1a as c1, c3l, c3r,
+        sum(c3l) OVER w1 as suma,
+        min(c3r) OVER w1 as sumb,
+      from (
+        select
+          {0}.c3 as c3l,
+          {0}.id as idx,
+          {1}.c3 as c3r,
+          {0}.c1 as c1a,
+          {0}.c7 as c7a
+        from t0 last join t1 on t0.c1=t1.c1
+      )
+      WINDOW w1 AS (
+        PARTITION BY c1a ORDER BY c7a ROWS_RANGE BETWEEN 10s PRECEDING AND CURRENT ROW);
+    request_plan: |
+      PROJECT(type=Aggregation)
+        SIMPLE_PROJECT(sources=(t0.c3 -> c3l, t0.id -> idx, t1.c3 -> c3r, t0.c1 -> c1a, t0.c7 -> c7a))
+          JOIN(type=LastJoin, condition=, left_keys=(), right_keys=(), index_keys=(t0.c1))
+            REQUEST_UNION(partition_keys=(), orders=(ASC), range=(c7, 10000 PRECEDING, 0 CURRENT), index_keys=(c1))
+              DATA_PROVIDER(request=t0)
+              DATA_PROVIDER(type=Partition, table=t0, index=index1)
+            DATA_PROVIDER(type=Partition, table=t1, index=index1)
+    expect:
+      order: idx
+      columns:
+        - idx int
+        - c1 string
+        - c3l int
+        - c3r int
+        - suma int
+        - sumb int
+      rows:
+        - [1,"aa", 2, 20,   2, 20 ]
+        - [2,"aa", 2, 20,   4, 20 ]
+        - [3,"bb", 2, null, 2, NULL]
+        - [4,"cc", 2, 21,   2, 21]

--- a/cases/query/last_join_window_query.yaml
+++ b/cases/query/last_join_window_query.yaml
@@ -256,33 +256,38 @@ cases:
           - [2,"cc",21,32,1.1,2.1,1606755780000,"2020-05-01"]
     sql: |
       select
-        idx, c1,
+        idx, c1, c3x,
         sum(c3a) OVER w1 as suma,
-        sum(c3x) OVER w1 as sumb
+        min(c3x) OVER w1 as sumb,
       from (
         select
           {0}.id as idx,
-          {0}.c1 as c1,
           {0}.c3 as c3a,
+          {0}.c1 as c1,
           {1}.c3 as c3x,
           {0}.c7 as c7
         from {0} last join {1} on {0}.c1={1}.c1
       )
       WINDOW w1 AS (
         PARTITION BY c1 ORDER BY c7 ROWS_RANGE BETWEEN 10s PRECEDING AND CURRENT ROW);
-    request_plan: |
-      PROJECT(type=Aggregation)
-        SIMPLE_PROJECT(sources=(auto_t0.id -> idx, auto_t0.c1, auto_t0.c3 -> c3a, auto_t1.c3 -> c3x, auto_t0.c7))
-          JOIN(type=LastJoin, condition=, left_keys=(), right_keys=(), index_keys=(auto_t0.c1))
-            REQUEST_UNION(partition_keys=(), orders=(ASC), range=(c7, 10000 PRECEDING, 0 CURRENT), index_keys=(c1))
-              DATA_PROVIDER(request=auto_t0)
-              DATA_PROVIDER(type=Partition, table=auto_t0, index=index1)
-            DATA_PROVIDER(type=Partition, table=auto_t1, index=index1)
+    # request_plan: |
+    #   PROJECT(type=Aggregation)
+    #     SIMPLE_PROJECT(sources=(auto_t0.id -> idx, auto_t0.c1, auto_t0.c3 -> c3a, auto_t1.c3 -> c3x, auto_t0.c7))
+    #       JOIN(type=LastJoin, condition=, left_keys=(), right_keys=(), index_keys=(auto_t0.c1))
+    #         REQUEST_UNION(partition_keys=(), orders=(ASC), range=(c7, 10000 PRECEDING, 0 CURRENT), index_keys=(c1))
+    #           DATA_PROVIDER(request=auto_t0)
+    #           DATA_PROVIDER(type=Partition, table=auto_t0, index=index1)
+    #         DATA_PROVIDER(type=Partition, table=auto_t1, index=index1)
     expect:
       order: idx
-      columns: ["idx int","c1 string","suma int", "sumb int"]
+      columns:
+        - idx int
+        - c1 string
+        - c3x int
+        - suma int
+        - sumb int
       rows:
-        - [1,"aa", 2, 20]
-        - [2,"aa", 4, 40]
-        - [3,"bb", 2, NULL]
-        - [4,"cc", 2, 21]
+        - [1,"aa",20,   2, 20 ]
+        - [2,"aa",20,   4, 20 ]
+        - [3,"bb",null, 2, NULL]
+        - [4,"cc",21,   2, 21]

--- a/cases/query/last_join_window_query.yaml
+++ b/cases/query/last_join_window_query.yaml
@@ -241,6 +241,7 @@ cases:
     desc: window over subquery(t1 last join t2)
     inputs:
       -
+        name: t0
         columns : ["id int","c1 string","c3 int","c4 bigint","c5 float","c6 double","c7 timestamp","c8 date"]
         indexs: ["index1:c1:c7"]
         rows:
@@ -249,6 +250,7 @@ cases:
           - [3,"bb",2,31,1.2,2.2,1590738991000,"2020-05-02"]
           - [4,"cc",2,32,1.3,2.3,1590738992000,"2020-05-03"]
       -
+        name: t1
         columns: ["id int","c1 string","c3 int","c4 bigint","c5 float","c6 double","c7 timestamp","c8 date"]
         indexs: ["index1:c1:c7","index2:c3:c7"]
         rows:
@@ -256,38 +258,39 @@ cases:
           - [2,"cc",21,32,1.1,2.1,1606755780000,"2020-05-01"]
     sql: |
       select
-        idx, c1, c3x,
-        sum(c3a) OVER w1 as suma,
-        min(c3x) OVER w1 as sumb,
+        idx, c1, c3l, c3r,
+        sum(c3l) OVER w1 as suma,
+        min(c3r) OVER w1 as sumb,
       from (
         select
+          {0}.c3 as c3l,
           {0}.id as idx,
-          {0}.c3 as c3a,
           {0}.c1 as c1,
-          {1}.c3 as c3x,
+          {1}.c3 as c3r,
           {0}.c7 as c7
-        from {0} last join {1} on {0}.c1={1}.c1
+        from t0 last join t1 on t0.c1=t1.c1
       )
       WINDOW w1 AS (
         PARTITION BY c1 ORDER BY c7 ROWS_RANGE BETWEEN 10s PRECEDING AND CURRENT ROW);
-    # request_plan: |
-    #   PROJECT(type=Aggregation)
-    #     SIMPLE_PROJECT(sources=(auto_t0.id -> idx, auto_t0.c1, auto_t0.c3 -> c3a, auto_t1.c3 -> c3x, auto_t0.c7))
-    #       JOIN(type=LastJoin, condition=, left_keys=(), right_keys=(), index_keys=(auto_t0.c1))
-    #         REQUEST_UNION(partition_keys=(), orders=(ASC), range=(c7, 10000 PRECEDING, 0 CURRENT), index_keys=(c1))
-    #           DATA_PROVIDER(request=auto_t0)
-    #           DATA_PROVIDER(type=Partition, table=auto_t0, index=index1)
-    #         DATA_PROVIDER(type=Partition, table=auto_t1, index=index1)
+    request_plan: |
+      PROJECT(type=Aggregation)
+        SIMPLE_PROJECT(sources=(t0.c3 -> c3l, t0.id -> idx, t0.c1, t1.c3 -> c3r, t0.c7))
+          JOIN(type=LastJoin, condition=, left_keys=(), right_keys=(), index_keys=(t0.c1))
+            REQUEST_UNION(partition_keys=(), orders=(ASC), range=(c7, 10000 PRECEDING, 0 CURRENT), index_keys=(c1))
+              DATA_PROVIDER(request=t0)
+              DATA_PROVIDER(type=Partition, table=t0, index=index1)
+            DATA_PROVIDER(type=Partition, table=t1, index=index1)
     expect:
       order: idx
       columns:
         - idx int
         - c1 string
-        - c3x int
+        - c3l int
+        - c3r int
         - suma int
         - sumb int
       rows:
-        - [1,"aa",20,   2, 20 ]
-        - [2,"aa",20,   4, 20 ]
-        - [3,"bb",null, 2, NULL]
-        - [4,"cc",21,   2, 21]
+        - [1,"aa", 2, 20,   2, 20 ]
+        - [2,"aa", 2, 20,   4, 20 ]
+        - [3,"bb", 2, null, 2, NULL]
+        - [4,"cc", 2, 21,   2, 21]

--- a/hybridse/include/vm/schemas_context.h
+++ b/hybridse/include/vm/schemas_context.h
@@ -305,6 +305,8 @@ class RowParser {
     std::vector<codec::RowView> row_view_list_;
 };
 
+base::Status DoSearchExprDependentColumns(const node::ExprNode* expr, std::vector<const node::ExprNode*>* columns);
+
 }  // namespace vm
 }  // namespace hybridse
 

--- a/hybridse/src/codegen/aggregate_ir_builder.cc
+++ b/hybridse/src/codegen/aggregate_ir_builder.cc
@@ -34,11 +34,7 @@ AggregateIRBuilder::AggregateIRBuilder(const vm::SchemasContext* sc,
                                        const node::FrameNode* frame_node,
                                        uint32_t id)
     : schema_context_(sc), module_(module), frame_node_(frame_node), id_(id) {
-    available_agg_func_set_.insert("sum");
-    available_agg_func_set_.insert("avg");
-    available_agg_func_set_.insert("count");
-    available_agg_func_set_.insert("min");
-    available_agg_func_set_.insert("max");
+    available_agg_func_set_ = {"sum", "avg", "count", "min", "max"};
 }
 
 bool AggregateIRBuilder::IsAggFuncName(const std::string& fname) {
@@ -563,11 +559,11 @@ base::Status ScheduleAggGenerators(
 }
 
 base::Status AggregateIRBuilder::BuildMulti(const std::string& base_funcname,
-                                    ExprIRBuilder* expr_ir_builder,
-                                    VariableIRBuilder* variable_ir_builder,
-                                    ::llvm::BasicBlock* cur_block,
-                                    const std::string& output_ptr_name,
-                                    const vm::Schema& output_schema) {
+                                            ExprIRBuilder* expr_ir_builder,
+                                            VariableIRBuilder* variable_ir_builder,
+                                            ::llvm::BasicBlock* cur_block,
+                                            const std::string& output_ptr_name,
+                                            const vm::Schema& output_schema) {
     ::llvm::LLVMContext& llvm_ctx = module_->getContext();
     ::llvm::IRBuilder<> builder(llvm_ctx);
     auto void_ty = llvm::Type::getVoidTy(llvm_ctx);

--- a/hybridse/src/codegen/aggregate_ir_builder.h
+++ b/hybridse/src/codegen/aggregate_ir_builder.h
@@ -105,7 +105,9 @@ class AggregateIRBuilder {
     bool empty() const { return agg_col_infos_.empty(); }
 
  private:
+    // schema context of input node
     const vm::SchemasContext* schema_context_;
+
     ::llvm::Module* module_;
     const node::FrameNode* frame_node_;
     uint32_t id_;

--- a/hybridse/src/codegen/expr_ir_builder.h
+++ b/hybridse/src/codegen/expr_ir_builder.h
@@ -117,7 +117,11 @@ class ExprIRBuilder {
 
  private:
     CodeGenContext* ctx_;
+
+    // window frame node
     const node::FrameNode* frame_ = nullptr;
+
+    // ExprIdNode definition of frame
     node::ExprNode* frame_arg_ = nullptr;
 };
 }  // namespace codegen

--- a/hybridse/src/codegen/fn_let_ir_builder.cc
+++ b/hybridse/src/codegen/fn_let_ir_builder.cc
@@ -95,9 +95,9 @@ Status RowFnLetIRBuilder::Build(
 
     if (primary_frame != nullptr && !primary_frame->IsPureHistoryFrame()) {
         NativeValue window;
-        variable_ir_builder.LoadWindow("", &window, status);
-        variable_ir_builder.StoreWindow(primary_frame->GetExprString(),
-                                        window.GetRaw(), status);
+        CHECK_TRUE(variable_ir_builder.LoadWindow("", &window, status), kCodegenError);
+        CHECK_TRUE(variable_ir_builder.StoreWindow(primary_frame->GetExprString(), window.GetRaw(), status),
+                   kCodegenError);
     }
 
     ExprIRBuilder expr_ir_builder(ctx_);

--- a/hybridse/src/codegen/fn_let_ir_builder_test.h
+++ b/hybridse/src/codegen/fn_let_ir_builder_test.h
@@ -108,8 +108,7 @@ void CheckFnLetBuilderWithParameterRow(::hybridse::node::NodeManager* manager, v
     if (pp_node_ptr->GetW() != nullptr) {
         frame_node = pp_node_ptr->GetW()->frame_node();
     }
-    status = vm::ExtractProjectInfos(pp_node_ptr->GetProjects(), frame_node,
-                                     schemas_ctx, manager, &column_projects);
+    status = vm::ExtractProjectInfos(pp_node_ptr->GetProjects(), frame_node, &column_projects);
     ASSERT_TRUE(status.isOK()) << status.str();
 
     bool is_agg = window_ptr != nullptr;

--- a/hybridse/src/passes/physical/transform_up_physical_pass.h
+++ b/hybridse/src/passes/physical/transform_up_physical_pass.h
@@ -17,8 +17,10 @@
 #define HYBRIDSE_SRC_PASSES_PHYSICAL_TRANSFORM_UP_PHYSICAL_PASS_H_
 
 #include <memory>
+#include <set>
 #include <string>
 #include <unordered_map>
+
 #include "passes/physical/physical_pass.h"
 
 namespace hybridse {

--- a/hybridse/src/vm/catalog_wrapper.h
+++ b/hybridse/src/vm/catalog_wrapper.h
@@ -33,9 +33,7 @@ class PredicateFun {
 };
 class IteratorProjectWrapper : public RowIterator {
  public:
-    IteratorProjectWrapper(std::unique_ptr<RowIterator> iter,
-                           const Row& parameter,
-                           const ProjectFun* fun)
+    IteratorProjectWrapper(std::unique_ptr<RowIterator>&& iter, const Row& parameter, const ProjectFun* fun)
         : RowIterator(), iter_(std::move(iter)), parameter_(parameter), fun_(fun), value_() {}
     virtual ~IteratorProjectWrapper() {}
     bool Valid() const override { return iter_->Valid(); }
@@ -56,11 +54,11 @@ class IteratorProjectWrapper : public RowIterator {
 
 class IteratorFilterWrapper : public RowIterator {
  public:
-    IteratorFilterWrapper(std::unique_ptr<RowIterator> iter,
-                          const Row& parameter,
-                          const PredicateFun* fun)
+    IteratorFilterWrapper(std::unique_ptr<RowIterator>&& iter, const Row& parameter, const PredicateFun* fun)
         : RowIterator(), iter_(std::move(iter)), parameter_(parameter), predicate_(fun) {}
+
     virtual ~IteratorFilterWrapper() {}
+
     bool Valid() const override {
         return iter_->Valid() && predicate_->operator()(iter_->GetValue(), parameter_);
     }

--- a/hybridse/src/vm/mem_catalog.cc
+++ b/hybridse/src/vm/mem_catalog.cc
@@ -402,6 +402,14 @@ void RowIterNext(int8_t* iter_ptr) {
         *reinterpret_cast<std::unique_ptr<RowIterator>*>(iter_ptr);
     local_iter->Next();
 }
+
+// FIXME(ace): `GetValue` and `row.buf` both returns a reference
+//  which make this function dangerous. When calls theis function
+//  multiple times or together with `RowIterGetCurSlice`, returned references
+//  got invalided except the last one.
+//
+//  It is better deprecated `RowIterGetCurSlice`, `RowIterGetCurSliceSize`, and
+//  use `RowGetSlice`, `RowIterGetCurSlice` instead.
 int8_t* RowIterGetCurSlice(int8_t* iter_ptr, size_t idx) {
     auto& local_iter =
         *reinterpret_cast<std::unique_ptr<RowIterator>*>(iter_ptr);

--- a/hybridse/src/vm/physical_op.cc
+++ b/hybridse/src/vm/physical_op.cc
@@ -285,7 +285,7 @@ void PhysicalProjectNode::Print(std::ostream& output, const std::string& tab) co
  *
  *  `schemas_ctx` used to resolve column and `plan_ctx` use to alloc unique id for non-column-reference column
  */
-static Status InitProjectSchemaSource(const ColumnProjects& projects, const SchemasContext* schemas_ctx,
+static Status InitProjectSchemaSource(const ColumnProjects& projects, const SchemasContext* depend_schemas_ctx,
                                       PhysicalPlanContext* plan_ctx, SchemaSource* project_source) {
     const FnInfo& fn_info = projects.fn_info();
     CHECK_TRUE(fn_info.IsValid(), common::kPlanError, "Project node's function info is not valid");
@@ -300,7 +300,7 @@ static Status InitProjectSchemaSource(const ColumnProjects& projects, const Sche
                    "* should be extend before generate projects");
         if (expr->GetExprType() == node::kExprColumnRef) {
             auto col_ref = dynamic_cast<const node::ColumnRefNode*>(expr);
-            CHECK_STATUS(schemas_ctx->ResolveColumnID(col_ref->GetDBName(), col_ref->GetRelationName(),
+            CHECK_STATUS(depend_schemas_ctx->ResolveColumnID(col_ref->GetDBName(), col_ref->GetRelationName(),
                                                       col_ref->GetColumnName(), &column_id));
             project_source->SetColumnID(i, column_id);
             project_source->SetSource(i, 0, column_id);

--- a/hybridse/src/vm/transform.cc
+++ b/hybridse/src/vm/transform.cc
@@ -304,7 +304,7 @@ Status BatchModeTransformer::InitFnInfo(PhysicalOpNode* node,
         if (fn_info->fn_name().empty()) {
             continue;
         }
-        CHECK_STATUS(InstantiateLLVMFunction(*fn_info), "Instantiate ", i,
+        CHECK_STATUS(InstantiateLLVMFunction(fn_info), "Instantiate ", i,
                      "th native function \"", fn_info->fn_name(),
                      "\" failed at node:\n", node->GetTreeString());
     }
@@ -689,15 +689,15 @@ Status RequestModeTransformer::TransformWindowOp(PhysicalOpNode* depend,
     return Status::OK();
 }
 
-Status RequestModeTransformer::OptimizeSimpleProjectAsWindowProducer(PhysicalSimpleProjectNode* depend,
+Status RequestModeTransformer::OptimizeSimpleProjectAsWindowProducer(PhysicalSimpleProjectNode* prj_node,
                                                                      const node::WindowPlanNode* w_ptr,
                                                                      PhysicalOpNode** output) {
     // - SimpleProject(DataProvider) -> RequestUnion(Request, DataSource)
     // - SimpleProject(RequestJoin) -> Join(RequestUnion, DataSource)
-    auto op_type = depend->GetProducer(0)->GetOpType();
+    auto op_type = prj_node->GetProducer(0)->GetOpType();
     switch (op_type) {
         case kPhysicalOpDataProvider: {
-            auto data_op = dynamic_cast<PhysicalDataProviderNode*>(depend->GetProducer(0));
+            auto data_op = dynamic_cast<PhysicalDataProviderNode*>(prj_node->GetProducer(0));
             CHECK_TRUE(data_op != nullptr, kPlanError, "not PhysicalDataProviderNode");
             CHECK_TRUE(data_op->provider_type_ == kProviderTypeRequest, kPlanError,
                        "Do not support window on non-request input");
@@ -714,11 +714,11 @@ Status RequestModeTransformer::OptimizeSimpleProjectAsWindowProducer(PhysicalSim
 
             // right side simple project
             PhysicalSimpleProjectNode* right_simple_project = nullptr;
-            CHECK_STATUS(CreateOp<PhysicalSimpleProjectNode>(&right_simple_project, right, depend->project()));
+            CHECK_STATUS(CreateOp<PhysicalSimpleProjectNode>(&right_simple_project, right, prj_node->project()));
 
             // request union
             PhysicalRequestUnionNode* request_union_op = nullptr;
-            CHECK_STATUS(CreateRequestUnionNode(depend, right_simple_project, table->GetDatabase(), table->GetName(),
+            CHECK_STATUS(CreateRequestUnionNode(prj_node, right_simple_project, table->GetDatabase(), table->GetName(),
                                                 table->GetSchema(), nullptr, w_ptr, &request_union_op));
             if (!w_ptr->union_tables().empty()) {
                 for (auto iter = w_ptr->union_tables().cbegin(); iter != w_ptr->union_tables().cend(); iter++) {
@@ -726,7 +726,7 @@ Status RequestModeTransformer::OptimizeSimpleProjectAsWindowProducer(PhysicalSim
                     CHECK_STATUS(TransformPlanOp(*iter, &union_table_op));
                     PhysicalRenameNode* rename_union_op = nullptr;
                     CHECK_STATUS(CreateOp<PhysicalRenameNode>(&rename_union_op, union_table_op,
-                                                              depend->schemas_ctx()->GetName()));
+                                                              prj_node->schemas_ctx()->GetName()));
                     CHECK_TRUE(request_union_op->AddWindowUnion(rename_union_op), kPlanError,
                                "Fail to add request window union table");
                 }
@@ -735,19 +735,19 @@ Status RequestModeTransformer::OptimizeSimpleProjectAsWindowProducer(PhysicalSim
             break;
         }
         case kPhysicalOpRequestJoin: {
-            auto join_op = dynamic_cast<PhysicalRequestJoinNode*>(depend->GetProducer(0));
+            auto join_op = dynamic_cast<PhysicalRequestJoinNode*>(prj_node->GetProducer(0));
             CHECK_TRUE(join_op != nullptr, kPlanError, "not PhysicalRequestJoinNode");
 
             PhysicalOpNode* out = nullptr;
             CHECK_STATUS(OptimizeRequestJoinAsWindowProducer(join_op, w_ptr, &out));
 
             PhysicalSimpleProjectNode* simple_proj = nullptr;
-            CHECK_STATUS(CreateOp<PhysicalSimpleProjectNode>(&simple_proj, out, depend->project()));
+            CHECK_STATUS(CreateOp<PhysicalSimpleProjectNode>(&simple_proj, out, prj_node->project()));
             *output = simple_proj;
             break;
         }
         default: {
-            FAIL_STATUS(kPlanError, "Do not support window on\n", depend->GetTreeString());
+            FAIL_STATUS(kPlanError, "Do not support window on\n", prj_node->GetTreeString());
         }
     }
     return Status::OK();
@@ -809,7 +809,8 @@ Status RequestModeTransformer::OptimizeRequestJoinAsWindowProducer(PhysicalReque
     return Status::OK();
 }
 
-Status RequestModeTransformer::ValidWindowLastJoin(const node::WindowPlanNode* w_ptr, const PhysicalOpNode* left_node) {
+Status RequestModeTransformer::ValidWindowLastJoin(const node::WindowPlanNode* w_ptr,
+                                                   const PhysicalOpNode* left_node) const {
     const node::OrderByNode* orders = w_ptr->GetOrders();
     const node::ExprListNode* groups = w_ptr->GetKeys();
     const SchemasContext* child_schemas_ctx = left_node->schemas_ctx();
@@ -980,10 +981,7 @@ bool BatchModeTransformer::AddPass(PhysicalPlanPassType type) {
     return true;
 }
 
-Status ExtractProjectInfos(const node::PlanNodeList& projects,
-                           const node::FrameNode* primary_frame,
-                           const SchemasContext* schemas_ctx,
-                           node::NodeManager* node_manager,
+Status ExtractProjectInfos(const node::PlanNodeList& projects, const node::FrameNode* primary_frame,
                            ColumnProjects* output) {
     for (auto plan_node : projects) {
         auto pp_node = dynamic_cast<node::ProjectNode*>(plan_node);
@@ -1004,12 +1002,12 @@ Status ExtractProjectInfos(const node::PlanNodeList& projects,
     return Status::OK();
 }
 
-Status BatchModeTransformer::InstantiateLLVMFunction(const FnInfo& fn_info) {
-    CHECK_TRUE(fn_info.IsValid(), kCodegenError, "Fail to install llvm function, function info is invalid");
-    codegen::CodeGenContext codegen_ctx(module_, fn_info.schemas_ctx(), plan_ctx_.parameter_types(), node_manager_);
+Status BatchModeTransformer::InstantiateLLVMFunction(const FnInfo* fn_info) {
+    CHECK_TRUE(fn_info->IsValid(), kCodegenError, "Fail to install llvm function, function info is invalid");
+    codegen::CodeGenContext codegen_ctx(module_, fn_info->schemas_ctx(), plan_ctx_.parameter_types(), node_manager_);
     codegen::RowFnLetIRBuilder builder(&codegen_ctx);
-    return builder.Build(fn_info.fn_name(), fn_info.fn_def(), fn_info.GetPrimaryFrame(), fn_info.GetFrames(),
-                         *fn_info.fn_schema());
+    return builder.Build(fn_info->fn_name(), fn_info->fn_def(), fn_info->GetPrimaryFrame(), fn_info->GetFrames(),
+                         *fn_info->fn_schema());
 }
 
 bool BatchModeTransformer::AddDefaultPasses() {
@@ -1138,9 +1136,8 @@ Status BatchModeTransformer::CreatePhysicalConstProjectNode(
                    "Invalid project: no table used");
     }
 
-    SchemasContext empty_schemas_ctx;
     ColumnProjects const_projects;
-    CHECK_STATUS(ExtractProjectInfos(projects, nullptr, &empty_schemas_ctx, node_manager_, &const_projects));
+    CHECK_STATUS(ExtractProjectInfos(projects, nullptr, &const_projects));
 
     PhysicalConstProjectNode* const_project_op = nullptr;
     CHECK_STATUS(
@@ -1194,8 +1191,7 @@ Status BatchModeTransformer::CreatePhysicalProjectNode(
 
     // Create project function and infer output schema
     ColumnProjects column_projects;
-    CHECK_STATUS(
-        ExtractProjectInfos(projects, primary_frame, depend->schemas_ctx(), node_manager_, &column_projects));
+    CHECK_STATUS(ExtractProjectInfos(projects, primary_frame, &column_projects));
 
     if (append_input) {
         CHECK_TRUE(project_type == kWindowAggregation, kPlanError,

--- a/hybridse/src/vm/transform.cc
+++ b/hybridse/src/vm/transform.cc
@@ -737,7 +737,14 @@ Status RequestModeTransformer::OptimizeSimpleProjectAsWindowProducer(PhysicalSim
         case kPhysicalOpRequestJoin: {
             auto join_op = dynamic_cast<PhysicalRequestJoinNode*>(depend->GetProducer(0));
             CHECK_TRUE(join_op != nullptr, kPlanError, "not PhysicalRequestJoinNode");
-            return OptimizeRequestJoinAsWindowProducer(join_op, w_ptr, output);
+
+            PhysicalOpNode* out = nullptr;
+            CHECK_STATUS(OptimizeRequestJoinAsWindowProducer(join_op, w_ptr, &out));
+
+            PhysicalSimpleProjectNode* simple_proj = nullptr;
+            CHECK_STATUS(CreateOp<PhysicalSimpleProjectNode>(&simple_proj, out, depend->project()));
+            *output = simple_proj;
+            break;
         }
         default: {
             FAIL_STATUS(kPlanError, "Do not support window on\n", depend->GetTreeString());

--- a/hybridse/src/vm/transform.h
+++ b/hybridse/src/vm/transform.h
@@ -297,6 +297,17 @@ class RequestModeTransformer : public BatchModeTransformer {
     Status OptimizeRequestJoinAsWindowProducer(PhysicalRequestJoinNode* depend, const node::WindowPlanNode* w_ptr,
                                                PhysicalOpNode** output);
 
+    // check support for either of
+    // - window (last join)
+    // - window (subquery (last join))
+    //
+    // currently, it expect window's group keys and order keys all refer to left table source of last join
+    // otherwise, error status returned.
+    //
+    // \param w_ptr Window definition node
+    // \param left_node Left node from the last join
+    Status ValidWindowLastJoin(const node::WindowPlanNode* w_ptr, const PhysicalOpNode* left_node);
+
  private:
     bool enable_batch_request_opt_;
     bool performance_sensitive_;

--- a/hybridse/src/vm/transform.h
+++ b/hybridse/src/vm/transform.h
@@ -294,19 +294,9 @@ class RequestModeTransformer : public BatchModeTransformer {
     // Optimize simple project node which is the producer of window project
     Status OptimizeSimpleProjectAsWindowProducer(PhysicalSimpleProjectNode* depend, const node::WindowPlanNode* w_ptr,
                                                  PhysicalOpNode** output);
-    Status OptimizeRequestJoinAsWindowProducer(PhysicalRequestJoinNode* depend, const node::WindowPlanNode* w_ptr,
-                                               PhysicalOpNode** output);
 
-    // check support for either of
-    // - window (last join)
-    // - window (subquery (last join))
-    //
-    // currently, it expect window's group keys and order keys all refer to left table source of last join
-    // otherwise, error status returned.
-    //
-    // \param w_ptr Window definition node
-    // \param left_node Left node from the last join
-    Status ValidWindowLastJoin(const node::WindowPlanNode* w_ptr, const PhysicalOpNode* left_node) const;
+    Status OptimizeRequestJoinAsWindowProducer(PhysicalRequestJoinNode* depend, const SchemasContext* window_depend_sc,
+                                               const node::WindowPlanNode* w_ptr, PhysicalOpNode** output);
 
  private:
     bool enable_batch_request_opt_;

--- a/hybridse/src/vm/transform.h
+++ b/hybridse/src/vm/transform.h
@@ -214,7 +214,7 @@ class BatchModeTransformer {
     /**
      * Instantiate underlying llvm function with specified fn info.
      */
-    Status InstantiateLLVMFunction(const FnInfo& fn_info);
+    Status InstantiateLLVMFunction(const FnInfo* fn_info);
 
     Status GenWindowJoinList(PhysicalWindowAggrerationNode* window_agg_op,
                              PhysicalOpNode* in);
@@ -306,7 +306,7 @@ class RequestModeTransformer : public BatchModeTransformer {
     //
     // \param w_ptr Window definition node
     // \param left_node Left node from the last join
-    Status ValidWindowLastJoin(const node::WindowPlanNode* w_ptr, const PhysicalOpNode* left_node);
+    Status ValidWindowLastJoin(const node::WindowPlanNode* w_ptr, const PhysicalOpNode* left_node) const;
 
  private:
     bool enable_batch_request_opt_;
@@ -365,10 +365,7 @@ inline bool SchemaType2DataType(const ::hybridse::type::Type type,
     return true;
 }
 
-Status ExtractProjectInfos(const node::PlanNodeList& projects,
-                           const node::FrameNode* primary_frame,
-                           const SchemasContext* schemas_ctx,
-                           node::NodeManager* node_manager,
+Status ExtractProjectInfos(const node::PlanNodeList& projects, const node::FrameNode* primary_frame,
                            ColumnProjects* output);
 }  // namespace vm
 }  // namespace hybridse

--- a/hybridse/src/vm/transform.h
+++ b/hybridse/src/vm/transform.h
@@ -292,8 +292,9 @@ class RequestModeTransformer : public BatchModeTransformer {
 
  private:
     // Optimize simple project node which is the producer of window project
-    Status OptimizeSimpleProjectAsWindowProducer(PhysicalSimpleProjectNode* depend, const node::WindowPlanNode* w_ptr,
-                                                 PhysicalOpNode** output);
+    Status OptimizeSimpleProjectAsWindowProducer(PhysicalSimpleProjectNode* depend,
+                                                 const SchemasContext* window_depend_sc,
+                                                 const node::WindowPlanNode* w_ptr, PhysicalOpNode** output);
 
     Status OptimizeRequestJoinAsWindowProducer(PhysicalRequestJoinNode* depend, const SchemasContext* window_depend_sc,
                                                const node::WindowPlanNode* w_ptr, PhysicalOpNode** output);


### PR DESCRIPTION
the PR try to fix #2621 , which add the SimpleProject Node above RequestUnion Node, as a handler for column rename. 

So for the SQL
```sql
select id, agg_func(col) over w as agg
from (
   select i as id,
   colx as col
   from t1 last join t2 on t1.i = t2.i
) window w as (
    partition by id order by col rows_range ....
);
```

The physical plan will be
```
AggProject
  SimpleProject
    LastJoin
      RequestUnion
        Request
        Table(t1)
      Table(t2)
```


**Known Limits**
- Window union will not handles correctly in this case, track in #2832 
