### PR TITLE
fix: fix tablet coredump

### DIFF
--- a/src/catalog/distribute_iterator.cc
+++ b/src/catalog/distribute_iterator.cc
@@ -180,7 +180,7 @@ const ::hybridse::codec::Row& FullTableIterator::GetValue() {
     } else {
         auto slice_row = kv_it_->GetValue();
         size_t sz = slice_row.size();
-        int8_t* copyed_row_data = new int8_t[sz];
+        int8_t* copyed_row_data = reinterpret_cast<int8_t*>(malloc(sz));
         memcpy(copyed_row_data, slice_row.data(), sz);
         auto shared_slice = ::hybridse::base::RefCountedSlice::CreateManaged(copyed_row_data, sz);
         value_.Reset(shared_slice);
@@ -419,7 +419,7 @@ const ::hybridse::codec::Row& RemoteWindowIterator::GetValue() {
     size_t sz = slice_row.size();
     // for distributed environment, slice_row's data probably become invalid when the DistributeWindowIterator
     // iterator goes out of scope. so copy action occurred here
-    int8_t* copyed_row_data = new int8_t[sz];
+    int8_t* copyed_row_data = reinterpret_cast<int8_t*>(malloc(sz));
     memcpy(copyed_row_data, slice_row.data(), sz);
     auto shared_slice = ::hybridse::base::RefCountedSlice::CreateManaged(copyed_row_data, sz);
     row_.Reset(shared_slice);

--- a/src/storage/disk_table.cc
+++ b/src/storage/disk_table.cc
@@ -1040,7 +1040,7 @@ const ::hybridse::codec::Row& DiskTableRowIterator::GetValue() {
     }
     valid_value_ = true;
     size_t size = it_->value().size();
-    int8_t* copyed_row_data = new int8_t[size];
+    int8_t* copyed_row_data = reinterpret_cast<int8_t*>(malloc(size));
     memcpy(copyed_row_data, it_->value().data(), size);
     row_.Reset(::hybridse::base::RefCountedSlice::CreateManaged(copyed_row_data, size));
     return row_;

--- a/src/storage/disk_table.h
+++ b/src/storage/disk_table.h
@@ -290,6 +290,15 @@ class DiskTableRowIterator : public ::hybridse::vm::RowIterator {
     void SeekToFirst() override;
     inline bool IsSeekable() const override;
 
+   private:
+    inline void ResetValue() {
+        valid_value_ = false;
+    }
+
+    inline bool ValidValue() const {
+        return valid_value_;
+    }
+
  private:
     rocksdb::DB* db_;
     rocksdb::Iterator* it_;
@@ -303,6 +312,7 @@ class DiskTableRowIterator : public ::hybridse::vm::RowIterator {
     uint32_t ts_idx_;
     ::hybridse::codec::Row row_;
     bool pk_valid_;
+    bool valid_value_ = false;
 };
 
 class DiskTableKeyIterator : public ::hybridse::vm::WindowIterator {

--- a/src/storage/disk_table.h
+++ b/src/storage/disk_table.h
@@ -290,7 +290,7 @@ class DiskTableRowIterator : public ::hybridse::vm::RowIterator {
     void SeekToFirst() override;
     inline bool IsSeekable() const override;
 
-   private:
+ private:
     inline void ResetValue() {
         valid_value_ = false;
     }

--- a/src/tablet/tablet_impl.cc
+++ b/src/tablet/tablet_impl.cc
@@ -4222,8 +4222,8 @@ bool TabletImpl::UpdateAggrs(uint32_t tid, uint32_t pid, const std::string& valu
 void TabletImpl::ShowMemPool(RpcController* controller, const ::openmldb::api::HttpRequest* request,
                              ::openmldb::api::HttpResponse* response, Closure* done) {
     brpc::ClosureGuard done_guard(done);
-#ifdef TCMALLOC_ENABLE
     brpc::Controller* cntl = static_cast<brpc::Controller*>(controller);
+#ifdef TCMALLOC_ENABLE
     MallocExtension* tcmalloc = MallocExtension::instance();
     std::string stat;
     stat.resize(1024);
@@ -4232,6 +4232,8 @@ void TabletImpl::ShowMemPool(RpcController* controller, const ::openmldb::api::H
     cntl->response_attachment().append("<html><head><title>Mem Stat</title></head><body><pre>");
     cntl->response_attachment().append(stat);
     cntl->response_attachment().append("</pre></body></html>");
+#else
+    cntl->response_attachment().append("TCMALLOC_ENABLE is not defined\n");
 #endif
 }
 

--- a/src/tablet/tablet_impl.cc
+++ b/src/tablet/tablet_impl.cc
@@ -35,6 +35,7 @@
 #include "absl/cleanup/cleanup.h"
 #include "boost/bind.hpp"
 #include "boost/container/deque.hpp"
+#include "config.h" // NOLINT
 #ifdef TCMALLOC_ENABLE
 #include "gperftools/malloc_extension.h"
 #endif

--- a/src/tablet/tablet_impl_mem_test.cc
+++ b/src/tablet/tablet_impl_mem_test.cc
@@ -166,6 +166,18 @@ TEST_F(TabletImplMemTest, TestMem) {
 #endif
 }
 
+TEST_F(TabletImplMemTest, TestMemStat) {
+    auto tablet = std::make_unique<TabletImpl>();
+    tablet->Init("");
+    ::openmldb::api::HttpRequest request;
+    ::openmldb::api::HttpResponse response;
+    brpc::Controller cntl;
+    MockClosure closure;
+    tablet->ShowMemPool(&cntl, &request, &response, &closure);
+    auto str = cntl.response_attachment().to_string();
+    ASSERT_TRUE(str.find("Mem Stat") != std::string::npos);
+}
+
 }  // namespace tablet
 }  // namespace openmldb
 


### PR DESCRIPTION
- tablet core dump
![WX20221230-163951](https://user-images.githubusercontent.com/6183996/210315745-df29b988-3f15-4943-b2bf-06b20df05463.png)

the value of rocksdb iterator will invalid if call the next/seek/seektofirst
https://github.com/facebook/rocksdb/blob/main/include/rocksdb/iterator.h#L87-L89
- `ShowMemPool` does not print memory stat