### PR TITLE
fix: add hdd root path

### DIFF
--- a/release/conf/tablet.flags.template
+++ b/release/conf/tablet.flags.template
@@ -34,6 +34,8 @@
 # 多个磁盘使用英文符号, 隔开
 --db_root_path=./db
 --recycle_bin_root_path=./recycle
+--hdd_root_path=./db
+--recycle_bin_hdd_root_path=./recycle
 
 # snapshot conf
 # 每天23点做snapshot

--- a/release/conf/tablet.flags.template
+++ b/release/conf/tablet.flags.template
@@ -34,8 +34,18 @@
 # 多个磁盘使用英文符号, 隔开
 --db_root_path=./db
 --recycle_bin_root_path=./recycle
---hdd_root_path=./db
---recycle_bin_hdd_root_path=./recycle
+
+# HDD表数据文件路径
+# 配置数据目录，多个磁盘使用英文符号, 隔开
+--hdd_root_path=./db_hdd
+# 配置数据回收站目录，drop表的数据就会放在这里
+--recycle_bin_hdd_root_path=./recycle_hdd
+#
+# SSD表数据文件路径（可选，默认为空）
+# 配置数据目录，多个磁盘使用英文符号, 隔开
+#--ssd_root_path=./db_ssd
+# 配置数据回收站目录，drop表的数据就会放在这里
+#--recycle_bin_ssd_root_path=./recycle_ssd
 
 # snapshot conf
 # 每天23点做snapshot


### PR DESCRIPTION
create table failed with hdd storage mode as `hdd_root_path` is empty