### PR TITLE
feat: add `skip_index_check` option

### DIFF
--- a/docs/en/reference/sql/deployment_manage/DEPLOY_STATEMENT.md
+++ b/docs/en/reference/sql/deployment_manage/DEPLOY_STATEMENT.md
@@ -97,12 +97,9 @@ DeployOption
 						::= 'OPTIONS' '(' DeployOptionItem (',' DeployOptionItem)* ')'
 
 DeployOptionItem
-						::= LongWindowOption
-
-LongWindowOption
-						::= 'LONG_WINDOWS' '=' LongWindowDefinitions
+            ::= 'LONG_WINDOWS' '=' LongWindowDefinitions
+            | 'SKIP_INDEX_CHECK' '=' string_literal
 ```
-Currently, only the optimization option of long windows `LONG_WINDOWS` is supported.
 
 #### Long Window Optimization
 ```sql
@@ -156,6 +153,16 @@ DEPLOY demo_deploy OPTIONS(long_windows="w1:1d") SELECT c1, sum(c2) OVER w1 FROM
 -- SUCCEED
 ```
 
+#### Skip Index Check
+
+By default, the value of `SKIP_INDEX_CHECK` option is `false`. It means that when deploying SQL, it will check whether the existing index
+is match the required index. An error will be reported if it does not matched. If this option is set to `true`, the existing index will not be verified and modified when deploying.
+
+**Example**
+```sql
+DEPLOY demo OPTIONS (SKIP_INDEX_CHECK="TRUE")
+    SELECT * FROM t1 LAST JOIN t2 ORDER BY t2.col3 ON t1.col1 = t2.col1;
+```
 
 ## Relevant SQL
 

--- a/docs/zh/openmldb_sql/deployment_manage/DEPLOY_STATEMENT.md
+++ b/docs/zh/openmldb_sql/deployment_manage/DEPLOY_STATEMENT.md
@@ -97,12 +97,9 @@ DeployOption
 						::= 'OPTIONS' '(' DeployOptionItem (',' DeployOptionItem)* ')'
 
 DeployOptionItem
-						::= LongWindowOption
-
-LongWindowOption
-						::= 'LONG_WINDOWS' '=' LongWindowDefinitions
+            ::= 'LONG_WINDOWS' '=' LongWindowDefinitions
+            | 'SKIP_INDEX_CHECK' '=' string_literal
 ```
-目前只支持长窗口`LONG_WINDOWS`的优化选项。
 
 #### 长窗口优化
 ```sql
@@ -152,6 +149,15 @@ interval_literal ::= int_literal 's'|'m'|'h'|'d'
 DEPLOY demo_deploy OPTIONS(long_windows="w1:1d") SELECT c1, sum(c2) OVER w1 FROM demo_table1
     WINDOW w1 AS (PARTITION BY c1 ORDER BY c2 ROWS_RANGE BETWEEN 5d PRECEDING AND CURRENT ROW);
 -- SUCCEED
+```
+
+#### 关闭索引类型校验
+默认情况下`SKIP_INDEX_CHECK`选项为`false`, 即deploy SQL时会校验现有的索引和期望的索引类型是否一致，如果不一致会报错。如果这个选项设置为`true`, deploy的时候对已有索引不会校验已有索引，也不会修改已有索引的TTL。
+
+**Example**
+```sql
+DEPLOY demo OPTIONS (SKIP_INDEX_CHECK="TRUE")
+    SELECT * FROM t1 LAST JOIN t2 ORDER BY t2.col3 ON t1.col1 = t2.col1;
 ```
 
 ## 相关SQL

--- a/src/cmd/sql_cmd_test.cc
+++ b/src/cmd/sql_cmd_test.cc
@@ -794,6 +794,51 @@ TEST_P(DBSDKTest, DeployCol) {
     ASSERT_TRUE(cs->GetNsClient()->DropDatabase("test2", msg));
 }
 
+TEST_P(DBSDKTest, DeploySkipIndexCheck) {
+    auto cli = GetParam();
+    cs = cli->cs;
+    sr = cli->sr;
+    std::string ddl1 =
+        "create table if not exists t1 (col1 string, col2 string, col3 bigint, "
+        "index(key=col1, ts=col3, TTL_TYPE=absolute));";
+    std::string ddl2 =
+        "create table if not exists t2 (col1 string, col2 string, col3 bigint, "
+        "index(key=col1, ts=col3, TTL_TYPE=absolute));";
+    ProcessSQLs(sr, {
+                        "set @@execute_mode = 'online';",
+                        "create database test2;",
+                        "use test2;",
+                        ddl1,
+                        ddl2,
+                    });
+    std::string deploy_sql = "deploy demo SELECT * FROM t1 LAST JOIN t2 ORDER BY t2.col3 ON t1.col1 = t2.col1;";
+    hybridse::sdk::Status status;
+    sr->ExecuteSQL(deploy_sql, &status);
+    ASSERT_FALSE(status.IsOK());
+   deploy_sql = "deploy demo  OPTIONS (skip_index_check=\"false\") "
+        "SELECT * FROM t1 LAST JOIN t2 ORDER BY t2.col3 ON t1.col1 = t2.col1;";
+    sr->ExecuteSQL(deploy_sql, &status);
+    ASSERT_FALSE(status.IsOK());
+    deploy_sql = "deploy demo  OPTIONS (skip_index_check=\"false\") "
+        "SELECT * FROM t1 LAST JOIN t2 ORDER BY t2.col3 ON t1.col1 = t2.col1;";
+    sr->ExecuteSQL(deploy_sql, &status);
+    ASSERT_FALSE(status.IsOK());
+    deploy_sql = "deploy demo  OPTIONS (skip_index_check=\"true\") "
+        "SELECT * FROM t1 LAST JOIN t2 ORDER BY t2.col3 ON t1.col1 = t2.col1;";
+    sr->ExecuteSQL(deploy_sql, &status);
+    ASSERT_TRUE(status.IsOK()) << status.msg;
+    std::string msg;
+    ASSERT_TRUE(cs->GetNsClient()->DropProcedure("test2", "demo", msg));
+    deploy_sql = "deploy demo  OPTIONS (SKIP_INDEX_CHECK=\"TRUE\") "
+        "SELECT * FROM t1 LAST JOIN t2 ORDER BY t2.col3 ON t1.col1 = t2.col1;";
+    sr->ExecuteSQL(deploy_sql, &status);
+    ASSERT_TRUE(status.IsOK());
+    ASSERT_TRUE(cs->GetNsClient()->DropProcedure("test2", "demo", msg));
+    ASSERT_TRUE(cs->GetNsClient()->DropTable("test2", "t1", msg));
+    ASSERT_TRUE(cs->GetNsClient()->DropTable("test2", "t2", msg));
+    ASSERT_TRUE(cs->GetNsClient()->DropDatabase("test2", msg));
+}
+
 TEST_P(DBSDKTest, Delete) {
     auto cli = GetParam();
     sr = cli->sr;

--- a/src/cmd/sql_cmd_test.cc
+++ b/src/cmd/sql_cmd_test.cc
@@ -815,7 +815,7 @@ TEST_P(DBSDKTest, DeploySkipIndexCheck) {
     hybridse::sdk::Status status;
     sr->ExecuteSQL(deploy_sql, &status);
     ASSERT_FALSE(status.IsOK());
-   deploy_sql = "deploy demo  OPTIONS (skip_index_check=\"false\") "
+    deploy_sql = "deploy demo  OPTIONS (skip_index_check=\"false\") "
         "SELECT * FROM t1 LAST JOIN t2 ORDER BY t2.col3 ON t1.col1 = t2.col1;";
     sr->ExecuteSQL(deploy_sql, &status);
     ASSERT_FALSE(status.IsOK());

--- a/src/sdk/sql_cluster_router.h
+++ b/src/sdk/sql_cluster_router.h
@@ -334,11 +334,13 @@ class SQLClusterRouter : public SQLRouter {
 
     hybridse::sdk::Status HandleIndex(const std::string& db,
                                       const std::set<std::pair<std::string, std::string>>& table_pair,
-                                      const std::string& select_sql);
+                                      const std::string& select_sql,
+                                      const hybridse::node::DeployPlanNode* deploy_node);
 
     hybridse::sdk::Status GetNewIndex(
         const std::map<std::string, ::openmldb::nameserver::TableInfo>& table_map,
         const std::map<std::string, std::vector<::openmldb::common::ColumnKey>>& index_map,
+        bool skip_index_check,
         std::map<std::string, std::vector<::openmldb::common::ColumnKey>>* new_index_map);
 
     hybridse::sdk::Status AddNewIndex(


### PR DESCRIPTION
if we deploy a SQL contains `LAST JOIN`, `kLatestTime` index is required. if there is another index type like `kAbsoluteTIme`, it will deploy failed. So we add `skip_index_check` option to skip index checking