### PR TITLE
docs: updated techdoc date_format function documentation

### DIFF
--- a/hybridse/src/udf/default_udf_library.cc
+++ b/hybridse/src/udf/default_udf_library.cc
@@ -851,7 +851,7 @@ void DefaultUdfLibrary::InitStringUdf() {
             Example:
 
             @code{.sql}
-                select date_format(date(1590115420000),"%Y-%m-%d");
+                select date_format(date(timestamp(1590115420000)),"%Y-%m-%d");
                 --output "2020-05-22"
             @endcode)");
     /// Escape is Nullable


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  - docs update

* **What is the current behavior?** (You can also link to an open issue here)

    close #2803 
    
    The example of function date_format is incorrect: 
    `select date_format(date(1590115420000),"%Y-%m-%d");`

* **What is the new behavior (if this is a feature change)?**

```diff
- select date_format(date(1590115420000),"%Y-%m-%d");
+ select date_format(date(timestamp(1590115420000)),"%Y-%m-%d");
```