### PR TITLE
feat: add std built-in function

### DIFF
--- a/hybridse/src/udf/udaf_test.cc
+++ b/hybridse/src/udf/udaf_test.cc
@@ -264,30 +264,30 @@ TEST_F(UdafTest, AvgTest) {
     CheckUdf<Nullable<double>, ListRef<Nullable<double>>>("avg", nullptr, MakeList<Nullable<double>>({nullptr}));
 }
 
-TEST_F(UdafTest, StdTest) {
+TEST_F(UdafTest, StdPopTest) {
     double expected = 1.118034;
-    CheckUdf<double, ListRef<int16_t>>("std", expected, MakeList<int16_t>({1, 2, 3, 4}));
-    CheckUdf<double, ListRef<int32_t>>("std", expected, MakeList<int32_t>({1, 2, 3, 4}));
-    CheckUdf<double, ListRef<int64_t>>("std", expected, MakeList<int64_t>({1, 2, 3, 4}));
-    CheckUdf<double, ListRef<float>>("stddev", expected, MakeList<float>({1, 2, 3, 4}));
-    CheckUdf<double, ListRef<Nullable<double>>>("std", expected, MakeList<Nullable<double>>({1, 2, nullptr, 3, 4}));
+    CheckUdf<double, ListRef<int16_t>>("stddev_pop", expected, MakeList<int16_t>({1, 2, 3, 4}));
+    CheckUdf<double, ListRef<int32_t>>("stddev_pop", expected, MakeList<int32_t>({1, 2, 3, 4}));
+    CheckUdf<double, ListRef<int64_t>>("stddev_pop", expected, MakeList<int64_t>({1, 2, 3, 4}));
+    CheckUdf<double, ListRef<float>>("stddev_pop", expected, MakeList<float>({1, 2, 3, 4}));
+    CheckUdf<double, ListRef<Nullable<double>>>("stddev_pop", expected, MakeList<Nullable<double>>({1, 2, nullptr, 3, 4}));
     // nullable
-    CheckUdf<Nullable<double>, ListRef<double>>("std", nullptr, MakeList<double>({}));
-    CheckUdf<Nullable<double>, ListRef<Nullable<double>>>("std", nullptr, MakeList<Nullable<double>>({nullptr}));
+    CheckUdf<Nullable<double>, ListRef<double>>("stddev_pop", nullptr, MakeList<double>({}));
+    CheckUdf<Nullable<double>, ListRef<Nullable<double>>>("stddev_pop", nullptr, MakeList<Nullable<double>>({nullptr}));
 }
 
 TEST_F(UdafTest, StdSampTest) {
     double expected = 1.290994;
-    CheckUdf<double, ListRef<int16_t>>("std_samp", expected, MakeList<int16_t>({1, 2, 3, 4}));
-    CheckUdf<double, ListRef<int32_t>>("stddev_samp", expected, MakeList<int32_t>({1, 2, 3, 4}));
+    CheckUdf<double, ListRef<int16_t>>("std", expected, MakeList<int16_t>({1, 2, 3, 4}));
+    CheckUdf<double, ListRef<int32_t>>("stddev", expected, MakeList<int32_t>({1, 2, 3, 4}));
     CheckUdf<double, ListRef<int64_t>>("stddev_samp", expected, MakeList<int64_t>({1, 2, 3, 4}));
-    CheckUdf<double, ListRef<float>>("std_samp", expected, MakeList<float>({1, 2, 3, 4}));
-    CheckUdf<double, ListRef<Nullable<double>>>("std_samp", expected,
+    CheckUdf<double, ListRef<float>>("stddev_samp", expected, MakeList<float>({1, 2, 3, 4}));
+    CheckUdf<double, ListRef<Nullable<double>>>("stddev_samp", expected,
                                                 MakeList<Nullable<double>>({1, 2, nullptr, 3, 4}));
     // nullable
-    CheckUdf<Nullable<double>, ListRef<double>>("std_samp", nullptr, MakeList<double>({1}));
-    CheckUdf<Nullable<double>, ListRef<double>>("std_samp", nullptr, MakeList<double>({}));
-    CheckUdf<Nullable<double>, ListRef<Nullable<double>>>("std_samp", nullptr, MakeList<Nullable<double>>({nullptr}));
+    CheckUdf<Nullable<double>, ListRef<double>>("stddev_samp", nullptr, MakeList<double>({1}));
+    CheckUdf<Nullable<double>, ListRef<double>>("stddev_samp", nullptr, MakeList<double>({}));
+    CheckUdf<Nullable<double>, ListRef<Nullable<double>>>("stddev_samp", nullptr, MakeList<Nullable<double>>({nullptr}));
 }
 
 TEST_F(UdafTest, SumTest) {

--- a/hybridse/src/udf/udaf_test.cc
+++ b/hybridse/src/udf/udaf_test.cc
@@ -270,7 +270,8 @@ TEST_F(UdafTest, StdPopTest) {
     CheckUdf<double, ListRef<int32_t>>("stddev_pop", expected, MakeList<int32_t>({1, 2, 3, 4}));
     CheckUdf<double, ListRef<int64_t>>("stddev_pop", expected, MakeList<int64_t>({1, 2, 3, 4}));
     CheckUdf<double, ListRef<float>>("stddev_pop", expected, MakeList<float>({1, 2, 3, 4}));
-    CheckUdf<double, ListRef<Nullable<double>>>("stddev_pop", expected, MakeList<Nullable<double>>({1, 2, nullptr, 3, 4}));
+    CheckUdf<double, ListRef<Nullable<double>>>("stddev_pop", expected,
+                                                MakeList<Nullable<double>>({1, 2, nullptr, 3, 4}));
     // nullable
     CheckUdf<Nullable<double>, ListRef<double>>("stddev_pop", nullptr, MakeList<double>({}));
     CheckUdf<Nullable<double>, ListRef<Nullable<double>>>("stddev_pop", nullptr, MakeList<Nullable<double>>({nullptr}));
@@ -287,7 +288,8 @@ TEST_F(UdafTest, StdSampTest) {
     // nullable
     CheckUdf<Nullable<double>, ListRef<double>>("stddev_samp", nullptr, MakeList<double>({1}));
     CheckUdf<Nullable<double>, ListRef<double>>("stddev_samp", nullptr, MakeList<double>({}));
-    CheckUdf<Nullable<double>, ListRef<Nullable<double>>>("stddev_samp", nullptr, MakeList<Nullable<double>>({nullptr}));
+    CheckUdf<Nullable<double>, ListRef<Nullable<double>>>("stddev_samp", nullptr,
+                                                          MakeList<Nullable<double>>({nullptr}));
 }
 
 TEST_F(UdafTest, SumTest) {

--- a/hybridse/src/udf/udaf_test.cc
+++ b/hybridse/src/udf/udaf_test.cc
@@ -266,18 +266,28 @@ TEST_F(UdafTest, AvgTest) {
 
 TEST_F(UdafTest, StdTest) {
     double expected = 1.118034;
-    CheckUdf<double, ListRef<int16_t>>("std", expected,
-                                       MakeList<int16_t>({1, 2, 3, 4}));
-    CheckUdf<double, ListRef<int32_t>>("std", expected,
-                                       MakeList<int32_t>({1, 2, 3, 4}));
-    CheckUdf<double, ListRef<int64_t>>("std", expected,
-                                       MakeList<int64_t>({1, 2, 3, 4}));
-    CheckUdf<double, ListRef<float>>("std", expected, MakeList<float>({1, 2, 3, 4}));
-    CheckUdf<double, ListRef<Nullable<double>>>("std", expected,
-                                                MakeList<Nullable<double>>({1, 2, nullptr, 3, 4}));
+    CheckUdf<double, ListRef<int16_t>>("std", expected, MakeList<int16_t>({1, 2, 3, 4}));
+    CheckUdf<double, ListRef<int32_t>>("std", expected, MakeList<int32_t>({1, 2, 3, 4}));
+    CheckUdf<double, ListRef<int64_t>>("std", expected, MakeList<int64_t>({1, 2, 3, 4}));
+    CheckUdf<double, ListRef<float>>("stddev", expected, MakeList<float>({1, 2, 3, 4}));
+    CheckUdf<double, ListRef<Nullable<double>>>("std", expected, MakeList<Nullable<double>>({1, 2, nullptr, 3, 4}));
     // nullable
     CheckUdf<Nullable<double>, ListRef<double>>("std", nullptr, MakeList<double>({}));
     CheckUdf<Nullable<double>, ListRef<Nullable<double>>>("std", nullptr, MakeList<Nullable<double>>({nullptr}));
+}
+
+TEST_F(UdafTest, StdSampTest) {
+    double expected = 1.290994;
+    CheckUdf<double, ListRef<int16_t>>("std_samp", expected, MakeList<int16_t>({1, 2, 3, 4}));
+    CheckUdf<double, ListRef<int32_t>>("stddev_samp", expected, MakeList<int32_t>({1, 2, 3, 4}));
+    CheckUdf<double, ListRef<int64_t>>("stddev_samp", expected, MakeList<int64_t>({1, 2, 3, 4}));
+    CheckUdf<double, ListRef<float>>("std_samp", expected, MakeList<float>({1, 2, 3, 4}));
+    CheckUdf<double, ListRef<Nullable<double>>>("std_samp", expected,
+                                                MakeList<Nullable<double>>({1, 2, nullptr, 3, 4}));
+    // nullable
+    CheckUdf<Nullable<double>, ListRef<double>>("std_samp", nullptr, MakeList<double>({1}));
+    CheckUdf<Nullable<double>, ListRef<double>>("std_samp", nullptr, MakeList<double>({}));
+    CheckUdf<Nullable<double>, ListRef<Nullable<double>>>("std_samp", nullptr, MakeList<Nullable<double>>({nullptr}));
 }
 
 TEST_F(UdafTest, SumTest) {

--- a/hybridse/src/udf/udaf_test.cc
+++ b/hybridse/src/udf/udaf_test.cc
@@ -264,6 +264,22 @@ TEST_F(UdafTest, AvgTest) {
     CheckUdf<Nullable<double>, ListRef<Nullable<double>>>("avg", nullptr, MakeList<Nullable<double>>({nullptr}));
 }
 
+TEST_F(UdafTest, StdTest) {
+    double expected = 1.118034;
+    CheckUdf<double, ListRef<int16_t>>("std", expected,
+                                       MakeList<int16_t>({1, 2, 3, 4}));
+    CheckUdf<double, ListRef<int32_t>>("std", expected,
+                                       MakeList<int32_t>({1, 2, 3, 4}));
+    CheckUdf<double, ListRef<int64_t>>("std", expected,
+                                       MakeList<int64_t>({1, 2, 3, 4}));
+    CheckUdf<double, ListRef<float>>("std", expected, MakeList<float>({1, 2, 3, 4}));
+    CheckUdf<double, ListRef<Nullable<double>>>("std", expected,
+                                                MakeList<Nullable<double>>({1, 2, nullptr, 3, 4}));
+    // nullable
+    CheckUdf<Nullable<double>, ListRef<double>>("std", nullptr, MakeList<double>({}));
+    CheckUdf<Nullable<double>, ListRef<Nullable<double>>>("std", nullptr, MakeList<Nullable<double>>({nullptr}));
+}
+
 TEST_F(UdafTest, SumTest) {
     CheckUdf<int16_t, ListRef<int16_t>>("sum", 10,
                                        MakeList<int16_t>({1, 2, 3, 4}));


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes #1961


* **What is the current behavior?** (You can also link to an open issue here)
Support two versions of std functions:
- `std`/`stddev`/`stddev_samp`: sample standard devision 
![image](https://user-images.githubusercontent.com/7508922/218024751-c2deb67e-8d0f-4573-939b-281a4c94b0af.png)
- `stddev_pop`: population standard devision
![image](https://user-images.githubusercontent.com/7508922/218016551-0b475cf0-7feb-400b-8e2c-2584ab4f1bb7.png)

where `u` is the avg and `N` is the number of values. It has the same semantics as the SparkSQL (however different from MySQL)

* **What is the new behavior (if this is a feature change)?**

