### PR TITLE
fix(#3023): query expr `at(list, numeric)` as non-window function

### DIFF
--- a/cases/function/function/test_udaf_function.yaml
+++ b/cases/function/function/test_udaf_function.yaml
@@ -2689,12 +2689,15 @@ cases:
       select
         idx,
         `join`(split_by_key(count_cate(idx, val) over w, ",", ":"), "-") as ref,
-        at(split_by_key(count_cate(idx, val) over w, ",", ":"), 1) as out
+        at(split_by_key(count_cate(idx, val) over w, ",", ":"), 1) as out,
+        at(split_by_key(count_cate(idx, val) over w2, ",", ":"), 1) as out2
       from t1
       window w as (
         partition by gp order by ts
-        rows_range between 10s preceding and current row
-      )
+        rows_range between 10s preceding and current row),
+      w2 as (
+        partition by gp order by ts
+        rows_range between 10s preceding and 1s preceding)
     inputs:
       - name: t1
         columns: ["idx int", "gp int", "val int", "ts timestamp"]
@@ -2709,9 +2712,10 @@ cases:
         - idx int
         - ref string
         - out string
+        - out2 string
       order: idx
       data: |
-        100, 1, NULL
-        200, 1-2, 2
-        300, 1-2, 2
-        400, 1-2, 2
+        100, 1, NULL, NULL
+        200, 1-2, 2,  NULL
+        300, 1-2, 2,  2
+        400, 1-2, 2,  2

--- a/cases/function/function/test_udaf_function.yaml
+++ b/cases/function/function/test_udaf_function.yaml
@@ -2683,3 +2683,35 @@ cases:
         6, g2, NULL, NULL, 9.0,  B,    2,    7.0,  1590738990003
         7, g2, NULL, 2,    9.0,  A,    2,    7.0,  1590738990003
         8, g2, NULL, NULL, 9.0,  C,    2,    7.0,  1590738990003
+
+  - id: 65
+    sql: |
+      select
+        idx,
+        `join`(split_by_key(count_cate(idx, val) over w, ",", ":"), "-") as ref,
+        at(split_by_key(count_cate(idx, val) over w, ",", ":"), 1) as out
+      from t1
+      window w as (
+        partition by gp order by ts
+        rows_range between 10s preceding and current row
+      )
+    inputs:
+      - name: t1
+        columns: ["idx int", "gp int", "val int", "ts timestamp"]
+        indexs: ['idx:gp:ts']
+        data: |
+          100, 1, 1, 1000
+          200, 1, 2, 2000
+          300, 1, 1, 3000
+          400, 1, 2, 4000
+    expect:
+      columns:
+        - idx int
+        - ref string
+        - out string
+      order: idx
+      data: |
+        100, 1, NULL
+        200, 1-2, 2
+        300, 1-2, 2
+        400, 1-2, 2

--- a/cases/function/function/test_udf_function.yaml
+++ b/cases/function/function/test_udf_function.yaml
@@ -343,3 +343,29 @@ cases:
         - dis5 double
       data: |
         1, 139.72810080682342, 139.72810080682342, 139.72810080682342, 139.72810080682342, 139.72810080682342
+
+  - id: 7
+    desc: udf at
+    inputs:
+      - name: t1
+        columns: ["idx int", "gp int", "val string", "ts timestamp"]
+        indexs: ['idx:gp:ts']
+        rows:
+          - [100, 1, "7,8,9", 1000]
+    sql: |
+      select idx,
+        at(split(val, ","), 0) as s0,
+        at(split(val, ","), 1) as s1,
+        at(split(val, ","), 2) as s2,
+        at(split(val, ","), 3) as s3
+      from t1
+    expect:
+      order: id
+      columns:
+        - idx int
+        - s0 string
+        - s1 string
+        - s2 string
+        - s3 string
+      data: |
+        100, 7, 8, 9, NULL

--- a/hybridse/include/codec/list_iterator_codec.h
+++ b/hybridse/include/codec/list_iterator_codec.h
@@ -100,7 +100,13 @@ class ColumnImpl : public WrapListImpl<V, Row> {
         return new ColumnIterator<V>(root_, this);
     }
     const uint64_t GetCount() override { return root_->GetCount(); }
-    V At(uint64_t pos) override { return GetFieldUnsafe(root_->At(pos)); }
+    std::optional<V> At(uint64_t pos) override {
+        auto row = root_->At(pos);
+        if (row.empty()) {
+            return std::nullopt;
+        }
+        return GetFieldUnsafe(row);
+    }
 
     ListV<Row> *root() const override { return root_; }
 

--- a/hybridse/src/node/sql_node.cc
+++ b/hybridse/src/node/sql_node.cc
@@ -1293,8 +1293,7 @@ bool IsAggregationExpression(const udf::UdfLibrary *lib, const ExprNode *node_pt
 
 bool WindowOfExpression(const std::map<std::string, const WindowDefNode *> &windows, ExprNode *node_ptr,
                         const WindowDefNode **output) {
-    // try to resolved window ptr from expression like: call(args...) over
-    // window
+    // try to resolved window ptr from expression like: call(args...) over window
     if (kExprCall == node_ptr->GetExprType()) {
         CallExprNode *func_node_ptr = dynamic_cast<CallExprNode *>(node_ptr);
         if (nullptr != func_node_ptr->GetOver()) {

--- a/hybridse/src/udf/default_defs/feature_zero_def.cc
+++ b/hybridse/src/udf/default_defs/feature_zero_def.cc
@@ -56,7 +56,12 @@ class MutableStringListV : public codec::ListV<StringRef> {
 
     const uint64_t GetCount() override { return buffer_.size(); }
 
-    StringRef At(uint64_t pos) override { return StringRef(buffer_[pos]); }
+    codec::AtOut<StringRef>::T At(uint64_t pos) override {
+        if (pos >= buffer_.size()) {
+            return codec::AtOut<codec::StringRef>::Null();
+        }
+        return StringRef(buffer_.at(pos));
+    }
 
     void Add(const std::string& str) {
         if (total_len_ + str.size() > MAXIMUM_STRING_LENGTH) {

--- a/hybridse/src/udf/default_defs/window_functions_def.cc
+++ b/hybridse/src/udf/default_defs/window_functions_def.cc
@@ -42,7 +42,7 @@ void AtList(::hybridse::codec::ListRef<V>* list_ref, int64_t pos, V* v, bool* is
         *v = static_cast<V>(DataTypeTrait<V>::zero_value());
         return;
     }
-    auto list = reinterpret_cast<codec::ListV<V>*>(list_ref->list);
+    codec::ListV<V>* list = reinterpret_cast<codec::ListV<V>*>(list_ref->list);
     auto column = dynamic_cast<codec::WrapListImpl<V, codec::Row>*>(list);
     if (column != nullptr) {
         auto row = column->root()->At(pos);
@@ -53,8 +53,9 @@ void AtList(::hybridse::codec::ListRef<V>* list_ref, int64_t pos, V* v, bool* is
             column->GetField(row, v, is_null);
         }
     } else {
-        *is_null = false;
-        *v = list->At(pos);
+        auto out = list->At(pos);
+        *is_null = codec::AtOut<V>::IsNull(out);
+        *v = codec::AtOut<V>::Value(out);
     }
 }
 


### PR DESCRIPTION
FIX support of `at` as non-window function. 

distinct `at` & `lag`. Key difference:
- `lag` & `lead` is window functions, and should only used with a window
- `at` can be used else where too, like `at(split_by_key(col, ",", ":"), 1)`, a udf function

The rules is not enforced in this PR, should be backward-compatible. So it may work like `lag(split(col, ','), 1)`, but is generally not recommended.  **Breaking changes** may introduce later, see https://github.com/4paradigm/OpenMLDB/issues/3023#issuecomment-1568568980. 