### PR TITLE
feat: size udf

### DIFF
--- a/cases/function/test_feature_zero_function.yaml
+++ b/cases/function/test_feature_zero_function.yaml
@@ -174,3 +174,30 @@ cases:
         - [3, "", "", "", "", "", ""]
         - [4, "", "", "", "", "", ""]
         - [5, "", "", "", "", "", ""]
+  - id: 6
+    desc: size function of split result on single row
+    inputs:
+      - name: main
+        columns: ["id int64", "pk int64", "c1 string"]
+        indexs: ["index1:pk:id"]
+        rows:
+          - [1, 0, "k1:v1,k2:v2"]
+          - [2, 0, "k3:v3"]
+          - [3, 0, "???,,k4:v4"]
+          - [4, 0, NULL]
+          - [5, 0, "k5:v5,k3:v3"]
+    sql: |
+      SELECT id,
+        size(fz_split(c1, ",")) AS split_and_size,
+        size(fz_split_by_key(c1, ",", ":")) AS split_key_and_size,
+        size(fz_split_by_value(c1, ",", ":")) AS split_value_and_size
+      FROM main;
+    expect:
+      order: id
+      columns: ["id int64", "split_and_size int", "split_key_and_size int", "split_value_and_size int"]
+      rows:
+        - [1, 2, 2, 2]
+        - [2, 1, 1, 1]
+        - [3, 3, 1, 1]
+        - [4, 0, 0, 0]
+        - [5, 2, 2, 2]

--- a/cases/function/test_feature_zero_function.yaml
+++ b/cases/function/test_feature_zero_function.yaml
@@ -188,9 +188,9 @@ cases:
           - [5, 0, "k5:v5,k3:v3"]
     sql: |
       SELECT id,
-        size(fz_split(c1, ",")) AS split_and_size,
-        size(fz_split_by_key(c1, ",", ":")) AS split_key_and_size,
-        size(fz_split_by_value(c1, ",", ":")) AS split_value_and_size
+        size(split(c1, ",")) AS split_and_size,
+        size(split_by_key(c1, ",", ":")) AS split_key_and_size,
+        size(split_by_value(c1, ",", ":")) AS split_value_and_size
       FROM main;
     expect:
       order: id

--- a/hybridse/src/udf/default_defs/feature_zero_def.cc
+++ b/hybridse/src/udf/default_defs/feature_zero_def.cc
@@ -380,9 +380,9 @@ struct FZStringOpsDef {
         output->data_ = buf;
     }
 
-    static void ListSize(hybridse::codec::ListRef<StringRef>* list, int32_t* size) {
+    static int32_t ListSize(hybridse::codec::ListRef<StringRef>* list) {
         auto list_v = reinterpret_cast<hybridse::codec::ListV<StringRef> *>(list->list);
-        *size = list_v->GetCount();
+        return list_v->GetCount();
     }
 };
 
@@ -667,8 +667,7 @@ void DefaultUdfLibrary::InitFeatureZero() {
 
     RegisterExternal("size")
         .list_argument_at(0)
-        .args<ListRef<StringRef>>(reinterpret_cast<void (*)(ListRef<StringRef>*, int32_t*)>(FZStringOpsDef::ListSize))
-        .return_by_arg(true)
+        .args<ListRef<StringRef>>(reinterpret_cast<int32_t (*)(ListRef<StringRef>*)>(FZStringOpsDef::ListSize))
         .returns<int32_t>()
         .doc(R"(
             @brief Get the size of a List (e.g., result of split)

--- a/hybridse/src/udf/default_defs/feature_zero_def.cc
+++ b/hybridse/src/udf/default_defs/feature_zero_def.cc
@@ -379,6 +379,11 @@ struct FZStringOpsDef {
         output->size_ = bytes;
         output->data_ = buf;
     }
+
+    static void ListSize(hybridse::codec::ListRef<StringRef>* list, int32_t* size) {
+        auto list_v = reinterpret_cast<hybridse::codec::ListV<StringRef> *>(list->list);
+        *size = list_v->GetCount();
+    }
 };
 
 template <typename K>
@@ -660,6 +665,22 @@ void DefaultUdfLibrary::InitFeatureZero() {
         .args_in<int16_t, int32_t, int64_t, float, double, Date, Timestamp,
                  StringRef>();
 
+    RegisterExternal("size")
+        .list_argument_at(0)
+        .args<ListRef<StringRef>>(reinterpret_cast<void (*)(ListRef<StringRef>*, int32_t*)>(FZStringOpsDef::ListSize))
+        .return_by_arg(true)
+        .returns<int32_t>()
+        .doc(R"(
+            @brief Get the size of a List (e.g., result of split)
+
+            Example:
+
+            @code{.sql}
+                select size(split("a b c", " "));
+                -- output 3
+
+            @endcode
+            @since 0.7.0)");
 
     RegisterAlias("fz_window_split", "window_split");
     RegisterAlias("fz_split", "split");


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
support `size` like `size(split("a b c", " "))`


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**

