### PR TITLE
feat: taskmanager kubernetes watch job status and support hadoop

### DIFF
--- a/java/openmldb-taskmanager/src/main/java/com/_4paradigm/openmldb/taskmanager/config/TaskManagerConfig.java
+++ b/java/openmldb-taskmanager/src/main/java/com/_4paradigm/openmldb/taskmanager/config/TaskManagerConfig.java
@@ -61,6 +61,7 @@ public class TaskManagerConfig {
     public static String NAMENODE_URI;
     public static String BATCHJOB_JAR_PATH;
     public static String HADOOP_CONF_DIR;
+    public static String HADOOP_USER_NAME;
     public static boolean ENABLE_HIVE_SUPPORT;
     public static long BATCH_JOB_RESULT_MAX_WAIT_TIME;
     public static String K8S_HADOOP_CONFIGMAP_NAME;
@@ -240,6 +241,8 @@ public class TaskManagerConfig {
                 throw new ConfigException("batchjob.jar.path", "config is null and fail to load default openmldb-batchjob jar");
             }
         }
+
+        HADOOP_USER_NAME = prop.getProperty("hadoop.user.name", "root");
 
         HADOOP_CONF_DIR = prop.getProperty("hadoop.conf.dir", "");
         if (isYarn && HADOOP_CONF_DIR.isEmpty()) {

--- a/java/openmldb-taskmanager/src/main/java/com/_4paradigm/openmldb/taskmanager/config/TaskManagerConfig.java
+++ b/java/openmldb-taskmanager/src/main/java/com/_4paradigm/openmldb/taskmanager/config/TaskManagerConfig.java
@@ -63,6 +63,8 @@ public class TaskManagerConfig {
     public static String HADOOP_CONF_DIR;
     public static boolean ENABLE_HIVE_SUPPORT;
     public static long BATCH_JOB_RESULT_MAX_WAIT_TIME;
+    public static String K8S_HADOOP_CONFIGMAP_NAME;
+    public static String K8S_MOUNT_LOCAL_PATH;
 
     private static volatile boolean isParsed = false;
 
@@ -256,6 +258,10 @@ public class TaskManagerConfig {
         ENABLE_HIVE_SUPPORT = Boolean.parseBoolean(prop.getProperty("enable.hive.support", "true"));
 
         BATCH_JOB_RESULT_MAX_WAIT_TIME = Long.parseLong(prop.getProperty("batch.job.result.max.wait.time", "600000")); // 10min
+
+        K8S_HADOOP_CONFIGMAP_NAME = prop.getProperty("k8s.hadoop.configmap", "hadoop-config");
+
+        K8S_MOUNT_LOCAL_PATH = prop.getProperty("k8s.mount.local.path", "/tmp");
     }
 
     public static boolean isK8s() throws ConfigException {

--- a/java/openmldb-taskmanager/src/main/java/com/_4paradigm/openmldb/taskmanager/server/impl/TaskManagerImpl.java
+++ b/java/openmldb-taskmanager/src/main/java/com/_4paradigm/openmldb/taskmanager/server/impl/TaskManagerImpl.java
@@ -353,8 +353,20 @@ public class TaskManagerImpl implements TaskManagerInterface {
     @Override
     public TaskManager.GetJobLogResponse GetJobLog(TaskManager.GetJobLogRequest request) {
         try {
-            String outLog = LogManager.getJobLog(request.getId());
-            String errorLog = LogManager.getJobErrorLog(request.getId());
+            String outLog = "";
+            try {
+                outLog = LogManager.getJobLog(request.getId());
+            } catch (Exception e) {
+                logger.warn(String.format("Fail to to get job log of job %s", request.getId()));
+            }
+
+            String errorLog = "";
+            try {
+                errorLog = LogManager.getJobErrorLog(request.getId());
+            } catch (Exception e) {
+                logger.warn(String.format("Fail to to get job error log of job %s", request.getId()));
+            }
+
             String log = String.format("Stdout:\n%s\n\nStderr:\n%s", outLog, errorLog);
             return TaskManager.GetJobLogResponse.newBuilder().setCode(StatusCode.SUCCESS).setLog(log).build();
         } catch (Exception e) {

--- a/java/openmldb-taskmanager/src/main/scala/com/_4paradigm/openmldb/taskmanager/k8s/K8sJobManager.scala
+++ b/java/openmldb-taskmanager/src/main/scala/com/_4paradigm/openmldb/taskmanager/k8s/K8sJobManager.scala
@@ -114,6 +114,13 @@ object K8sJobManager {
 
     // Update K8S job status
     manager.waitAndWatch(jobInfo: JobInfo)
+    
+    if (blocking) {
+      while (JobInfoManager.getJob(jobInfo.getId).get.isFinished) {
+        // TODO: Make this configurable
+        Thread.sleep(3000L)
+      }
+    }
 
     jobInfo
   }
@@ -298,9 +305,9 @@ class K8sJobManager(val namespace:String = "default",
           jobInfo.setEndTime(endTime)
 
           // TODO: Get error message to set
-
-          jobInfo.sync()
         }
+
+        jobInfo.sync()
 
       }
 

--- a/java/openmldb-taskmanager/src/main/scala/com/_4paradigm/openmldb/taskmanager/k8s/K8sJobManager.scala
+++ b/java/openmldb-taskmanager/src/main/scala/com/_4paradigm/openmldb/taskmanager/k8s/K8sJobManager.scala
@@ -33,7 +33,7 @@ object K8sJobManager {
   private val logger = LoggerFactory.getLogger(this.getClass)
 
   def getK8sJobName(jobId: Int): String = {
-    s"openmldb-job-tobe1-$jobId"
+    s"openmldb-job-$jobId"
   }
 
   def getDrvierPodName(jobId: Int): String = {
@@ -152,10 +152,13 @@ class K8sJobManager(val namespace:String = "default",
         |  restartPolicy:
         |    type: Never
         |  volumes:
-        |    - name: "host-local"
+        |    - name: host-local
         |      hostPath:
         |        path: ${jobConfig.mountLocalPath}
         |        type: Directory
+        |    - name: hadoop-config
+        |      configMap:
+        |        name: hadoop-config
         |  driver:
         |    cores: ${jobConfig.driverCores}
         |    memory: "${jobConfig.driverMemory}"
@@ -163,8 +166,13 @@ class K8sJobManager(val namespace:String = "default",
         |      version: 3.1.1
         |    serviceAccount: spark
         |    volumeMounts:
-        |      - name: "host-local"
+        |      - name: host-local
         |        mountPath: ${jobConfig.mountLocalPath}
+        |      - name: hadoop-config
+        |        mountPath: /etc/hadoop/conf
+        |    env:
+        |      - name: HADOOP_CONF_DIR
+        |        value: /etc/hadoop/conf
         |  executor:
         |    cores: ${jobConfig.executorCores}
         |    instances: ${jobConfig.executorNum}
@@ -172,8 +180,13 @@ class K8sJobManager(val namespace:String = "default",
         |    labels:
         |      version: 3.1.1
         |    volumeMounts:
-        |      - name: "host-local"
+        |      - name: host-local
         |        mountPath: ${jobConfig.mountLocalPath}
+        |      - name: hadoop-config
+        |        mountPath: /etc/hadoop/conf
+        |    env:
+        |      - name: HADOOP_CONF_DIR
+        |        value: /etc/hadoop/conf
       """.stripMargin
 
     // Create a CustomResourceDefinitionContext for the SparkApplication

--- a/java/openmldb-taskmanager/src/main/scala/com/_4paradigm/openmldb/taskmanager/k8s/K8sJobManager.scala
+++ b/java/openmldb-taskmanager/src/main/scala/com/_4paradigm/openmldb/taskmanager/k8s/K8sJobManager.scala
@@ -158,6 +158,9 @@ class K8sJobManager(val namespace:String = "default",
         |  sparkVersion: "3.1.1"
         |  restartPolicy:
         |    type: Never
+        |  env:
+        |    - name: SPARK_USER
+        |      value: ${TaskManagerConfig.HADOOP_USER_NAME}
         |  volumes:
         |    - name: host-local
         |      hostPath:


### PR DESCRIPTION
* Watch k8s job status and update internal table, support blocking mode
* Support hadoop config in kubernetes mode

Usage:

Create k8s hadoop configmap.

```
kubectl create configmap hadoop-config --from-file=/Users/tobe/software/2023_hadoop/hadoop-3.3.4/etc/hadoop_simple/
```

You can update the configmap by add config in taskmanager.properties.

```
k8s.hadoop.configmap=hadoop-config
```