### PR TITLE
feat: support register table in spark and openmldb

### DIFF
--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/api/OpenmldbSession.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/api/OpenmldbSession.scala
@@ -226,6 +226,14 @@ class OpenmldbSession {
   }
 
   def registerTable(dbName: String, tableName: String, df: DataFrame): Unit = {
+    // Register in OpenMLDB session
+    registerTableInOpenmldbSession(dbName, tableName, df)
+
+    // Register in Spark catalog
+    df.createOrReplaceTempView(tableName)
+  }
+
+  def registerTableInOpenmldbSession(dbName: String, tableName: String, df: DataFrame): Unit = {
     if (!registeredTables.contains(dbName)) {
       registeredTables.put(dbName, new mutable.HashMap[String, DataFrame]())
     }

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/sparksql/TestRegisterTable.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/sparksql/TestRegisterTable.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 4Paradigm
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com._4paradigm.openmldb.batch.end2end.sparksql
+
+import com._4paradigm.openmldb.batch.SparkTestSuite
+import com._4paradigm.openmldb.batch.api.OpenmldbSession
+import com._4paradigm.openmldb.batch.end2end.DataUtil
+import com._4paradigm.openmldb.batch.utils.SparkUtil
+
+class TestRegisterTable extends SparkTestSuite {
+
+  test("Test register table for OpenMLDB session and Spark catalog") {
+    val spark = getSparkSession
+    val sess = new OpenmldbSession(spark)
+
+    val df = DataUtil.getTestDf(spark)
+    sess.registerTable("t1", df)
+
+    val sqlText = "select * from t1"
+    val sparksqlOutputDf = spark.sql(sqlText)
+    val outputDf = sess.sql(sqlText)
+    assert(SparkUtil.approximateDfEqual(outputDf.getSparkDf(), sparksqlOutputDf, false))
+  }
+
+}


### PR DESCRIPTION
* Resolve https://github.com/4paradigm/OpenMLDB/issues/1726 .

The Spark distribution need to be changed like this.

```
diff --git a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
index 0c5496bf9d..68c92302f3 100644
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -3273,9 +3273,6 @@ class Dataset[T] private[sql](
   @deprecated("Use createOrReplaceTempView(viewName) instead.", "2.0.0")
   def registerTempTable(tableName: String): Unit = {
     createOrReplaceTempView(tableName)
-
-    // Add by 4paradigm
-    sparkSession.openmldbSession.registerTable(tableName, this.asInstanceOf[DataFrame])
   }

   /**
@@ -3306,6 +3303,10 @@ class Dataset[T] private[sql](
    * @since 2.0.0
    */
   def createOrReplaceTempView(viewName: String): Unit = withPlan {
+    // Add by 4paradigm
+    //sparkSession.openmldbSession.registerTable(viewName, this.asInstanceOf[DataFrame])
+    sparkSession.openmldbSession.registerTableInOpenmldbSession(viewName, this.asInstanceOf[DataFrame])
+
     createTempViewCommand(viewName, replace = true, global = false)
   }
```