### PR TITLE
docs: updated techdoc example function

### DIFF
--- a/docs/en/reference/sql/functions_and_operators/Files/udfs_8h.md
+++ b/docs/en/reference/sql/functions_and_operators/Files/udfs_8h.md
@@ -1130,7 +1130,7 @@ Example:
 
 ```sql
 
-select date_format(date(1590115420000),"%Y-%m-%d");
+select date_format(date(timestamp(1590115420000)),"%Y-%m-%d");
 --output "2020-05-22"
 ```
 

--- a/docs/zh/reference/sql/functions_and_operators/Files/udfs_8h.md
+++ b/docs/zh/reference/sql/functions_and_operators/Files/udfs_8h.md
@@ -1130,7 +1130,7 @@ Example:
 
 ```sql
 
-select date_format(date(1590115420000),"%Y-%m-%d");
+select date_format(date(timestamp(1590115420000)),"%Y-%m-%d");
 --output "2020-05-22"
 ```
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  - docs update

* **What is the current behavior?** (You can also link to an open issue here)

    #2803 
    
    The example of function date_format is incorrect: 
    `select date_format(date(1590115420000),"%Y-%m-%d");`

* **What is the new behavior (if this is a feature change)?**

```diff
- select date_format(date(1590115420000),"%Y-%m-%d");
+ select date_format(date(timestamp(1590115420000)),"%Y-%m-%d");
```