### PR TITLE
feat(round): supports decimal place as second parameter

### DIFF
--- a/cases/function/function/test_calculate.yaml
+++ b/cases/function/function/test_calculate.yaml
@@ -142,7 +142,7 @@ cases:
          floor(c5) as r5 from {0};
     expect:
       order: id
-      columns: ["id int", "r0 bigint", "r1 bigint", "r2 bigint", "r3 double", "r4 double","r5 double"]
+      columns: ["id int", "r0 bigint", "r1 bigint", "r2 bigint", "r3 float", "r4 double","r5 double"]
       rows:
         - [1, 1, 2, 2, 1.000000, 0.000000,1.0]
         - [2, NULL, NULL, 2, NULL, NULL,0.0]

--- a/cases/integration_test/function/test_calculate.yaml
+++ b/cases/integration_test/function/test_calculate.yaml
@@ -142,7 +142,7 @@ cases:
          floor(c5) as r5 from {0};
     expect:
       order: id
-      columns: ["id int", "r0 bigint", "r1 bigint", "r2 bigint", "r3 double", "r4 double","r5 double"]
+      columns: ["id int", "r0 bigint", "r1 bigint", "r2 bigint", "r3 float", "r4 double","r5 double"]
       rows:
         - [1, 1, 2, 2, 1.000000, 0.000000,1.0]
         - [2, NULL, NULL, 2, NULL, NULL,0.0]

--- a/hybridse/src/codegen/udf_ir_builder_test.cc
+++ b/hybridse/src/codegen/udf_ir_builder_test.cc
@@ -609,12 +609,20 @@ TEST_F(UdfIRBuilderTest, PowerUdfTest) {
                                       2147483648, 65536);
 }
 
-TEST_F(UdfIRBuilderTest, RoundUdfTest) {
-    CheckUdf<int32_t, int16_t>("round", round(5), 5);
-    CheckUdf<int32_t, int32_t>("round", round(65536), 65536);
-    CheckUdf<int64_t, int64_t>("round", round(2147483648), 2147483648);
-    CheckUdf<double, float>("round", roundf(0.5f), 0.5f);
-    CheckUdf<double, double>("round", round(0.5), 0.5);
+TEST_F(UdfIRBuilderTest, RoundWithPositiveD) {
+    std::initializer_list<std::pair<double, std::string>> cases = {
+        // before decimal position = 0
+        {0.5, "0.50"}, {0.12, "0.12"}, {0.123, "0.12"}, {0.1478, "0.15"},
+        {0, "0.00"}, {0.012, "0.01"}, {0.0012, "0.00"}, {0.0078, "0.01"},
+        // before decimal position > 0
+        {1.1, "1.10" }, {1.14, "1.14"}, {1.177, "1.18"}, {1.171, "1.17"},
+        {21.1, "21.10" }, {21.14, "21.14"}, {21.177, "21.18"}, {21.171, "21.17"},
+        {1889, "1889.00"}
+    };
+
+    for (auto& val : cases) {
+        CheckUdf<StringRef, double, int32_t>("round", val.second, val.first, 2);
+    }
 }
 
 TEST_F(UdfIRBuilderTest, SinUdfTest) {

--- a/hybridse/src/udf/default_udf_library.cc
+++ b/hybridse/src/udf/default_udf_library.cc
@@ -1627,6 +1627,11 @@ void DefaultUdfLibrary::InitMathUdf() {
         .doc(R"(
             @brief Returns expr rounded to d decimal places using HALF_UP rounding mode.
 
+            @param numeric_expr Expression evaluated to double or can be casted to
+            @param d Integer decimal place
+
+            When `d` is a positive, `numeric_expr` is rounded to the number of decimal positions specified by `d`. When `d` is a negative , `numeric_expr` is rounded on the left side of the decimal point.
+
             Example:
 
             @code{.sql}
@@ -1639,9 +1644,6 @@ void DefaultUdfLibrary::InitMathUdf() {
                 SELECT round(123, -1)
                 -- 120
             @endcode
-
-            @param expr Expr evaluated to double or can be casted to
-            @param d Integer decimal place
 
             @since 0.1.0)")
         .args_in<int64_t, int16_t, int32_t>();

--- a/hybridse/src/udf/udf.h
+++ b/hybridse/src/udf/udf.h
@@ -18,6 +18,7 @@
 #define HYBRIDSE_SRC_UDF_UDF_H_
 #include <stdint.h>
 
+#include <iomanip>
 #include <string>
 #include <tuple>
 
@@ -218,16 +219,20 @@ struct Pow {
 
 template <class V>
 struct Round {
-    using Args = std::tuple<V>;
+    using Args = std::tuple<double, V>;
 
-    V operator()(V r) { return static_cast<V>(round(r)); }
-};
+    void operator()(double val, V decimal_number, StringRef *out) {
+        std::stringstream ss;
+        ss << std::setprecision(decimal_number) << val;
 
-template <class V>
-struct Round32 {
-    using Args = std::tuple<V>;
+        std::string str = ss.str();
+        auto sz = str.size();
+        char *buf = AllocManagedStringBuf(sz);
+        memcpy(buf, str.data(), sz);
 
-    int32_t operator()(V r) { return static_cast<int32_t>(round(r)); }
+        out->data_ = buf;
+        out->size_ = sz;
+    }
 };
 
 template <class V>

--- a/hybridse/src/udf/udf.h
+++ b/hybridse/src/udf/udf.h
@@ -223,7 +223,15 @@ struct Round {
 
     void operator()(double val, V decimal_number, StringRef *out) {
         std::stringstream ss;
-        ss << std::setprecision(decimal_number) << val;
+
+        if (decimal_number > 0) {
+            double integer = std::trunc(val);
+            double abs_left = std::abs(val - integer);
+            ss << integer << "." << std::setfill('0') << std::right << std::setw(decimal_number)
+               << std::round(abs_left * std::pow(10, decimal_number));
+        } else {
+            ss << std::round(val * std::pow(10, decimal_number)) / std::pow(10, decimal_number);
+        }
 
         std::string str = ss.str();
         auto sz = str.size();

--- a/hybridse/src/udf/udf.h
+++ b/hybridse/src/udf/udf.h
@@ -219,27 +219,20 @@ struct Pow {
 
 template <class V>
 struct Round {
-    using Args = std::tuple<double, V>;
+    using Args = std::tuple<V, int32_t>;
 
-    void operator()(double val, V decimal_number, StringRef *out) {
-        std::stringstream ss;
-
-        if (decimal_number > 0) {
-            double integer = std::trunc(val);
-            double abs_left = std::abs(val - integer);
-            ss << integer << "." << std::setfill('0') << std::right << std::setw(decimal_number)
-               << std::round(abs_left * std::pow(10, decimal_number));
+    V operator()(V val, int32_t decimal_number) {
+        if constexpr (std::is_integral_v<V>) {
+            if (decimal_number >= 0) {
+                return val;
+            } else {
+                double factor = std::pow(10, -decimal_number);
+                return static_cast<V>(std::round(val / factor) * factor);
+            }
         } else {
-            ss << std::round(val * std::pow(10, decimal_number)) / std::pow(10, decimal_number);
+            // floats
+            return static_cast<V>(std::round(val * std::pow(10, decimal_number)) / std::pow(10, decimal_number));
         }
-
-        std::string str = ss.str();
-        auto sz = str.size();
-        char *buf = AllocManagedStringBuf(sz);
-        memcpy(buf, str.data(), sz);
-
-        out->data_ = buf;
-        out->size_ = sz;
     }
 };
 

--- a/hybridse/src/udf/udf.h
+++ b/hybridse/src/udf/udf.h
@@ -18,7 +18,6 @@
 #define HYBRIDSE_SRC_UDF_UDF_H_
 #include <stdint.h>
 
-#include <iomanip>
 #include <string>
 #include <tuple>
 


### PR DESCRIPTION
Follows the defs in Transact-SQL or SparkSQL. 

KeyPoints
- decimal place can be positive, 0 or negative, indicating the position to decimal point (after, 0, before)
- return type is same as the first parameter. E.g `round(double, ..) -> double, round(int, ..) -> int`
- second parameter can be omitted, default to zero, for backwards compatibility
