### PR TITLE
fix: make test deps to extras require in pysdk

### DIFF
--- a/docs/zh/developer/python_dev.md
+++ b/docs/zh/developer/python_dev.md
@@ -2,9 +2,18 @@
 
 `python/`中有两个组件，一个Python SDK，一个诊断工具OpenMLDB Tool。
 
-## SDK 测试方法
+## SDK
 
-在根目录执行`make SQL_PYSDK_ENABLE=ON OPENMLDB_BUILD_TARGET=cp_python_sdk_so`，确保`python/openmldb_sdk/openmldb/native/`中使用的是最新的native库。
+Python SDK本身不依赖测试用的pytest和tox库，如果你想使用tests测试文件进行测试，可以通过以下方式下载测试依赖。
+
+```
+pip install 'openmldb[test]'
+pip install 'dist/....whl[test]'
+```
+
+### 测试方法
+
+在根目录执行`make SQL_PYSDK_ENABLE=ON OPENMLDB_BUILD_TARGET=cp_python_sdk_so`，确保`python/openmldb_sdk/openmldb/native/`中使用的是最新的native库。测试通常需要连接一个OpenMLDB集群，如果你还没有启动集群，或对服务组件有代码改动，还需要编译TARGET openmldb，并启动onebox集群，可参考`steps/test_python.sh`的启动部分。
 
 1. 安装包测试：安装编译好的whl，再`pytest test/`。可直接使用脚本`steps/test_python.sh`。
 1. 动态测试：确认pip中无openmldb，也不要安装编译好的whl，在`python/openmldb_sdk`中执行`pytest test/`即可。这种方式可以方便调试代码。

--- a/python/openmldb_sdk/setup.py
+++ b/python/openmldb_sdk/setup.py
@@ -31,9 +31,13 @@ setup(
         "sqlalchemy <= 1.4.9",
         "IPython",
         "prettytable",
-        "tox",
-        "pytest"
     ],
+    extras_require={
+        'test': [
+            "pytest",
+            "tox",
+        ]
+    },
     include_package_data=True,
     package_data = {'':['*.so']},
     packages=find_packages(),


### PR DESCRIPTION
`pip install openmldb` Requires: IPython, prettytable, sqlalchemy
pytest & tox will be installed by `pip install openmldb[test]`