### PR TITLE
fix: rm curator when building docker

### DIFF
--- a/demo/setup_openmldb.sh
+++ b/demo/setup_openmldb.sh
@@ -50,6 +50,7 @@ tar xzf spark-3.2.1-bin-openmldbspark.tgz -C "${WORKDIR}/openmldb/spark-3.2.1-bi
 pushd "${WORKDIR}/openmldb"
 ln -s "${WORKDIR}/zookeeper-3.4.14" zookeeper
 ln -s spark-3.2.1-bin-openmldbspark spark
+rm -f spark-3.2.1-bin-openmldbspark/jars/curator-* # curator NoSuchMethodError error
 popd
 
 rm -f ./*.tar.gz


### PR DESCRIPTION
#3089 has removed `curator` in docker-compose. it also need to rm when building docker
<img width="755" alt="WX20230223-160406@2x" src="https://user-images.githubusercontent.com/6183996/220851814-16378a63-209a-4bd0-9538-473e2194e716.png">
