### PR TITLE
ci: rm curator in docker-compose.test.yml

### DIFF
--- a/demo/docker-compose.test.yml
+++ b/demo/docker-compose.test.yml
@@ -16,7 +16,7 @@ services:
       - /bin/bash
       - -cx
       - |
-        # rm /work/openmldb/spark-3.2.1-bin-openmldbspark/jars/curator-* # curator NoSuchMethodError error
+        rm -f /work/openmldb/spark-3.2.1-bin-openmldbspark/jars/curator-* # curator NoSuchMethodError error
         ./init.sh
         sleep 5
         # quickstart test


### PR DESCRIPTION
To avoid docker test failed in the beginning.