### PR TITLE
feat: support ew_avg function

### DIFF
--- a/hybridse/src/udf/default_udf_library.cc
+++ b/hybridse/src/udf/default_udf_library.cc
@@ -2872,6 +2872,9 @@ void DefaultUdfLibrary::InitUdaf() {
             @brief Compute exponentially-weighted average of values.
             It's equivalent to pandas ewm(alpha=<alpha>, adjust=True, ignore_na=True, com=None, span=None, halflife=None, min_periods=0)
 
+            It requires that values are ordered so that it can only be used with WINDOW (PARTITION BY xx ORDER BY xx).
+            Undefined behaviour if it is used with GROUP BY and full table aggregation.
+
             @param value  Specify value column to aggregate on.
             @param alpha  Specify smoothing factor alpha (0 < alpha <= 1).
 

--- a/hybridse/src/udf/default_udf_library.cc
+++ b/hybridse/src/udf/default_udf_library.cc
@@ -344,6 +344,50 @@ struct StdSampUdafDef {
 };
 
 template <typename T>
+struct EwAvgUdafDef {
+    struct EwState {
+        double sum = 0;
+        double cnt = 0;
+        double weight = 1.0;
+        bool is_null = true;
+    };
+
+    using ContainerT = EwState;
+    void operator()(UdafRegistryHelper& helper) {  // NOLINT
+        std::string suffix = ".opaque_ewstate_" + DataTypeTrait<T>::to_string();
+        helper.templates<Nullable<double>, Opaque<ContainerT>, Nullable<T>, double>()
+            .init("ew_avg_init" + suffix, Init)
+            .update("ew_avg_update" + suffix, Update)
+            .output("ew_avg_output" + suffix, reinterpret_cast<void *>(Output), true);
+    }
+
+    static void Init(ContainerT* ptr) {
+        new (ptr) ContainerT();
+    }
+
+    // data is fed in the reverse order of timestamp. Newer data comes first
+    static ContainerT* Update(ContainerT* ptr, T t, bool is_null, double alpha) {
+        if (!is_null) {
+            ptr->sum += ptr->weight * t;
+            ptr->cnt += ptr->weight;
+            ptr->weight = ptr->weight * (1 - alpha);
+            ptr->is_null = false;
+        }
+        return ptr;
+    }
+
+    static void Output(ContainerT* ptr, double* ret, bool* is_null) {
+        if (ptr->is_null || ptr->cnt == 0) {
+            *is_null = true;
+        } else {
+            *ret = ptr->sum / ptr->cnt;
+            *is_null = false;
+        }
+        ptr->~ContainerT();
+    }
+};
+
+template <typename T>
 struct DistinctCountDef {
     using ArgT = typename DataTypeTrait<T>::CCallArgType;
     using SetT = std::unordered_set<T>;
@@ -2822,6 +2866,31 @@ void DefaultUdfLibrary::InitUdaf() {
         )")
         .args_in<bool, int16_t, int32_t, int64_t, float, double, Timestamp,
                  Date, StringRef>();
+
+    RegisterUdafTemplate<EwAvgUdafDef>("ew_avg")
+        .doc(R"(
+            @brief Compute exponentially-weighted average of values.
+            It's equivalent to pandas ewm(alpha=<alpha>, adjust=True, ignore_na=True, com=None, span=None, halflife=None, min_periods=0)
+
+            @param value  Specify value column to aggregate on.
+            @param alpha  Specify smoothing factor alpha (0 < alpha <= 1).
+
+            Example:
+
+            |value|
+            |--|
+            |0|
+            |1|
+            |2|
+            |3|
+            |4|
+            @code{.sql}
+                SELECT ew_avg(value, 0.5) OVER w;
+                -- output 3.161290
+            @endcode
+            @since 0.7.2
+        )")
+        .args_in<int16_t, int32_t, int64_t, float, double>();
 
     RegisterUdafTemplate<SumWhereDef>("sum_where")
         .doc(R"(

--- a/hybridse/src/udf/udaf_test.cc
+++ b/hybridse/src/udf/udaf_test.cc
@@ -292,6 +292,36 @@ TEST_F(UdafTest, StdSampTest) {
                                                           MakeList<Nullable<double>>({nullptr}));
 }
 
+TEST_F(UdafTest, EwAvgTest) {
+    double expect = 3.161290;
+    auto alpha_list = MakeList<double>({0.5, 0.5, 0.5, 0.5, 0.5, 0.5});
+    CheckUdf<double, ListRef<int16_t>, ListRef<double>>("ew_avg", expect, MakeList<int16_t>({4, 3, 2, 1, 0}),
+                                                        alpha_list);
+    CheckUdf<double, ListRef<Nullable<int32_t>>, ListRef<double>>(
+        "ew_avg", expect, MakeList<Nullable<int32_t>>({4, 3, 2, 1, 0}), alpha_list);
+    CheckUdf<double, ListRef<int64_t>, ListRef<double>>("ew_avg", expect, MakeList<int64_t>({4, 3, 2, 1, 0}),
+                                                        alpha_list);
+    CheckUdf<double, ListRef<float>, ListRef<double>>("ew_avg", expect, MakeList<float>({4, 3, 2, 1, 0}), alpha_list);
+    CheckUdf<double, ListRef<Nullable<double>>, ListRef<double>>(
+        "ew_avg", expect, MakeList<Nullable<double>>({4, 3, 2, nullptr, 1, 0.0}), alpha_list);
+
+    CheckUdf<double, ListRef<Nullable<double>>, ListRef<double>>(
+        "ew_avg", 1.733333, MakeList<Nullable<double>>({1, 2, 3, 4}), alpha_list);
+    CheckUdf<double, ListRef<Nullable<double>>, ListRef<double>>(
+        "ew_avg", 1, MakeList<Nullable<double>>({1}), alpha_list);
+    CheckUdf<double, ListRef<Nullable<double>>, ListRef<double>>(
+        "ew_avg", 0, MakeList<Nullable<double>>({0.0}), alpha_list);
+    CheckUdf<double, ListRef<Nullable<double>>, ListRef<double>>(
+        "ew_avg", 2.224932, MakeList<Nullable<double>>({1, 2, 3, 4}), MakeList<double>({0.2, 0.2, 0.2, 0.2}));
+    CheckUdf<double, ListRef<Nullable<double>>, ListRef<double>>(
+        "ew_avg", 4, MakeList<Nullable<double>>({4, 3, 2, 1}), MakeList<double>({1, 1, 1, 1}));
+
+    // nullable
+    CheckUdf<Nullable<double>, ListRef<double>, ListRef<double>>("ew_avg", nullptr, MakeList<double>({}), alpha_list);
+    CheckUdf<Nullable<double>, ListRef<Nullable<double>>, ListRef<double>>(
+        "ew_avg", nullptr, MakeList<Nullable<double>>({nullptr}), alpha_list);
+}
+
 TEST_F(UdafTest, SumTest) {
     CheckUdf<int16_t, ListRef<int16_t>>("sum", 10,
                                        MakeList<int16_t>({1, 2, 3, 4}));

--- a/hybridse/src/udf/udaf_test.cc
+++ b/hybridse/src/udf/udaf_test.cc
@@ -316,6 +316,13 @@ TEST_F(UdafTest, EwAvgTest) {
     CheckUdf<double, ListRef<Nullable<double>>, ListRef<double>>(
         "ew_avg", 4, MakeList<Nullable<double>>({4, 3, 2, 1}), MakeList<double>({1, 1, 1, 1}));
 
+    // NULL alpha will fall back to nornal avg
+    CheckUdf<double, ListRef<Nullable<double>>, ListRef<Nullable<double>>>(
+        "ew_avg", 2.5, MakeList<Nullable<double>>({4, 3, 2, 1}),
+        MakeList<Nullable<double>>({nullptr, nullptr, nullptr, nullptr}));
+    CheckUdf<double, ListRef<Nullable<double>>, ListRef<Nullable<double>>>(
+        "ew_avg", 2.5, MakeList<Nullable<double>>({4, 3, 2, 1}), MakeList<Nullable<double>>({0.0, 0.0, 0.0, 0.0}));
+
     // nullable
     CheckUdf<Nullable<double>, ListRef<double>, ListRef<double>>("ew_avg", nullptr, MakeList<double>({}), alpha_list);
     CheckUdf<Nullable<double>, ListRef<Nullable<double>>, ListRef<double>>(


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
fixes #3007 

`ew_avg` is the same as `EWMA` in pandas


* **What is the current behavior?** (You can also link to an open issue here)
It's equivalent to pandas `ewm(alpha=<alpha>, adjust=True, ignore_na=True, com=None, span=None, halflife=None, min_periods=0).mean()`
Ref:
https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.ewm.html


* **What is the new behavior (if this is a feature change)?**

