### PR TITLE
fix: show components result is wrong

### DIFF
--- a/src/sdk/sql_cluster_router.cc
+++ b/src/sdk/sql_cluster_router.cc
@@ -3866,7 +3866,7 @@ std::shared_ptr<hybridse::sdk::ResultSet> SQLClusterRouter::ExecuteShowNameServe
             "nameserver",                   // role
             std::to_string(it->second),     // connect time
             "online",                       // status
-            it->first == leader ? "master" : "standby" // ns_role
+            it->first == leader ? "master" : "standby"  // ns_role
         };
         data.push_back(std::move(val));
     }


### PR DESCRIPTION
![WX20230103-162409](https://user-images.githubusercontent.com/6183996/211263806-7d8c7ea4-89aa-4728-82d7-b43ebbc9a94c.png)

reproduce steps:
- start OpenMLDB cluster with two or more nameserver
- restart nameserver leader
- execute `show components;` command