### PR TITLE
fix: deploy failed if the column name of main table is keyword

### DIFF
--- a/src/cmd/sql_cmd_test.cc
+++ b/src/cmd/sql_cmd_test.cc
@@ -711,7 +711,7 @@ TEST_P(DBSDKTest, DeployWithSameIndex) {
         " WINDOW w1 AS (PARTITION BY trans1.c1 ORDER BY trans1.c7 ROWS BETWEEN 2 PRECEDING AND CURRENT ROW);";
     sr->ExecuteSQL(deploy_sql, &status);
     ASSERT_FALSE(status.IsOK());
-    ASSERT_EQ(status.msg, "new ttl type kLatestTime doesn't match the old ttl type kAbsoluteTime");
+    ASSERT_EQ(status.msg, "new ttl type kLatestTime doesn't match the old ttl type kAbsoluteTime in table trans1");
 
     ASSERT_FALSE(cs->GetNsClient()->DropTable("test1", "trans", msg));
     ASSERT_TRUE(cs->GetNsClient()->DropProcedure("test1", "demo", msg));

--- a/src/cmd/sql_cmd_test.cc
+++ b/src/cmd/sql_cmd_test.cc
@@ -614,10 +614,10 @@ TEST_P(DBSDKTest, Deploy) {
     HandleSQL("use test1;");
     std::string create_sql =
         "create table trans (c1 string, c3 int, c4 bigint, c5 float, c6 double, c7 timestamp, "
-        "c8 date, index(key=c3, ts=c7, abs_ttl=0, ttl_type=absolute));";
+        "c8 date, `index` bigint, index(key=c3, ts=c7, abs_ttl=0, ttl_type=absolute));";
     HandleSQL(create_sql);
     if (!cs->IsClusterMode()) {
-        HandleSQL("insert into trans values ('aaa', 11, 22, 1.2, 1.3, 1635247427000, \"2021-05-20\");");
+        HandleSQL("insert into trans values ('aaa', 11, 22, 1.2, 1.3, 1635247427000, \"2021-05-20\", 113);");
     }
 
     std::string deploy_sql =

--- a/src/sdk/sql_cluster_router.cc
+++ b/src/sdk/sql_cluster_router.cc
@@ -3268,7 +3268,7 @@ hybridse::sdk::Status SQLClusterRouter::HandleDeploy(const std::string& db,
         if (it == codec::DATA_TYPE_STR_MAP.end()) {
             return {StatusCode::kCmdError, "illegal data type"};
         }
-        str_stream << col.name() << " " << it->second;
+        str_stream << "`" << col.name() << "` " << it->second;
         if (idx != input_schema->size() - 1) {
             str_stream << ", ";
         }

--- a/src/sdk/sql_cluster_router.cc
+++ b/src/sdk/sql_cluster_router.cc
@@ -3385,10 +3385,11 @@ hybridse::sdk::Status SQLClusterRouter::GetNewIndex(
                 auto& old_column_key = it->second;
                 // type mismatch, return here and deploy failed
                 if (old_column_key.ttl().ttl_type() != column_key.ttl().ttl_type()) {
-                    return {StatusCode::kCmdError, "new ttl type " +
-                                                       ::openmldb::type::TTLType_Name(column_key.ttl().ttl_type()) +
-                                                       " doesn't match the old ttl type " +
-                                                       ::openmldb::type::TTLType_Name(old_column_key.ttl().ttl_type())};
+                    return {StatusCode::kCmdError, absl::StrCat("new ttl type ",
+                                                       ::openmldb::type::TTLType_Name(column_key.ttl().ttl_type()),
+                                                       " doesn't match the old ttl type ",
+                                                       ::openmldb::type::TTLType_Name(old_column_key.ttl().ttl_type()),
+                                                       " in table ", table_name)};
                 } else {
                     // type match, if old ttl == 0, won't update
                     ::openmldb::type::TTLType type = column_key.ttl().ttl_type();


### PR DESCRIPTION
- print table name if ttl_type mismatch
- deploy failed if the column name of main table is keyword like `index`