### PR TITLE
feat: support `drawdown` built-in func

### DIFF
--- a/hybridse/src/udf/default_udf_library.cc
+++ b/hybridse/src/udf/default_udf_library.cc
@@ -2931,6 +2931,9 @@ void DefaultUdfLibrary::InitUdaf() {
             Drawdown is defined as the max decline percentage from a historical peak to a subsequent valley.
             It is commonly used as an indicator of risk in quant-trading to measure the max loss.
 
+            It requires that values are ordered so that it can only be used with WINDOW (PARTITION BY xx ORDER BY xx).
+            GROUP BY and full table aggregation are not supported.
+
             @param value  Specify value column to aggregate on.
 
             It requires that all values are non-negative. Negative values will be ignored.

--- a/hybridse/src/udf/default_udf_library.cc
+++ b/hybridse/src/udf/default_udf_library.cc
@@ -556,7 +556,7 @@ struct TopKDef {
 
 template <typename T>
 struct DrawdownUdafDef {
-    // <drawdown, current peak>
+    // <current drawdown, current min>
     using ContainerT = std::pair<double, T>;
     void operator()(UdafRegistryHelper& helper) {  // NOLINT
         std::string suffix = ".opaque_std_pair_double_" + DataTypeTrait<T>::to_string();

--- a/hybridse/src/udf/udaf_test.cc
+++ b/hybridse/src/udf/udaf_test.cc
@@ -992,7 +992,32 @@ TEST_F(UdafTest, TopNValueAvgCateWhereTest) {
                                MakeList<int32_t>({2, 2, 2, 2, 2, 2, 2}));
 }
 
+TEST_F(UdafTest, DrawdownTest) {
+    double expected = 0.75;
+    CheckUdf<double, ListRef<int16_t>>("drawdown", expected, MakeList<int16_t>({1, 8, 5, 2, 10, 4}));
+    CheckUdf<double, ListRef<int32_t>>("drawdown", expected, MakeList<int32_t>({1, 8, 5, 2, 10, 4}));
+    CheckUdf<double, ListRef<int64_t>>("drawdown", expected, MakeList<int64_t>({1, 8, 5, 2, 10, 4}));
+    CheckUdf<double, ListRef<float>>("drawdown", expected, MakeList<float>({1, 8, 5, 2, 10, 4}));
+    CheckUdf<double, ListRef<Nullable<double>>>("drawdown", expected,
+                                                MakeList<Nullable<double>>({1, 8, 5, 2, nullptr, 10, 4}));
 
+    CheckUdf<double, ListRef<Nullable<double>>>("drawdown", 0, MakeList<Nullable<double>>({1}));
+    CheckUdf<double, ListRef<Nullable<double>>>("drawdown", 0, MakeList<Nullable<double>>({1, 8}));
+    CheckUdf<double, ListRef<Nullable<double>>>("drawdown", 1, MakeList<Nullable<double>>({1, 0.0}));
+    CheckUdf<double, ListRef<Nullable<double>>>("drawdown", 0, MakeList<Nullable<double>>({0.0, 0.0}));
+    CheckUdf<double, ListRef<Nullable<double>>>("drawdown", 0, MakeList<Nullable<double>>({1, 1}));
+    CheckUdf<double, ListRef<Nullable<double>>>("drawdown", 1, MakeList<Nullable<double>>({10, 1, 0.0, 20, 20, 10}));
+    CheckUdf<double, ListRef<Nullable<double>>>("drawdown", 0.8, MakeList<Nullable<double>>({10, 4, 5, 20, 50, 10}));
+
+    // nullable
+    CheckUdf<Nullable<double>, ListRef<double>>("drawdown", nullptr, MakeList<double>({}));
+    CheckUdf<Nullable<double>, ListRef<Nullable<double>>>("drawdown", nullptr, MakeList<Nullable<double>>({nullptr}));
+
+    // negative value will be skipped
+    CheckUdf<double, ListRef<Nullable<double>>>("drawdown", 0.5, MakeList<Nullable<double>>({-1, 2, -2, 1}));
+    CheckUdf<Nullable<double>, ListRef<Nullable<double>>>("drawdown", nullptr,
+                                                          MakeList<Nullable<double>>({-1, -2, -1}));
+}
 
 }  // namespace udf
 }  // namespace hybridse

--- a/hybridse/src/udf/udaf_test.cc
+++ b/hybridse/src/udf/udaf_test.cc
@@ -994,27 +994,27 @@ TEST_F(UdafTest, TopNValueAvgCateWhereTest) {
 
 TEST_F(UdafTest, DrawdownTest) {
     double expected = 0.75;
-    CheckUdf<double, ListRef<int16_t>>("drawdown", expected, MakeList<int16_t>({1, 8, 5, 2, 10, 4}));
-    CheckUdf<double, ListRef<int32_t>>("drawdown", expected, MakeList<int32_t>({1, 8, 5, 2, 10, 4}));
-    CheckUdf<double, ListRef<int64_t>>("drawdown", expected, MakeList<int64_t>({1, 8, 5, 2, 10, 4}));
-    CheckUdf<double, ListRef<float>>("drawdown", expected, MakeList<float>({1, 8, 5, 2, 10, 4}));
+    CheckUdf<double, ListRef<int16_t>>("drawdown", expected, MakeList<int16_t>({4, 10, 2, 5, 8, 1}));
+    CheckUdf<double, ListRef<int32_t>>("drawdown", expected, MakeList<int32_t>({4, 10, 2, 5, 8, 1}));
+    CheckUdf<double, ListRef<int64_t>>("drawdown", expected, MakeList<int64_t>({4, 10, 2, 5, 8, 1}));
+    CheckUdf<double, ListRef<float>>("drawdown", expected, MakeList<float>({4, 10, 2, 5, 8, 1}));
     CheckUdf<double, ListRef<Nullable<double>>>("drawdown", expected,
-                                                MakeList<Nullable<double>>({1, 8, 5, 2, nullptr, 10, 4}));
+                                                MakeList<Nullable<double>>({4, 10, nullptr, 2, 5, 8, 1}));
 
     CheckUdf<double, ListRef<Nullable<double>>>("drawdown", 0, MakeList<Nullable<double>>({1}));
-    CheckUdf<double, ListRef<Nullable<double>>>("drawdown", 0, MakeList<Nullable<double>>({1, 8}));
-    CheckUdf<double, ListRef<Nullable<double>>>("drawdown", 1, MakeList<Nullable<double>>({1, 0.0}));
+    CheckUdf<double, ListRef<Nullable<double>>>("drawdown", 0, MakeList<Nullable<double>>({8, 1}));
+    CheckUdf<double, ListRef<Nullable<double>>>("drawdown", 1, MakeList<Nullable<double>>({0.0, 1}));
     CheckUdf<double, ListRef<Nullable<double>>>("drawdown", 0, MakeList<Nullable<double>>({0.0, 0.0}));
     CheckUdf<double, ListRef<Nullable<double>>>("drawdown", 0, MakeList<Nullable<double>>({1, 1}));
-    CheckUdf<double, ListRef<Nullable<double>>>("drawdown", 1, MakeList<Nullable<double>>({10, 1, 0.0, 20, 20, 10}));
-    CheckUdf<double, ListRef<Nullable<double>>>("drawdown", 0.8, MakeList<Nullable<double>>({10, 4, 5, 20, 50, 10}));
+    CheckUdf<double, ListRef<Nullable<double>>>("drawdown", 1, MakeList<Nullable<double>>({10, 20, 20, 0.0, 1, 10}));
+    CheckUdf<double, ListRef<Nullable<double>>>("drawdown", 0.8, MakeList<Nullable<double>>({10, 50, 20, 5, 4, 10}));
 
     // nullable
     CheckUdf<Nullable<double>, ListRef<double>>("drawdown", nullptr, MakeList<double>({}));
     CheckUdf<Nullable<double>, ListRef<Nullable<double>>>("drawdown", nullptr, MakeList<Nullable<double>>({nullptr}));
 
     // negative value will be skipped
-    CheckUdf<double, ListRef<Nullable<double>>>("drawdown", 0.5, MakeList<Nullable<double>>({-1, 2, -2, 1}));
+    CheckUdf<double, ListRef<Nullable<double>>>("drawdown", 0.5, MakeList<Nullable<double>>({1, -2, 2, -1}));
     CheckUdf<Nullable<double>, ListRef<Nullable<double>>>("drawdown", nullptr,
                                                           MakeList<Nullable<double>>({-1, -2, -1}));
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
```
Drawdown is defined as the max decline percentage from a historical peak to a subsequent valley.
It is commonly used as an indicator of risk in quant-trading to measure the max loss.
```


* **What is the current behavior?** (You can also link to an open issue here)

`drawdown=mdd(T)`

![image](https://user-images.githubusercontent.com/7508922/217991473-01e9dbc9-776e-419c-a6fc-3ebbc541d427.png)
![image](https://user-images.githubusercontent.com/7508922/217991428-66787a4f-de10-438b-bb56-3eb98a544b6a.png)
![image](https://user-images.githubusercontent.com/7508922/217991344-32ed14e9-c005-4455-b058-522ec0cbb68e.png)



* **What is the new behavior (if this is a feature change)?**

