### PR TITLE
fix(#3087): correct schema for asterisk project over multiple join

### DIFF
--- a/cases/function/cluster/window_and_lastjoin.yaml
+++ b/cases/function/cluster/window_and_lastjoin.yaml
@@ -293,7 +293,7 @@ cases:
         window w4 as (PARTITION BY {0}.c4 ORDER BY {0}.c7 ROWS_RANGE BETWEEN 10d PRECEDING AND CURRENT ROW)
       ) as out4 on out1_id=out4_id;
     request_plan: |
-      SIMPLE_PROJECT(sources=(out1_id, c1, w1_sum_c6, out2_id, c2, w2_sum_c6, out3_id, c3, w3_sum_c6, out4.out4_id, out4.c4, out4.w4_sum_c6))
+      SIMPLE_PROJECT(sources=(out1.out1_id, out1.c1, out1.w1_sum_c6, out2.out2_id, out2.c2, out2.w2_sum_c6, out3.out3_id, out3.c3, out3.w3_sum_c6, out4.out4_id, out4.c4, out4.w4_sum_c6))
         REQUEST_JOIN(type=LastJoin, condition=, left_keys=(out1_id), right_keys=(out4_id), index_keys=)
           REQUEST_JOIN(type=LastJoin, condition=, left_keys=(out1_id), right_keys=(out3_id), index_keys=)
             REQUEST_JOIN(type=LastJoin, condition=, left_keys=(out1_id), right_keys=(out2_id), index_keys=)
@@ -319,7 +319,7 @@ cases:
                 DATA_PROVIDER(type=Partition, table=auto_t0, index=index4)
 
     cluster_request_plan: |
-      SIMPLE_PROJECT(sources=(out1_id, c1, w1_sum_c6, out2_id, c2, w2_sum_c6, out3_id, c3, w3_sum_c6, out4.out4_id, out4.c4, out4.w4_sum_c6))
+      SIMPLE_PROJECT(sources=(out1.out1_id, out1.c1, out1.w1_sum_c6, out2.out2_id, out2.c2, out2.w2_sum_c6, out3.out3_id, out3.c3, out3.w3_sum_c6, out4.out4_id, out4.c4, out4.w4_sum_c6))
         REQUEST_JOIN(type=LastJoin, condition=, left_keys=(out1_id), right_keys=(out4_id), index_keys=)
           REQUEST_JOIN(type=LastJoin, condition=, left_keys=(out1_id), right_keys=(out3_id), index_keys=)
             REQUEST_JOIN(type=LastJoin, condition=, left_keys=(out1_id), right_keys=(out2_id), index_keys=)

--- a/cases/query/simple_query.yaml
+++ b/cases/query/simple_query.yaml
@@ -958,3 +958,30 @@ cases:
       data: |
         1, 10, 1000
         2, 30, 2000
+
+  - id: 107
+    desc: |
+      select(t1.*) over last join (multiple input source)
+    inputs:
+      - name: t1
+        columns: ["id int32", "b int32", "ts int64"]
+        indexs: ["idx1:id:ts", "idx2:b:ts"]
+        data: |
+          1, 10, 1000
+          2, 30, 2000
+      - name: t2
+        columns: ["id int32", "b int32", "ts int64"]
+        indexs: ["idx1:id:ts", "idx2:b:ts"]
+        data: |
+          3, 10, 1000
+          4, 30, 2000
+    sql: |
+      select t1.* from t1
+      last join t2 on t1.b = t2.b
+      last join t2 as t3 on t1.b = t3.b
+    expect:
+      columns: ["id int32", "b int32", "ts int64"]
+      order: id
+      data: |
+        1, 10, 1000
+        2, 30, 2000

--- a/hybridse/src/vm/schemas_context.cc
+++ b/hybridse/src/vm/schemas_context.cc
@@ -168,7 +168,15 @@ void SchemasContext::Merge(size_t child_idx, const SchemasContext* child) {
         auto new_source = this->AddSource();
         new_source->SetSchema(source->GetSchema());
         // source can take the child name for detail showing
-        new_source->SetSourceDBAndTableName(child->GetDBName(), child->GetName());
+        std::string db_name = child->GetDBName();
+        if (db_name.empty() && !source->GetSourceDB().empty()) {
+            db_name = source->GetSourceDB();
+        }
+        std::string rel_name = child->GetName();
+        if (rel_name.empty()&& !source->GetSourceName().empty()) {
+            rel_name = source->GetSourceName();
+        }
+        new_source->SetSourceDBAndTableName(db_name, rel_name);
         for (size_t j = 0; j < source->size(); ++j) {
             // inherit child column id
             new_source->SetColumnID(j, source->GetColumnID(j));
@@ -185,7 +193,17 @@ void SchemasContext::MergeWithNewID(size_t child_idx,
         auto new_source = this->AddSource();
         new_source->SetSchema(source->GetSchema());
         // source can take the child name for detail showing
-        new_source->SetSourceDBAndTableName(child->GetDBName(), child->GetName());
+        // take the first one db/relation name from SchemasContext & SchemaSource,
+        // SchemasContext has higher priority
+        std::string db_name = child->GetDBName();
+        if (db_name.empty() && !source->GetSourceDB().empty()) {
+            db_name = source->GetSourceDB();
+        }
+        std::string rel_name = child->GetName();
+        if (rel_name.empty()&& !source->GetSourceName().empty()) {
+            rel_name = source->GetSourceName();
+        }
+        new_source->SetSourceDBAndTableName(db_name, rel_name);
         for (size_t j = 0; j < source->size(); ++j) {
             // use new column id but record source child column id
             new_source->SetColumnID(j, plan_ctx->GetNewColumnID());


### PR DESCRIPTION
close #3087 

`PhysicalOpJoinNode::InitSchema` not take table & db name if input source is JoinNode