### PR TITLE
feat: support symbolic paths

### DIFF
--- a/java/openmldb-batch/pom.xml
+++ b/java/openmldb-batch/pom.xml
@@ -433,7 +433,7 @@
                 </configuration>
             </plugin>
 
-            <!-- Generate report for spotbugs -->
+            <!-- Generate report for spotbugs
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
@@ -451,7 +451,7 @@
                     </execution>
                 </executions>
             </plugin>
-
+            -->
         </plugins>
 
         <pluginManagement>

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/api/OpenmldbSession.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/api/OpenmldbSession.scala
@@ -288,14 +288,16 @@ class OpenmldbSession {
           val path = offlineTableInfo.getPath
           val format = offlineTableInfo.getFormat
           val options = offlineTableInfo.getOptionsMap.asScala.toMap
+          val symbolicPathsSize = offlineTableInfo.getSymbolicPathsCount()
+          val symbolicPaths = offlineTableInfo.getSymbolicPathsList().asScala.toList
 
           // TODO: Ignore the register exception which occurs when switching local and yarn mode
           try {
             // default offlineTableInfo required members 'path' & 'format' won't be null
-            if (path != null && path.nonEmpty && format != null && format.nonEmpty) {
+            if ((path != null && path.nonEmpty) || symbolicPathsSize > 0) {
               // Has offline table meta, use the meta and table schema to read data
               // hive load will use sparksql
-              val df = autoLoad(this, path, format, options, tableInfo.getColumnDescList)
+              val df = autoLoad(this, path, symbolicPaths, format, options, tableInfo.getColumnDescList)
               registerTable(dbName, tableName, df)
             } else {
               // Register empty df for table

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/LoadDataPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/LoadDataPlan.scala
@@ -121,9 +121,9 @@ object LoadDataPlan {
         var (writePath, writeFormat) = (offlineDataPath, "parquet")
         var writeOptions: mutable.Map[String, String] = mutable.Map()
         if (info.hasOfflineTableInfo) {
-          require(mode != "errorifexists", "offline info exists")
-
-          if (mode.equals("append")) {
+          if (mode.equals("errorifexists")) {
+            throw new IllegalArgumentException("offline info exists")
+          } else if (mode.equals("append")) {
             throw new IllegalArgumentException("Deep copy with append mode is not supported yet")
           }
 

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/LoadDataPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/LoadDataPlan.scala
@@ -69,7 +69,7 @@ object LoadDataPlan {
       if (!deepCopy) {
 
         // Get error if exists
-        if (mode=="errorifexists" && info.hasOfflineTableInfo){
+        if (mode.equals("errorifexists") && info.hasOfflineTableInfo){
           throw new IllegalArgumentException("offline info exists")
         }
 
@@ -129,7 +129,7 @@ object LoadDataPlan {
 
           val old = info.getOfflineTableInfo
           if (!old.getDeepCopy) {
-            require(mode == "overwrite", "Only overwrite mode works. Old offline data is soft-coped, only can " +
+            require(mode.equals("overwrite"), "Only overwrite mode works. Old offline data is soft-coped, only can " +
               "overwrite the offline info, leave the soft-coped data as it is.")
             // if old offline data is soft-coped, we need to reject the old info, use the 'offlineDataPath' and
             // normal settings

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/utils/HybridseUtil.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/utils/HybridseUtil.scala
@@ -222,7 +222,7 @@ object HybridseUtil {
       case "error_if_exists" => "errorifexists"
       // append/overwrite, stay the same
       case "append" | "overwrite" => modeStr
-      case others: Any => throw new UnsupportedHybridSeException(s"unsupported write mode $others")
+      case _ => throw new UnsupportedHybridSeException(s"unsupported write mode $modeStr")
     }
 
     // only for PhysicalLoadDataNode

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/TestLoadDataPlan.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/TestLoadDataPlan.scala
@@ -37,8 +37,8 @@ class TestLoadDataPlan extends SparkTestSuite with Matchers {
     // load data needs openmldb cluster
     val prop = new Properties
     prop.load(getClass.getResourceAsStream("/test.properties"))
-    val cluster = prop.getProperty("openmldb.zk.cluster", "127.0.0.1:2181")
-    val path = prop.getProperty("openmldb.zk.root.path", "/openmldb")
+    val cluster = prop.getProperty("openmldb.zk.cluster", "127.0.0.1:6181")
+    val path = prop.getProperty("openmldb.zk.root.path", "/onebox")
     getSparkSession.conf.set("openmldb.zk.cluster", cluster)
     getSparkSession.conf.set("openmldb.zk.root.path", path)
     //      set("openmldb.loaddata.mode", "offline") // default is offline

--- a/src/cmd/display.h
+++ b/src/cmd/display.h
@@ -430,9 +430,9 @@ __attribute__((unused)) static void PrintOfflineTableInfo(
         std::ostream& stream) {
     ::hybridse::base::TextTable t('-', ' ', ' ');
 
-    t.add("Offline path");
+    t.add("Data path");
+    t.add("Symbolic paths");
     t.add("Format");
-    t.add("Deep copy");
     t.add("Options");
     t.end_of_row();
 
@@ -448,9 +448,19 @@ __attribute__((unused)) static void PrintOfflineTableInfo(
         }
     }
 
+    std::string offline_symbolic_paths = "";
+    auto symbolic_paths = offline_table_info.symbolic_paths();
+    int symbolic_paths_size = offline_table_info.symbolic_paths_size();
+    for (int i = 0; i < symbolic_paths_size; i++) {
+        offline_symbolic_paths += symbolic_paths.Get(i);
+        if (i != symbolic_paths_size - 1) {
+            offline_symbolic_paths += ", ";
+        }
+    }
+
     t.add(offline_table_info.path());
+    t.add(offline_symbolic_paths);
     t.add(offline_table_info.format());
-    t.add(offline_table_info.deep_copy() ? "true" : "false");
     t.add(optionStr);
     t.end_of_row();
 

--- a/src/proto/name_server.proto
+++ b/src/proto/name_server.proto
@@ -81,7 +81,7 @@ message UpdateTTLResponse {
 message OfflineTableInfo {
     required string path = 1;
     required string format = 2;
-    optional bool deep_copy = 3 [default = true];
+    optional bool deep_copy = 3 [default = true, deprecated = true];
     map<string, string> options = 4;
     repeated string symbolic_paths = 5;
 }

--- a/src/proto/name_server.proto
+++ b/src/proto/name_server.proto
@@ -83,6 +83,7 @@ message OfflineTableInfo {
     required string format = 2;
     optional bool deep_copy = 3 [default = true];
     map<string, string> options = 4;
+    repeated string symbolic_paths = 5;
 }
 
 message TableInfo {


### PR DESCRIPTION
* Support symbolic paths.
* Deprecated the deep_copy config.
* Show symbolic_path for `desc table`.

<img width="1792" alt="Screenshot 2023-04-26 at 17 11 46" src="https://user-images.githubusercontent.com/2715000/234549234-1b72eb6f-3155-40ed-bdc3-d035a87634f2.png">
