### PR TITLE
fix: refresh table info after zk updated

### DIFF
--- a/src/cmd/sql_cmd_test.cc
+++ b/src/cmd/sql_cmd_test.cc
@@ -3826,6 +3826,7 @@ int main(int argc, char** argv) {
     ::openmldb::sdk::ClusterOptions copt;
     copt.zk_cluster = mc.GetZkCluster();
     copt.zk_path = mc.GetZkPath();
+    copt.zk_session_timeout = FLAGS_zk_session_timeout;
     ::openmldb::cmd::cluster_cli.cs = new ::openmldb::sdk::ClusterSDK(copt);
     ::openmldb::cmd::cluster_cli.cs->Init();
     ::openmldb::cmd::cluster_cli.sr = new ::openmldb::sdk::SQLClusterRouter(::openmldb::cmd::cluster_cli.cs);

--- a/src/cmd/sql_cmd_test.cc
+++ b/src/cmd/sql_cmd_test.cc
@@ -363,8 +363,6 @@ TEST_F(SqlCmdTest, SelectMultiPartition) {
 }
 
 TEST_F(SqlCmdTest, ShowNameserverJob) {
-    // timeout larger for workflow
-    FLAGS_request_timeout_ms=40000;
     auto sr = cluster_cli.sr;
     std::string db_name = "test" + GenRand();
     std::string name = "table" + GenRand();

--- a/src/cmd/sql_cmd_test.cc
+++ b/src/cmd/sql_cmd_test.cc
@@ -363,6 +363,8 @@ TEST_F(SqlCmdTest, SelectMultiPartition) {
 }
 
 TEST_F(SqlCmdTest, ShowNameserverJob) {
+    // timeout larger for workflow
+    FLAGS_request_timeout_ms=40000;
     auto sr = cluster_cli.sr;
     std::string db_name = "test" + GenRand();
     std::string name = "table" + GenRand();

--- a/src/cmd/sql_cmd_test.cc
+++ b/src/cmd/sql_cmd_test.cc
@@ -363,7 +363,7 @@ TEST_F(SqlCmdTest, SelectMultiPartition) {
 }
 
 TEST_F(SqlCmdTest, ShowNameserverJob) {
-    auto sr = cluster_cli.sr;
+    sr = cluster_cli.sr;
     std::string db_name = "test" + GenRand();
     std::string name = "table" + GenRand();
     std::string ddl = "create table " + name +

--- a/src/nameserver/name_server_impl.cc
+++ b/src/nameserver/name_server_impl.cc
@@ -17,15 +17,16 @@
 #include "nameserver/name_server_impl.h"
 
 #include <algorithm>
-#include <iostream>
-#include <iterator>
-#include <random>
 #include <set>
+#include <random>
+#include <iterator>
+#include <iostream>
 #include <vector>
 
-#include "absl/strings/numbers.h"
+
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"
+#include "absl/strings/numbers.h"
 #include "absl/time/time.h"
 #include "nameserver/system_table.h"
 #include "sdk/db_sdk.h"
@@ -43,10 +44,10 @@
 #include "base/strings.h"
 #include "boost/algorithm/string.hpp"
 #include "boost/bind.hpp"
-#include "codec/row_codec.h"
 #include "gflags/gflags.h"
 #include "schema/index_util.h"
 #include "schema/schema_adapter.h"
+#include "codec/row_codec.h"
 
 DECLARE_string(endpoint);
 DECLARE_string(zk_cluster);
@@ -73,6 +74,7 @@ DECLARE_int32(make_snapshot_check_interval);
 DECLARE_bool(use_name);
 DECLARE_bool(enable_distsql);
 DECLARE_uint32(sync_deploy_stats_timeout);
+
 
 namespace openmldb {
 namespace nameserver {
@@ -1028,8 +1030,8 @@ int NameServerImpl::CreateMakeSnapshotOPTask(std::shared_ptr<OPData> op_data) {
     if (request.has_offset() && request.offset() > 0) {
         end_offset = request.offset();
     }
-    auto task = CreateTask<MakeSnapshotTaskMeta>(op_data->op_info_.op_id(), ::openmldb::api::OPType::kMakeSnapshotOP,
-                                                 endpoint, tid, pid, end_offset);
+    auto task = CreateTask<MakeSnapshotTaskMeta>(op_data->op_info_.op_id(),
+            ::openmldb::api::OPType::kMakeSnapshotOP, endpoint, tid, pid, end_offset);
     if (!task) {
         PDLOG(WARNING, "create makesnapshot task failed. tid[%u] pid[%u]", tid, pid);
         return -1;
@@ -1117,6 +1119,8 @@ void NameServerImpl::UpdateTablets(const std::vector<std::string>& endpoints) {
             real_ep_map_.emplace(cur_endpoint, cur_endpoint);
         }
     }
+
+
 
     auto it = tablet_endpoints.begin();
     for (; it != tablet_endpoints.end(); ++it) {
@@ -1524,8 +1528,7 @@ int NameServerImpl::UpdateTaskStatus(bool is_recover_op) {
                         continue;
                     }
                     if (task->task_info_->has_endpoint() && task->task_info_->endpoint() == iter->first) {
-                        PDLOG(WARNING,
-                              "tablet is offline. update task status from[kDoing] to[kFailed]. "
+                        PDLOG(WARNING, "tablet is offline. update task status from[kDoing] to[kFailed]. "
                               "op_id[%lu], task_type[%s] endpoint[%s]",
                               op_data->op_info_.op_id(),
                               ::openmldb::api::TaskType_Name(task->task_info_->task_type()).c_str(),
@@ -1578,7 +1581,7 @@ int NameServerImpl::UpdateTaskStatusRemote(bool is_recover_op) {
                 continue;
             }
             client_map.emplace(iter->first,
-                               std::atomic_load_explicit(&iter->second->client_, std::memory_order_relaxed));
+                    std::atomic_load_explicit(&iter->second->client_, std::memory_order_relaxed));
         }
     }
     uint64_t last_task_rpc_version = task_rpc_version_.load(std::memory_order_acquire);
@@ -1651,8 +1654,9 @@ int NameServerImpl::UpdateZKTaskStatus() {
             }
             // revert task index
             op_data->op_info_.set_task_index(cur_task_index);
-            PDLOG(WARNING, "set zk status value failed! node[%s] op_id[%lu] op_type[%s] task_index[%u]", node.c_str(),
-                  op_data->GetOpId(), op_data->GetReadableType().c_str(), op_data->op_info_.task_index());
+            PDLOG(WARNING, "set zk status value failed! node[%s] op_id[%lu] op_type[%s] task_index[%u]",
+                    node.c_str(), op_data->GetOpId(), op_data->GetReadableType().c_str(),
+                    op_data->op_info_.task_index());
         }
     }
     return 0;
@@ -1673,10 +1677,10 @@ void NameServerImpl::UpdateTaskMapStatus(uint64_t remote_op_id, uint64_t op_id,
                     task_info->set_status(status);
                     if (status == ::openmldb::api::kFailed) {
                         DEBUGLOG("update task status from[kDoing] to[kFailed]. op_id[%lu], task_type[%s]",
-                                 task_info->op_id(), ::openmldb::api::TaskType_Name(task_info->task_type()).c_str());
+                            task_info->op_id(), ::openmldb::api::TaskType_Name(task_info->task_type()).c_str());
                     } else {
                         DEBUGLOG("update task status from[kDoing] to[kCanceled]. op_id[%lu], task_type[%s]",
-                                 task_info->op_id(), ::openmldb::api::TaskType_Name(task_info->task_type()).c_str());
+                            task_info->op_id(), ::openmldb::api::TaskType_Name(task_info->task_type()).c_str());
                     }
                 }
                 if (idx == task_info->rep_cluster_op_id_size() - 1) {
@@ -1684,7 +1688,7 @@ void NameServerImpl::UpdateTaskMapStatus(uint64_t remote_op_id, uint64_t op_id,
                         task_info->status() != ::openmldb::api::kCanceled) {
                         task_info->set_status(status);
                         DEBUGLOG("update task status from[kDoing] to[kDone]. op_id[%lu], task_type[%s]",
-                                 task_info->op_id(), ::openmldb::api::TaskType_Name(task_info->task_type()).c_str());
+                            task_info->op_id(), ::openmldb::api::TaskType_Name(task_info->task_type()).c_str());
                     }
                 }
             }
@@ -1815,7 +1819,8 @@ void NameServerImpl::DeleteTask(const std::vector<uint64_t>& done_task_vec) {
             continue;
         }
         std::string node = absl::StrCat(zk_path_.op_data_path_, "/", op_id);
-        if (!op_data->task_list_.empty() && op_data->task_list_.front()->GetStatus() == ::openmldb::api::kFailed) {
+        if (!op_data->task_list_.empty() &&
+            op_data->task_list_.front()->GetStatus() == ::openmldb::api::kFailed) {
             op_data->SetTaskStatus(::openmldb::api::kFailed);
             op_data->op_info_.set_end_time(::baidu::common::timer::now_time());
             PDLOG(WARNING, "set op[%s] status failed. op_id[%lu]", op_data->GetReadableType().c_str(), op_id);
@@ -1878,28 +1883,27 @@ void NameServerImpl::ProcessTask() {
                     op_data->SetTaskStatus(::openmldb::api::kDoing);
                     std::string value;
                     op_data->op_info_.SerializeToString(&value);
-                    std::string node = absl::StrCat(zk_path_.op_data_path_, "/", op_data->GetOpId());
+                    std::string node = absl::StrCat(zk_path_.op_data_path_ , "/", op_data->GetOpId());
                     if (!zk_client_->SetNodeValue(node, value)) {
-                        PDLOG(WARNING, "set zk op status value failed. node[%s] value[%s]", node.c_str(),
-                              value.c_str());
+                        PDLOG(WARNING, "set zk op status value failed. node[%s] value[%s]",
+                                node.c_str(), value.c_str());
                         op_data->SetTaskStatus(::openmldb::api::kInited);
                         continue;
                     }
                 }
                 std::shared_ptr<Task> task = op_data->task_list_.front();
                 if (task->GetStatus() == ::openmldb::api::kFailed) {
-                    PDLOG(WARNING, "task[%s] run failed, terminate op[%s]. op_id[%lu]", task->GetReadableType().c_str(),
-                          task->GetReadableOpType().c_str(), task->GetOpId());
+                    PDLOG(WARNING, "task[%s] run failed, terminate op[%s]. op_id[%lu]",
+                          task->GetReadableType().c_str(), task->GetReadableOpType().c_str(), task->GetOpId());
                 } else if (task->task_info_->status() == ::openmldb::api::kInited) {
-                    DEBUGLOG("run task. opid[%lu] op_type[%s] task_type[%s]", task->GetOpId(),
-                             task->GetReadableOpType().c_str(), task->GetReadableType().c_str());
+                    DEBUGLOG("run task. opid[%lu] op_type[%s] task_type[%s]",
+                            task->GetOpId(), task->GetReadableOpType().c_str(), task->GetReadableType().c_str());
                     task_thread_pool_.AddTask(task->fun_);
                     task->SetStatus(::openmldb::api::kDoing);
                 } else if (task->GetStatus() == ::openmldb::api::kDoing) {
                     uint64_t cur_ts = ::baidu::common::timer::now_time();
                     if (cur_ts - op_data->op_info_.start_time() > FLAGS_name_server_op_execute_timeout / 1000) {
-                        PDLOG(INFO,
-                              "The execution time of op is too long. opid[%lu] op_type[%s] cur task_type[%s] "
+                        PDLOG(INFO, "The execution time of op is too long. opid[%lu] op_type[%s] cur task_type[%s] "
                               "start_time[%lu] cur_time[%lu]",
                               task->GetOpId(), task->GetReadableOpType().c_str(), task->GetReadableType().c_str(),
                               op_data->op_info_.start_time(), cur_ts);
@@ -2049,7 +2053,7 @@ void NameServerImpl::MakeSnapshotNS(RpcController* controller, const MakeSnapsho
             return;
         } else {
             thread_pool_.AddTask(boost::bind(&NameServerImpl::MakeTablePartitionSnapshot, this, request->pid(),
-                                             request->offset(), table_info));
+                                            request->offset(), table_info));
             response->set_code(::openmldb::base::ReturnCode::kOk);
             return;
         }
@@ -2678,7 +2682,7 @@ void NameServerImpl::CancelOP(RpcController* controller, const CancelOPRequest* 
             for (auto& op_data : op_list) {
                 if (op_data->op_info_.op_id() == request->op_id()) {
                     if (op_data->op_info_.task_status() == ::openmldb::api::kInited ||
-                        (op_data->op_info_.task_status() == ::openmldb::api::kDoing)) {
+                         (op_data->op_info_.task_status() == ::openmldb::api::kDoing)) {
                         op_data->op_info_.set_task_status(::openmldb::api::kCanceled);
                         for (auto& task : op_data->task_list_) {
                             task->task_info_->set_status(::openmldb::api::kCanceled);
@@ -2871,11 +2875,10 @@ void NameServerImpl::DropTableFun(const DropTableRequest* request, GeneralRespon
 ::openmldb::base::Status NameServerImpl::CheckZoneInfo(const ::openmldb::nameserver::ZoneInfo& zone_info) {
     std::lock_guard<std::mutex> lock(mu_);
     if (zone_info.zone_name() != zone_info_.zone_name() || zone_info.zone_term() != zone_info_.zone_term()) {
-        PDLOG(WARNING,
-              "zone_info mismathch, expect zone name[%s], zone term [%lu], "
+        PDLOG(WARNING, "zone_info mismathch, expect zone name[%s], zone term [%lu], "
               "but zone name [%s], zone term [%u]",
-              zone_info_.zone_name().c_str(), zone_info_.zone_term(), zone_info.zone_name().c_str(),
-              zone_info.zone_term());
+              zone_info_.zone_name().c_str(), zone_info_.zone_term(),
+              zone_info.zone_name().c_str(), zone_info.zone_term());
         return {::openmldb::base::ReturnCode::kZoneInfoMismathch, "zone_info mismathch"};
     }
     return {};
@@ -3030,12 +3033,12 @@ void NameServerImpl::DropTableInternel(const DropTableRequest& request, GeneralR
             }
             for (auto& op_data : op_list) {
                 if (op_data->op_info_.for_replica_cluster() == 1 ||
-                    (task_ptr && task_ptr->op_id() == op_data->op_info_.op_id())) {
+                        (task_ptr && task_ptr->op_id() == op_data->op_info_.op_id())) {
                     continue;
                 }
                 if (op_data->op_info_.db() == db && op_data->op_info_.name() == name) {
                     if (op_data->op_info_.task_status() == ::openmldb::api::kInited ||
-                        (op_data->op_info_.task_status() == ::openmldb::api::kDoing)) {
+                         (op_data->op_info_.task_status() == ::openmldb::api::kDoing)) {
                         op_data->op_info_.set_task_status(::openmldb::api::kCanceled);
                         for (auto& task : op_data->task_list_) {
                             task->task_info_->set_status(::openmldb::api::kCanceled);
@@ -3641,7 +3644,8 @@ void NameServerImpl::CreateTable(RpcController* controller, const CreateTableReq
     auto status = schema::SchemaAdapter::CheckTableMeta(*table_info);
     if (!status.OK()) {
         PDLOG(WARNING, status.msg.c_str());
-        base::SetResponseStatus(base::ReturnCode::kInvalidParameter, "check TableMeta failed! " + status.msg, response);
+        base::SetResponseStatus(base::ReturnCode::kInvalidParameter, "check TableMeta failed! " + status.msg,
+                response);
         return;
     }
     if (!request->has_zone_info()) {
@@ -3713,6 +3717,8 @@ void NameServerImpl::CreateTable(RpcController* controller, const CreateTableReq
         response->set_msg(response->msg());
     }
 }
+
+
 
 bool NameServerImpl::SaveTableInfo(std::shared_ptr<TableInfo> table_info) {
     std::string table_value;
@@ -3898,15 +3904,15 @@ int NameServerImpl::CreateAddReplicaSimplyRemoteOPTask(std::shared_ptr<OPData> o
     uint64_t op_index = op_data->op_info_.op_id();
     auto op_type = ::openmldb::api::OPType::kAddReplicaSimplyRemoteOP;
     auto task = CreateTask<AddReplicaTaskMeta>(op_index, op_type, leader_endpoint, tid, pid,
-                                               add_replica_data.endpoint(), add_replica_data.remote_tid());
+                add_replica_data.endpoint(), add_replica_data.remote_tid());
     if (!task) {
-        PDLOG(WARNING, "create addreplica task failed. leader cluster tid[%u] replica cluster tid[%u] pid[%u]", tid,
-              add_replica_data.remote_tid(), pid);
+        PDLOG(WARNING, "create addreplica task failed. leader cluster tid[%u] replica cluster tid[%u] pid[%u]",
+              tid, add_replica_data.remote_tid(), pid);
         return -1;
     }
     op_data->task_list_.push_back(task);
-    task = CreateTask<AddTableInfoTaskMeta>(op_index, op_type, add_replica_data.name(), add_replica_data.db(), pid,
-                                            add_replica_data.endpoint(), alias, add_replica_data.remote_tid());
+    task = CreateTask<AddTableInfoTaskMeta>(op_index, op_type, add_replica_data.name(),
+                add_replica_data.db(), pid, add_replica_data.endpoint(), alias, add_replica_data.remote_tid());
     if (!task) {
         PDLOG(WARNING, "create addtableinfo task failed. tid[%u] pid[%u]", tid, pid);
         return -1;
@@ -3993,7 +3999,8 @@ int NameServerImpl::CreateAddReplicaRemoteOPTask(std::shared_ptr<OPData> op_data
         return -1;
     }
     op_data->task_list_.push_back(task);
-    task = CreateTask<SendSnapshotTaskMeta>(op_index, op_type, leader_endpoint, tid, remote_tid, pid, endpoint);
+    task = CreateTask<SendSnapshotTaskMeta>(op_index, op_type, leader_endpoint,
+            tid, remote_tid, pid, endpoint);
     if (!task) {
         PDLOG(WARNING,
               "create sendsnapshot task failed. leader cluster tid[%u] replica "
@@ -4013,8 +4020,8 @@ int NameServerImpl::CreateAddReplicaRemoteOPTask(std::shared_ptr<OPData> op_data
 
     task = CreateTask<AddReplicaTaskMeta>(op_index, op_type, leader_endpoint, tid, pid, endpoint, remote_tid);
     if (!task) {
-        PDLOG(WARNING, "create addreplica task failed. leader cluster tid[%u] replica cluster tid[%u] pid[%u]", tid,
-              remote_tid, pid);
+        PDLOG(WARNING, "create addreplica task failed. leader cluster tid[%u] replica cluster tid[%u] pid[%u]",
+              tid, remote_tid, pid);
         return -1;
     }
     op_data->task_list_.push_back(task);
@@ -4037,8 +4044,8 @@ int NameServerImpl::CreateAddReplicaRemoteOPTask(std::shared_ptr<OPData> op_data
         task = CreateTask<AddReplicaNSRemoteTaskMeta>(op_index, op_type, name, alias, endpoint_vec, pid);
         if (!task) {
             PDLOG(WARNING,
-                  "create addreplicaNS remote task failed. leader cluster tid[%u] replica cluster tid[%u] pid[%u]", tid,
-                  remote_tid, pid);
+                  "create addreplicaNS remote task failed. leader cluster tid[%u] replica cluster tid[%u] pid[%u]",
+                  tid, remote_tid, pid);
             return -1;
         }
         op_data->task_list_.push_back(task);
@@ -4292,14 +4299,15 @@ int NameServerImpl::CreateAddReplicaOPTask(std::shared_ptr<OPData> op_data) {
         return -1;
     }
     op_data->task_list_.push_back(task);
-    task = CreateTask<SendSnapshotTaskMeta>(op_index, op_type, leader_endpoint, tid, tid, pid, request.endpoint());
+    task = CreateTask<SendSnapshotTaskMeta>(op_index, op_type, leader_endpoint,
+            tid, tid, pid, request.endpoint());
     if (!task) {
         PDLOG(WARNING, "create sendsnapshot task failed. tid[%u] pid[%u]", tid, pid);
         return -1;
     }
     op_data->task_list_.push_back(task);
-    task = CreateTask<LoadTableTaskMeta>(op_index, op_type, request.endpoint(), request.name(), tid, pid, seg_cnt,
-                                         false, table_info->storage_mode());
+    task = CreateTask<LoadTableTaskMeta>(op_index, op_type, request.endpoint(),
+            request.name(), tid, pid, seg_cnt, false, table_info->storage_mode());
     if (!task) {
         PDLOG(WARNING, "create loadtable task failed. tid[%u] pid[%u]", tid, pid);
         return -1;
@@ -4318,21 +4326,22 @@ int NameServerImpl::CreateAddReplicaOPTask(std::shared_ptr<OPData> op_data) {
         return -1;
     }
     op_data->task_list_.push_back(task);
-    task = CreateTask<AddTableInfoTaskMeta>(op_index, op_type, request.name(), request.db(), pid, request.endpoint());
+    task = CreateTask<AddTableInfoTaskMeta>(op_index, op_type,
+                request.name(), request.db(), pid, request.endpoint());
     if (!task) {
         PDLOG(WARNING, "create addtableinfo task failed. tid[%u] pid[%u]", tid, pid);
         return -1;
     }
     op_data->task_list_.push_back(task);
-    task = CreateTask<CheckBinlogSyncProgressTaskMeta>(op_index, op_type, request.name(), request.db(), pid,
-                                                       request.endpoint(), FLAGS_check_binlog_sync_progress_delta);
+    task = CreateTask<CheckBinlogSyncProgressTaskMeta>(op_index, op_type,
+                request.name(), request.db(), pid, request.endpoint(), FLAGS_check_binlog_sync_progress_delta);
     if (!task) {
         PDLOG(WARNING, "create checkbinlogsyncprogress task failed. tid[%u] pid[%u]", tid, pid);
         return -1;
     }
     op_data->task_list_.push_back(task);
-    task = CreateTask<UpdatePartitionStatusTaskMeta>(op_index, op_type, request.name(), request.db(), pid,
-                                                     request.endpoint(), false, true);
+    task = CreateTask<UpdatePartitionStatusTaskMeta>(
+                op_index, op_type, request.name(), request.db(), pid, request.endpoint(), false, true);
     if (!task) {
         PDLOG(WARNING, "create update table alive status task failed. table[%s] pid[%u] endpoint[%s]",
               request.name().c_str(), pid, request.endpoint().c_str());
@@ -4528,20 +4537,20 @@ int NameServerImpl::CreateMigrateTask(std::shared_ptr<OPData> op_data) {
     op_data->task_list_.push_back(task);
     task = CreateTask<SendSnapshotTaskMeta>(op_index, op_type, leader_endpoint, tid, tid, pid, des_endpoint);
     if (!task) {
-        PDLOG(WARNING, "create sendsnapshot task failed. tid[%u] pid[%u] endpoint[%s] des_endpoint[%s]", tid, pid,
-              leader_endpoint.c_str(), des_endpoint.c_str());
+        PDLOG(WARNING, "create sendsnapshot task failed. tid[%u] pid[%u] endpoint[%s] des_endpoint[%s]",
+              tid, pid, leader_endpoint.c_str(), des_endpoint.c_str());
         return -1;
     }
     op_data->task_list_.push_back(task);
     task = CreateTask<RecoverSnapshotTaskMeta>(op_index, op_type, leader_endpoint, tid, pid);
     if (!task) {
-        PDLOG(WARNING, "create recoversnapshot task failed. tid[%u] pid[%u] endpoint[%s] des_endpoint[%s]", tid, pid,
-              leader_endpoint.c_str(), des_endpoint.c_str());
+        PDLOG(WARNING, "create recoversnapshot task failed. tid[%u] pid[%u] endpoint[%s] des_endpoint[%s]",
+              tid, pid, leader_endpoint.c_str(), des_endpoint.c_str());
         return -1;
     }
     op_data->task_list_.push_back(task);
-    task = CreateTask<LoadTableTaskMeta>(op_index, op_type, des_endpoint, name, tid, pid, table_info->seg_cnt(), false,
-                                         table_info->storage_mode());
+    task = CreateTask<LoadTableTaskMeta>(op_index, op_type, des_endpoint,
+            name, tid, pid, table_info->seg_cnt(), false, table_info->storage_mode());
     if (!task) {
         PDLOG(WARNING, "create loadtable task failed. tid[%u] pid[%u] endpoint[%s]", tid, pid, des_endpoint.c_str());
         return -1;
@@ -4558,13 +4567,13 @@ int NameServerImpl::CreateMigrateTask(std::shared_ptr<OPData> op_data) {
     op_data->task_list_.push_back(task);
     task = CreateTask<AddTableInfoTaskMeta>(op_index, op_type, name, db, pid, des_endpoint);
     if (!task) {
-        PDLOG(WARNING, "create addtableinfo task failed. tid[%u] pid[%u] endpoint[%s] des_endpoint[%s]", tid, pid,
-              leader_endpoint.c_str(), des_endpoint.c_str());
+        PDLOG(WARNING, "create addtableinfo task failed. tid[%u] pid[%u] endpoint[%s] des_endpoint[%s]",
+              tid, pid, leader_endpoint.c_str(), des_endpoint.c_str());
         return -1;
     }
     op_data->task_list_.push_back(task);
-    task = CreateTask<CheckBinlogSyncProgressTaskMeta>(op_index, op_type, name, db, pid, des_endpoint,
-                                                       FLAGS_check_binlog_sync_progress_delta);
+    task = CreateTask<CheckBinlogSyncProgressTaskMeta>(op_index, op_type,
+                name, db, pid, des_endpoint, FLAGS_check_binlog_sync_progress_delta);
     if (!task) {
         PDLOG(WARNING, "create CheckBinlogSyncProgressTask failed. name[%s] pid[%u]", name.c_str(), pid);
         return -1;
@@ -4572,15 +4581,15 @@ int NameServerImpl::CreateMigrateTask(std::shared_ptr<OPData> op_data) {
     op_data->task_list_.push_back(task);
     task = CreateTask<DelReplicaTaskMeta>(op_index, op_type, leader_endpoint, tid, pid, src_endpoint);
     if (!task) {
-        PDLOG(WARNING, "create delreplica task failed. tid[%u] pid[%u] leader[%s] follower[%s]", tid, pid,
-              leader_endpoint.c_str(), src_endpoint.c_str());
+        PDLOG(WARNING, "create delreplica task failed. tid[%u] pid[%u] leader[%s] follower[%s]",
+              tid, pid, leader_endpoint.c_str(), src_endpoint.c_str());
         return -1;
     }
     op_data->task_list_.push_back(task);
     task = CreateTask<UpdateTableInfoTaskMeta>(op_index, op_type, name, db, pid, src_endpoint, des_endpoint);
     if (!task) {
-        PDLOG(WARNING, "create update table info task failed. tid[%u] pid[%u] endpoint[%s] des_endpoint[%s]", tid, pid,
-              src_endpoint.c_str(), des_endpoint.c_str());
+        PDLOG(WARNING, "create update table info task failed. tid[%u] pid[%u] endpoint[%s] des_endpoint[%s]",
+              tid, pid, src_endpoint.c_str(), des_endpoint.c_str());
         return -1;
     }
     op_data->task_list_.push_back(task);
@@ -4590,8 +4599,8 @@ int NameServerImpl::CreateMigrateTask(std::shared_ptr<OPData> op_data) {
         return -1;
     }
     op_data->task_list_.push_back(task);
-    PDLOG(INFO, "create migrate op task ok. src_endpoint[%s] name[%s] pid[%u] des_endpoint[%s]", src_endpoint.c_str(),
-          name.c_str(), pid, des_endpoint.c_str());
+    PDLOG(INFO, "create migrate op task ok. src_endpoint[%s] name[%s] pid[%u] des_endpoint[%s]",
+          src_endpoint.c_str(), name.c_str(), pid, des_endpoint.c_str());
     return 0;
 }
 
@@ -4729,7 +4738,7 @@ int NameServerImpl::AddOPTask(const ::openmldb::api::TaskInfo& task_info, ::open
 }
 
 std::shared_ptr<::openmldb::api::TaskInfo> NameServerImpl::FindTask(uint64_t op_id,
-                                                                    ::openmldb::api::TaskType task_type) {
+        ::openmldb::api::TaskType task_type) {
     auto iter = task_map_.find(op_id);
     if (iter == task_map_.end()) {
         return std::shared_ptr<::openmldb::api::TaskInfo>();
@@ -4794,8 +4803,8 @@ int NameServerImpl::AddOPData(const std::shared_ptr<OPData>& op_data, uint32_t c
     op_data->op_info_.SerializeToString(&value);
     std::string node = absl::StrCat(zk_path_.op_data_path_, "/", op_data->GetOpId());
     if (!zk_client_->CreateNode(node, value)) {
-        PDLOG(WARNING, "create op node[%s] failed. op_index[%lu] op_type[%s]", node.c_str(), op_data->GetOpId(),
-              op_data->GetReadableType().c_str());
+        PDLOG(WARNING, "create op node[%s] failed. op_index[%lu] op_type[%s]",
+                node.c_str(), op_data->GetOpId(), op_data->GetReadableType().c_str());
         return -1;
     }
     uint64_t parent_id = op_data->op_info_.parent_id();
@@ -4810,8 +4819,8 @@ int NameServerImpl::AddOPData(const std::shared_ptr<OPData>& op_data, uint32_t c
             iter++;
             task_vec_[idx].insert(iter, op_data);
         } else {
-            PDLOG(WARNING, "not found parent_id[%lu] with index[%u]. add op[%lu] failed, op_type[%s]", parent_id, idx,
-                  op_data->GetOpId(), op_data->GetReadableType().c_str());
+            PDLOG(WARNING, "not found parent_id[%lu] with index[%u]. add op[%lu] failed, op_type[%s]",
+                  parent_id, idx, op_data->GetOpId(), op_data->GetReadableType().c_str());
             return -1;
         }
     } else {
@@ -4838,8 +4847,8 @@ void NameServerImpl::DeleteDoneOP() {
                 break;
             }
         }
-        PDLOG(INFO, "done_op_list size[%u] is greater than the max_op_num[%u], delete op[%lu]", done_op_list_.size(),
-              (uint32_t)FLAGS_max_op_num, op_data->GetOpId());
+        PDLOG(INFO, "done_op_list size[%u] is greater than the max_op_num[%u], delete op[%lu]",
+              done_op_list_.size(), (uint32_t)FLAGS_max_op_num, op_data->GetOpId());
         done_op_list_.pop_front();
     }
 }
@@ -5006,7 +5015,7 @@ void NameServerImpl::UpdateTableStatus() {
         }
         for (int pos = 0; pos < tablet_status_response.all_table_status_size(); pos++) {
             std::string key = absl::StrCat(tablet_status_response.all_table_status(pos).tid(), "_",
-                                           tablet_status_response.all_table_status(pos).pid(), "_", kv.first);
+                              tablet_status_response.all_table_status(pos).pid(), "_", kv.first);
             pos_response.emplace(key, tablet_status_response.all_table_status(pos));
         }
     }
@@ -5192,8 +5201,8 @@ int NameServerImpl::CreateOfflineReplicaOP(const std::string& name, const std::s
         return -1;
     }
     if (CreateOfflineReplicaTask(op_data) < 0) {
-        PDLOG(WARNING, "create offline replica task failed. table[%s] pid[%u] endpoint[%s]", name.c_str(), pid,
-              endpoint.c_str());
+        PDLOG(WARNING, "create offline replica task failed. table[%s] pid[%u] endpoint[%s]",
+              name.c_str(), pid, endpoint.c_str());
         return -1;
     }
     if (AddOPData(op_data, concurrency) < 0) {
@@ -5234,10 +5243,11 @@ int NameServerImpl::CreateOfflineReplicaTask(std::shared_ptr<OPData> op_data) {
             return -1;
         }
         op_data->task_list_.push_back(task);
-        task = CreateTask<UpdatePartitionStatusTaskMeta>(op_index, op_type, name, db, pid, endpoint, false, false);
+        task = CreateTask<UpdatePartitionStatusTaskMeta>(
+                op_index, op_type, name, db, pid, endpoint, false, false);
         if (!task) {
-            PDLOG(WARNING, "create update table alive status task failed. table[%s] pid[%u] endpoint[%s]", name.c_str(),
-                  pid, endpoint.c_str());
+            PDLOG(WARNING, "create update table alive status task failed. table[%s] pid[%u] endpoint[%s]",
+                  name.c_str(), pid, endpoint.c_str());
             return -1;
         }
         op_data->task_list_.push_back(task);
@@ -5506,7 +5516,8 @@ int NameServerImpl::CreateRecoverTableOPTask(std::shared_ptr<OPData> op_data) {
         }
         op_data->task_list_.push_back(task);
     }
-    auto task = CreateTask<RecoverTableTaskMeta>(op_index, op_type, name, db, pid, endpoint, offset_delta, concurrency);
+    auto task = CreateTask<RecoverTableTaskMeta>(
+                op_index, op_type, name, db, pid, endpoint, offset_delta, concurrency);
     if (!task) {
         PDLOG(WARNING, "create RecoverTable task failed. table[%s] pid[%u] endpoint[%s]", name.c_str(), pid,
               endpoint.c_str());
@@ -5570,15 +5581,15 @@ void NameServerImpl::RecoverEndpointTable(const std::string& name, const std::st
                 }
                 if (partition_meta.endpoint() == endpoint) {
                     if (partition_meta.is_alive()) {
-                        PDLOG(INFO, "endpoint[%s] is alive, need not recover. name[%s] pid[%u]", endpoint.c_str(),
-                              name.c_str(), pid);
+                        PDLOG(INFO, "endpoint[%s] is alive, need not recover. name[%s] pid[%u]",
+                              endpoint.c_str(), name.c_str(), pid);
                         task_info->set_status(::openmldb::api::TaskStatus::kDone);
                         return;
                     }
                     auto tablet_iter = tablets_.find(endpoint);
                     if (tablet_iter == tablets_.end()) {
-                        PDLOG(WARNING, "can not find the endpoint[%s]'s client. op_id[%lu]", endpoint.c_str(),
-                              task_info->op_id());
+                        PDLOG(WARNING, "can not find the endpoint[%s]'s client. op_id[%lu]",
+                              endpoint.c_str(), task_info->op_id());
                         task_info->set_status(::openmldb::api::TaskStatus::kFailed);
                         return;
                     }
@@ -5608,8 +5619,8 @@ void NameServerImpl::RecoverEndpointTable(const std::string& name, const std::st
     uint64_t term = 0;
     uint64_t offset = 0;
     if (!tablet_ptr->client_->GetTermPair(tid, pid, storage_mode, term, offset, has_table, is_leader)) {
-        PDLOG(WARNING, "GetTermPair failed. name[%s] tid[%u] pid[%u] endpoint[%s] op_id[%lu]", name.c_str(), tid, pid,
-              endpoint.c_str(), task_info->op_id());
+        PDLOG(WARNING, "GetTermPair failed. name[%s] tid[%u] pid[%u] endpoint[%s] op_id[%lu]",
+              name.c_str(), tid, pid, endpoint.c_str(), task_info->op_id());
         task_info->set_status(::openmldb::api::TaskStatus::kFailed);
         return;
     }
@@ -5621,14 +5632,14 @@ void NameServerImpl::RecoverEndpointTable(const std::string& name, const std::st
             CreateReLoadTableOP(name, db, pid, endpoint, task_info->op_id(), concurrency);
         }
         task_info->set_status(::openmldb::api::TaskStatus::kDone);
-        PDLOG(INFO, "update task status from[kDoing] to[kDone]. op_id[%lu], task_type[%s]", task_info->op_id(),
-              ::openmldb::api::TaskType_Name(task_info->task_type()).c_str());
+        PDLOG(INFO, "update task status from[kDoing] to[kDone]. op_id[%lu], task_type[%s]",
+              task_info->op_id(), ::openmldb::api::TaskType_Name(task_info->task_type()).c_str());
         return;
     }
     if (has_table && is_leader) {
         if (!tablet_ptr->client_->ChangeRole(tid, pid, false, 0)) {
-            PDLOG(WARNING, "change role failed. name[%s] tid[%u] pid[%u] endpoint[%s] op_id[%lu]", name.c_str(), tid,
-                  pid, endpoint.c_str(), task_info->op_id());
+            PDLOG(WARNING, "change role failed. name[%s] tid[%u] pid[%u] endpoint[%s] op_id[%lu]",
+                  name.c_str(), tid, pid, endpoint.c_str(), task_info->op_id());
             task_info->set_status(::openmldb::api::TaskStatus::kFailed);
             return;
         }
@@ -5637,8 +5648,8 @@ void NameServerImpl::RecoverEndpointTable(const std::string& name, const std::st
     }
     if (!has_table) {
         if (!tablet_ptr->client_->DeleteBinlog(tid, pid, storage_mode)) {
-            PDLOG(WARNING, "delete binlog failed. name[%s] tid[%u] pid[%u] endpoint[%s] op_id[%lu]", name.c_str(), tid,
-                  pid, endpoint.c_str(), task_info->op_id());
+            PDLOG(WARNING, "delete binlog failed. name[%s] tid[%u] pid[%u] endpoint[%s] op_id[%lu]",
+                  name.c_str(), tid, pid, endpoint.c_str(), task_info->op_id());
             task_info->set_status(::openmldb::api::TaskStatus::kFailed);
             return;
         }
@@ -5752,8 +5763,8 @@ int NameServerImpl::CreateReAddReplicaTask(std::shared_ptr<OPData> op_data) {
         return -1;
     }
     op_data->task_list_.push_back(task);
-    task = CreateTask<LoadTableTaskMeta>(op_index, op_type, endpoint, name, tid, pid, seg_cnt, false,
-                                         table_info->storage_mode());
+    task = CreateTask<LoadTableTaskMeta>(op_index, op_type, endpoint,
+            name, tid, pid, seg_cnt, false, table_info->storage_mode());
     if (!task) {
         PDLOG(WARNING, "create loadtable task failed. tid[%u] pid[%u]", tid, pid);
         return -1;
@@ -5771,7 +5782,8 @@ int NameServerImpl::CreateReAddReplicaTask(std::shared_ptr<OPData> op_data) {
         return -1;
     }
     op_data->task_list_.push_back(task);
-    task = CreateTask<CheckBinlogSyncProgressTaskMeta>(op_index, op_type, name, db, pid, endpoint, offset_delta);
+    task = CreateTask<CheckBinlogSyncProgressTaskMeta>(op_index, op_type,
+                name, db, pid, endpoint, offset_delta);
     if (!task) {
         PDLOG(WARNING, "create CheckBinlogSyncProgressTask failed. name[%s] pid[%u]", name.c_str(), pid);
         return -1;
@@ -5779,8 +5791,8 @@ int NameServerImpl::CreateReAddReplicaTask(std::shared_ptr<OPData> op_data) {
     op_data->task_list_.push_back(task);
     task = CreateTask<UpdatePartitionStatusTaskMeta>(op_index, op_type, name, db, pid, endpoint, false, true);
     if (!task) {
-        PDLOG(WARNING, "create update table alive status task failed. table[%s] pid[%u] endpoint[%s]", name.c_str(),
-              pid, endpoint.c_str());
+        PDLOG(WARNING, "create update table alive status task failed. table[%s] pid[%u] endpoint[%s]",
+              name.c_str(), pid, endpoint.c_str());
         return -1;
     }
     op_data->task_list_.push_back(task);
@@ -5870,8 +5882,8 @@ int NameServerImpl::CreateReAddReplicaWithDropTask(std::shared_ptr<OPData> op_da
         return -1;
     }
     op_data->task_list_.push_back(task);
-    task = CreateTask<LoadTableTaskMeta>(op_index, op_type, endpoint, name, tid, pid, seg_cnt, false,
-                                         table_info->storage_mode());
+    task = CreateTask<LoadTableTaskMeta>(op_index, op_type, endpoint,
+            name, tid, pid, seg_cnt, false, table_info->storage_mode());
     if (!task) {
         PDLOG(WARNING, "create loadtable task failed. tid[%u] pid[%u]", tid, pid);
         return -1;
@@ -5889,7 +5901,8 @@ int NameServerImpl::CreateReAddReplicaWithDropTask(std::shared_ptr<OPData> op_da
         return -1;
     }
     op_data->task_list_.push_back(task);
-    task = CreateTask<CheckBinlogSyncProgressTaskMeta>(op_index, op_type, name, db, pid, endpoint, offset_delta);
+    task = CreateTask<CheckBinlogSyncProgressTaskMeta>(op_index, op_type,
+                name, db, pid, endpoint, offset_delta);
     if (!task) {
         PDLOG(WARNING, "create CheckBinlogSyncProgressTask failed. name[%s] pid[%u]", name.c_str(), pid);
         return -1;
@@ -5897,8 +5910,8 @@ int NameServerImpl::CreateReAddReplicaWithDropTask(std::shared_ptr<OPData> op_da
     op_data->task_list_.push_back(task);
     task = CreateTask<UpdatePartitionStatusTaskMeta>(op_index, op_type, name, db, pid, endpoint, false, true);
     if (!task) {
-        PDLOG(WARNING, "create update table alive status task failed. table[%s] pid[%u] endpoint[%s]", name.c_str(),
-              pid, endpoint.c_str());
+        PDLOG(WARNING, "create update table alive status task failed. table[%s] pid[%u] endpoint[%s]",
+              name.c_str(), pid, endpoint.c_str());
         return -1;
     }
     op_data->task_list_.push_back(task);
@@ -5979,8 +5992,8 @@ int NameServerImpl::CreateReAddReplicaNoSendTask(std::shared_ptr<OPData> op_data
         return -1;
     }
     op_data->task_list_.push_back(task);
-    task = CreateTask<LoadTableTaskMeta>(op_index, op_type, endpoint, name, tid, pid, seg_cnt, false,
-                                         table_info->storage_mode());
+    task = CreateTask<LoadTableTaskMeta>(op_index, op_type, endpoint,
+            name, tid, pid, seg_cnt, false, table_info->storage_mode());
     if (!task) {
         PDLOG(WARNING, "create loadtable task failed. tid[%u] pid[%u]", tid, pid);
         return -1;
@@ -5998,7 +6011,8 @@ int NameServerImpl::CreateReAddReplicaNoSendTask(std::shared_ptr<OPData> op_data
         return -1;
     }
     op_data->task_list_.push_back(task);
-    task = CreateTask<CheckBinlogSyncProgressTaskMeta>(op_index, op_type, name, db, pid, endpoint, offset_delta);
+    task = CreateTask<CheckBinlogSyncProgressTaskMeta>(op_index, op_type,
+                name, db, pid, endpoint, offset_delta);
     if (!task) {
         PDLOG(WARNING, "create CheckBinlogSyncProgressTask failed. name[%s] pid[%u]", name.c_str(), pid);
         return -1;
@@ -6006,8 +6020,8 @@ int NameServerImpl::CreateReAddReplicaNoSendTask(std::shared_ptr<OPData> op_data
     op_data->task_list_.push_back(task);
     task = CreateTask<UpdatePartitionStatusTaskMeta>(op_index, op_type, name, db, pid, endpoint, false, true);
     if (!task) {
-        PDLOG(WARNING, "create update table alive status task failed. table[%s] pid[%u] endpoint[%s]", name.c_str(),
-              pid, endpoint.c_str());
+        PDLOG(WARNING, "create update table alive status task failed. table[%s] pid[%u] endpoint[%s]",
+              name.c_str(), pid, endpoint.c_str());
         return -1;
     }
     op_data->task_list_.push_back(task);
@@ -6103,7 +6117,8 @@ int NameServerImpl::CreateReAddReplicaSimplifyTask(std::shared_ptr<OPData> op_da
         return -1;
     }
     op_data->task_list_.push_back(task);
-    task = CreateTask<CheckBinlogSyncProgressTaskMeta>(op_index, op_type, name, db, pid, endpoint, offset_delta);
+    task = CreateTask<CheckBinlogSyncProgressTaskMeta>(op_index, op_type,
+                name, db, pid, endpoint, offset_delta);
     if (!task) {
         PDLOG(WARNING, "create CheckBinlogSyncProgressTask failed. name[%s] pid[%u]", name.c_str(), pid);
         return -1;
@@ -6111,8 +6126,8 @@ int NameServerImpl::CreateReAddReplicaSimplifyTask(std::shared_ptr<OPData> op_da
     op_data->task_list_.push_back(task);
     task = CreateTask<UpdatePartitionStatusTaskMeta>(op_index, op_type, name, db, pid, endpoint, false, true);
     if (!task) {
-        PDLOG(WARNING, "create update table alive status task failed. table[%s] pid[%u] endpoint[%s]", name.c_str(),
-              pid, endpoint.c_str());
+        PDLOG(WARNING, "create update table alive status task failed. table[%s] pid[%u] endpoint[%s]",
+              name.c_str(), pid, endpoint.c_str());
         return -1;
     }
     op_data->task_list_.push_back(task);
@@ -6182,13 +6197,13 @@ int NameServerImpl::CreateTableRemoteOP(const ::openmldb::nameserver::TableInfo&
     uint32_t pid = INVALID_PID;
     std::shared_ptr<OPData> op_data;
     if (CreateOPData(::openmldb::api::OPType::kCreateTableRemoteOP, value, op_data, name, db, pid, parent_id) < 0) {
-        PDLOG(WARNING, "create CreateTableRemoteOP data error. table[%s] pid[%u] alias[%s]", name.c_str(), pid,
-              alias.c_str());
+        PDLOG(WARNING, "create CreateTableRemoteOP data error. table[%s] pid[%u] alias[%s]",
+              name.c_str(), pid, alias.c_str());
         return -1;
     }
     if (CreateTableRemoteTask(op_data) < 0) {
-        PDLOG(WARNING, "create CreateTableRemote task failed. table[%s] pid[%u] alias[%s]", table_info.name().c_str(),
-              pid, alias.c_str());
+        PDLOG(WARNING, "create CreateTableRemote task failed. table[%s] pid[%u] alias[%s]",
+                table_info.name().c_str(), pid, alias.c_str());
         return -1;
     }
     op_data->op_info_.set_for_replica_cluster(1);
@@ -6238,16 +6253,17 @@ int NameServerImpl::CreateTableRemoteTask(std::shared_ptr<OPData> op_data) {
                     PDLOG(WARNING, "get leader failed. table[%s] pid[%u]", name.c_str(), pid);
                     return -1;
                 }
-                task = CreateTask<AddReplicaTaskMeta>(op_index, op_type, leader_endpoint, tid, pid, endpoint,
-                                                      remote_tid, idx);
+                task = CreateTask<AddReplicaTaskMeta>(
+                            op_index, op_type, leader_endpoint, tid, pid, endpoint, remote_tid, idx);
                 if (!task) {
                     PDLOG(WARNING,
-                          "create addreplica task failed. leader cluster tid[%u] replica cluster tid[%u] pid[%u]", tid,
-                          remote_tid, pid);
+                          "create addreplica task failed. leader cluster tid[%u] replica cluster tid[%u] pid[%u]",
+                          tid, remote_tid, pid);
                     return -1;
                 }
                 op_data->task_list_.push_back(task);
-                task = CreateTask<AddTableInfoTaskMeta>(op_index, op_type, name, db, pid, endpoint, alias, remote_tid);
+                task = CreateTask<AddTableInfoTaskMeta>(op_index, op_type,
+                            name, db, pid, endpoint, alias, remote_tid);
                 if (!task) {
                     PDLOG(WARNING, "create addtableinfo task failed. tid[%u] pid[%u]", tid, pid);
                     return -1;
@@ -6331,8 +6347,8 @@ int NameServerImpl::CreateReLoadTableTask(std::shared_ptr<OPData> op_data) {
     uint32_t seg_cnt = table_info->seg_cnt();
     auto op_type = ::openmldb::api::OPType::kReLoadTableOP;
     uint64_t op_index = op_data->op_info_.op_id();
-    auto task = CreateTask<LoadTableTaskMeta>(op_index, op_type, endpoint, name, tid, pid, seg_cnt, true,
-                                              table_info->storage_mode());
+    auto task = CreateTask<LoadTableTaskMeta>(op_index, op_type, endpoint,
+            name, tid, pid, seg_cnt, true, table_info->storage_mode());
     if (!task) {
         PDLOG(WARNING, "create loadtable task failed. tid[%u] pid[%u]", tid, pid);
         return -1;
@@ -6340,8 +6356,8 @@ int NameServerImpl::CreateReLoadTableTask(std::shared_ptr<OPData> op_data) {
     op_data->task_list_.push_back(task);
     task = CreateTask<UpdatePartitionStatusTaskMeta>(op_index, op_type, name, db, pid, endpoint, true, true);
     if (!task) {
-        PDLOG(WARNING, "create update table alive status task failed. table[%s] pid[%u] endpoint[%s]", name.c_str(),
-              pid, endpoint.c_str());
+        PDLOG(WARNING, "create update table alive status task failed. table[%s] pid[%u] endpoint[%s]",
+              name.c_str(), pid, endpoint.c_str());
         return -1;
     }
     op_data->task_list_.push_back(task);
@@ -6410,11 +6426,11 @@ int NameServerImpl::CreateUpdatePartitionStatusOPTask(std::shared_ptr<OPData> op
     }
     uint64_t op_index = op_data->op_info_.op_id();
     ::openmldb::api::OPType op_type = ::openmldb::api::OPType::kUpdatePartitionStatusOP;
-    auto task =
-        CreateTask<UpdatePartitionStatusTaskMeta>(op_index, op_type, name, db, pid, endpoint, is_leader, is_alive);
+    auto task = CreateTask<UpdatePartitionStatusTaskMeta>(
+                op_index, op_type, name, db, pid, endpoint, is_leader, is_alive);
     if (!task) {
-        PDLOG(WARNING, "create update table alive status task failed. table[%s] pid[%u] endpoint[%s]", name.c_str(),
-              pid, endpoint.c_str());
+        PDLOG(WARNING, "create update table alive status task failed. table[%s] pid[%u] endpoint[%s]",
+              name.c_str(), pid, endpoint.c_str());
         return -1;
     }
     op_data->task_list_.push_back(task);
@@ -6480,9 +6496,8 @@ int NameServerImpl::MatchTermOffset(const std::string& name, const std::string& 
 
 void NameServerImpl::WrapTaskFun(const boost::function<bool()>& fun,
                                  std::shared_ptr<::openmldb::api::TaskInfo> task_info) {
-    std::string msg =
-        absl::StrCat("op_id ", task_info->op_id(), " type ", ::openmldb::api::TaskType_Name(task_info->task_type()),
-                     " ", Task::GetAdditionalMsg(*task_info));
+    std::string msg = absl::StrCat("op_id ", task_info->op_id(), " type ",
+            ::openmldb::api::TaskType_Name(task_info->task_type()), " ", Task::GetAdditionalMsg(*task_info));
     if (!fun()) {
         task_info->set_status(::openmldb::api::TaskStatus::kFailed);
         PDLOG(WARNING, "task run failed. %s", msg.c_str());
@@ -6493,10 +6508,9 @@ void NameServerImpl::WrapTaskFun(const boost::function<bool()>& fun,
 }
 
 void NameServerImpl::WrapNormalTaskFun(const boost::function<base::Status()>& fun,
-                                       std::shared_ptr<::openmldb::api::TaskInfo> task_info) {
-    std::string msg =
-        absl::StrCat("op_id ", task_info->op_id(), " type ", ::openmldb::api::TaskType_Name(task_info->task_type()),
-                     " ", Task::GetAdditionalMsg(*task_info));
+        std::shared_ptr<::openmldb::api::TaskInfo> task_info) {
+    std::string msg = absl::StrCat("op_id ", task_info->op_id(), " type ",
+            ::openmldb::api::TaskType_Name(task_info->task_type()), " ", Task::GetAdditionalMsg(*task_info));
     auto status = fun();
     if (!status.OK()) {
         task_info->set_status(::openmldb::api::TaskStatus::kFailed);
@@ -6803,8 +6817,8 @@ void NameServerImpl::DelTableInfo(const std::string& name, const std::string& db
         }
         if (!has_found) {
             task_info->set_status(::openmldb::api::TaskStatus::kFailed);
-            PDLOG(INFO, "not found endpoint[%s] in partition_meta. name[%s] pid[%u] op_id[%lu]", endpoint.c_str(),
-                  name.c_str(), pid, task_info->op_id());
+            PDLOG(INFO, "not found endpoint[%s] in partition_meta. name[%s] pid[%u] op_id[%lu]",
+                  endpoint.c_str(), name.c_str(), pid, task_info->op_id());
             return;
         }
         break;
@@ -7017,14 +7031,14 @@ void NameServerImpl::SelectLeader(const std::string& name, const std::string& db
     }
     ChangeLeaderData change_leader_data;
     if (!change_leader_data.ParseFromString(op_data->op_info_.data())) {
-        PDLOG(WARNING, "parse change leader data failed. name[%s] pid[%u] data[%s] op_id[%lu]", name.c_str(), pid,
-              op_data->op_info_.data().c_str(), task_info->op_id());
+        PDLOG(WARNING, "parse change leader data failed. name[%s] pid[%u] data[%s] op_id[%lu]",
+              name.c_str(), pid, op_data->op_info_.data().c_str(), task_info->op_id());
         task_info->set_status(::openmldb::api::TaskStatus::kFailed);
         return;
     }
     if (change_leader_data.has_candidate_leader()) {
-        if (std::find(follower_endpoint.begin(), follower_endpoint.end(), change_leader_data.candidate_leader()) ==
-            follower_endpoint.end()) {
+        if (std::find(follower_endpoint.begin(), follower_endpoint.end(), change_leader_data.candidate_leader())
+                == follower_endpoint.end()) {
             PDLOG(WARNING, "candidate_leader[%s] is not follower. name[%s] pid[%u] op_id[%lu]",
                   change_leader_data.candidate_leader().c_str(), name.c_str(), pid, task_info->op_id());
             task_info->set_status(::openmldb::api::TaskStatus::kFailed);
@@ -7048,7 +7062,7 @@ void NameServerImpl::SelectLeader(const std::string& name, const std::string& db
                 }
                 for (int meta_idx = 0; meta_idx < partition.partition_meta_size(); meta_idx++) {
                     if (partition.partition_meta(meta_idx).is_alive() &&
-                        partition.partition_meta(meta_idx).is_leader()) {
+                            partition.partition_meta(meta_idx).is_leader()) {
                         PDLOG(WARNING, "leader is alive, need not changeleader. table name[%s] pid[%u] op_id[%lu]",
                               name.c_str(), pid, task_info->op_id());
                         task_info->set_status(::openmldb::api::TaskStatus::kFailed);
@@ -7059,8 +7073,8 @@ void NameServerImpl::SelectLeader(const std::string& name, const std::string& db
             }
         }
         if (!zk_client_->SetNodeValue(zk_path_.term_node_, std::to_string(term_ + 2))) {
-            PDLOG(WARNING, "update leader id  node failed. table name[%s] pid[%u] op_id[%lu]", name.c_str(), pid,
-                  task_info->op_id());
+            PDLOG(WARNING, "update leader id  node failed. table name[%s] pid[%u] op_id[%lu]",
+                  name.c_str(), pid, task_info->op_id());
             task_info->set_status(::openmldb::api::TaskStatus::kFailed);
             return;
         }
@@ -7090,8 +7104,8 @@ void NameServerImpl::SelectLeader(const std::string& name, const std::string& db
             task_info->set_status(::openmldb::api::TaskStatus::kFailed);
             return;
         }
-        PDLOG(INFO, "FollowOfNoOne ok. term[%lu] offset[%lu] name[%s] tid[%u] pid[%u] endpoint[%s]", cur_term, offset,
-              name.c_str(), tid, pid, endpoint.c_str());
+        PDLOG(INFO, "FollowOfNoOne ok. term[%lu] offset[%lu] name[%s] tid[%u] pid[%u] endpoint[%s]",
+              cur_term, offset, name.c_str(), tid, pid, endpoint.c_str());
         if (offset > max_offset || leader_endpoint_vec.empty()) {
             max_offset = offset;
             leader_endpoint_vec.clear();
@@ -7303,8 +7317,8 @@ void NameServerImpl::UpdateLeaderInfo(std::shared_ptr<::openmldb::api::TaskInfo>
               leader_endpoint.c_str());
         task_info->set_status(::openmldb::api::TaskStatus::kDone);
         // notify client to update table partition information
-        PDLOG(INFO, "update task status from[kDoing] to[kDone]. op_id[%lu], task_type[%s]", task_info->op_id(),
-              ::openmldb::api::TaskType_Name(task_info->task_type()).c_str());
+        PDLOG(INFO, "update task status from[kDoing] to[kDone]. op_id[%lu], task_type[%s]",
+              task_info->op_id(), ::openmldb::api::TaskType_Name(task_info->task_type()).c_str());
         return;
     }
     PDLOG(WARNING, "partition[%u] does not exist. name[%s] op_id[%lu]", pid, name.c_str(), task_info->op_id());
@@ -7398,11 +7412,11 @@ bool NameServerImpl::UpdateTTLOnTablet(const std::string& endpoint, int32_t tid,
     }
     bool ok = tablet->client_->UpdateTTL(tid, pid, ttl.ttl_type(), ttl.abs_ttl(), ttl.lat_ttl(), index_name);
     if (!ok) {
-        PDLOG(WARNING, "fail to update ttl with tid %d, pid %d, abs_ttl %lu, lat_ttl %lu, endpoint %s", tid, pid,
-              ttl.abs_ttl(), ttl.lat_ttl(), endpoint.c_str());
+        PDLOG(WARNING, "fail to update ttl with tid %d, pid %d, abs_ttl %lu, lat_ttl %lu, endpoint %s",
+              tid, pid, ttl.abs_ttl(), ttl.lat_ttl(), endpoint.c_str());
     } else {
-        PDLOG(INFO, "update ttl with tid %d pid %d abs_ttl %lu, lat_ttl %lu endpoint %s ok", tid, pid, ttl.abs_ttl(),
-              ttl.lat_ttl(), endpoint.c_str());
+        PDLOG(INFO, "update ttl with tid %d pid %d abs_ttl %lu, lat_ttl %lu endpoint %s ok",
+              tid, pid, ttl.abs_ttl(), ttl.lat_ttl(), endpoint.c_str());
     }
     return ok;
 }
@@ -8332,9 +8346,9 @@ bool NameServerImpl::UpdateZkTableNodeWithoutNotify(const TableInfo* table_info)
     return true;
 }
 
-base::Status NameServerImpl::AddMultiIndexs(
-    const std::string& db, const std::string& name, std::shared_ptr<TableInfo> table_info,
-    const ::google::protobuf::RepeatedPtrField<openmldb::common::ColumnKey>& column_keys) {
+base::Status NameServerImpl::AddMultiIndexs(const std::string& db, const std::string& name,
+        std::shared_ptr<TableInfo> table_info,
+        const ::google::protobuf::RepeatedPtrField<openmldb::common::ColumnKey>& column_keys) {
     auto status = schema::IndexUtil::CheckUnique(column_keys);
     if (!status.OK()) {
         return status;
@@ -8369,7 +8383,8 @@ base::Status NameServerImpl::AddMultiIndexs(
                 return {base::ReturnCode::kError, "endpoint" + meta.endpoint() + ""};
             }
             if (!tablet->client_->AddMultiIndex(tid, pid, indexs, nullptr)) {
-                LOG(WARNING) << "add index failed. tid " << tid << " pid " << pid << " endpoint " << meta.endpoint();
+                LOG(WARNING) << "add index failed. tid " << tid << " pid " << pid <<
+                    " endpoint " << meta.endpoint();
                 return {base::ReturnCode::kError, "add index failed"};
             }
             endpoint_set.insert(meta.endpoint());
@@ -8534,8 +8549,7 @@ void NameServerImpl::AddIndex(RpcController* controller, const AddIndexRequest* 
                 }
                 if (!request->skip_load_data()) {
                     auto ret = tablet_ptr->client_->ExtractIndexData(table_info->tid(), pid,
-                                                                     (uint32_t)table_info->table_partition_size(),
-                                                                     column_key_vec, 0, false, nullptr);
+                                (uint32_t)table_info->table_partition_size(), column_key_vec, 0, false, nullptr);
                     if (!ret) {
                         base::SetResponseStatus(ReturnCode::kAddIndexFailed, "extract multi index failed", response);
                         return;
@@ -8550,8 +8564,8 @@ void NameServerImpl::AddIndex(RpcController* controller, const AddIndexRequest* 
 }
 
 bool NameServerImpl::AddIndexToTableInfo(const std::string& name, const std::string& db,
-                                         const std::vector<::openmldb::common::ColumnKey>& column_key,
-                                         std::shared_ptr<::openmldb::api::TaskInfo> task_info) {
+        const std::vector<::openmldb::common::ColumnKey>& column_key,
+        std::shared_ptr<::openmldb::api::TaskInfo> task_info) {
     std::shared_ptr<::openmldb::nameserver::TableInfo> table_info;
     std::lock_guard<std::mutex> lock(mu_);
     if (!GetTableInfoUnlock(name, db, &table_info)) {
@@ -8594,7 +8608,7 @@ bool NameServerImpl::AddIndexToTableInfo(const std::string& name, const std::str
 }
 
 base::Status NameServerImpl::CreateAddIndexOP(const std::string& name, const std::string& db,
-                                              const std::vector<::openmldb::common::ColumnKey>& column_key) {
+        const std::vector<::openmldb::common::ColumnKey>& column_key) {
     std::shared_ptr<::openmldb::nameserver::TableInfo> table_info;
     if (!GetTableInfoUnlock(name, db, &table_info)) {
         return {-1, "table does not exist"};
@@ -8636,10 +8650,10 @@ base::Status NameServerImpl::CreateAddIndexOPTask(std::shared_ptr<OPData> op_dat
     return FillAddIndexTask(op_index, op_type, name, db, column_key_vec, &op_data->task_list_);
 }
 
-base::Status NameServerImpl::FillAddIndexTask(uint64_t op_index, api::OPType op_type, const std::string& name,
-                                              const std::string& db,
-                                              const std::vector<::openmldb::common::ColumnKey>& column_key,
-                                              std::list<std::shared_ptr<Task>>* task_list) {
+base::Status NameServerImpl::FillAddIndexTask(uint64_t op_index, api::OPType op_type,
+        const std::string& name, const std::string& db,
+        const std::vector<::openmldb::common::ColumnKey>& column_key,
+        std::list<std::shared_ptr<Task>>* task_list) {
     std::shared_ptr<::openmldb::nameserver::TableInfo> table_info;
     if (!GetTableInfoUnlock(name, db, &table_info)) {
         return {-1, absl::StrCat("get table info failed, db ", db, " name ", name)};
@@ -8679,8 +8693,8 @@ base::Status NameServerImpl::FillAddIndexTask(uint64_t op_index, api::OPType op_
         return {-1, "create add index to table info task failed"};
     }
     task_list->push_back(task);
-    task = CreateTask<ExtractIndexDataTaskMeta>(op_index, op_type, tid, part_size, column_key, pid_offset_map,
-                                                pid_endpoint_map);
+    task = CreateTask<ExtractIndexDataTaskMeta>(op_index, op_type, tid, part_size,
+                column_key, pid_offset_map, pid_endpoint_map);
     if (!task) {
         return {-1, "create extract index task failed"};
     }
@@ -8700,8 +8714,8 @@ base::Status NameServerImpl::FillAddIndexTask(uint64_t op_index, api::OPType op_
 
 void NameServerImpl::RunSubTask(std::shared_ptr<Task> task) {
     for (const auto& cur_task : task->sub_task_) {
-        PDLOG(INFO, "task starts running. op_id %lu task type %s %s", cur_task->GetOpId(),
-              cur_task->GetReadableType().c_str(), cur_task->GetAdditionalMsg().c_str());
+        PDLOG(INFO, "task starts running. op_id %lu task type %s %s",
+                cur_task->GetOpId(), cur_task->GetReadableType().c_str(), cur_task->GetAdditionalMsg().c_str());
         cur_task->SetStatus(::openmldb::api::TaskStatus::kDoing);
         cur_task->fun_();
     }
@@ -8709,23 +8723,24 @@ void NameServerImpl::RunSubTask(std::shared_ptr<Task> task) {
 
 void NameServerImpl::RunSeqTask(std::shared_ptr<Task> task) {
     if (task->seq_task_.empty()) {
-        PDLOG(INFO, "update task status from %s to kDone. op_id %lu task_type %s %s", task->GetReadableStatus().c_str(),
-              task->GetOpId(), task->GetReadableType().c_str(), task->GetAdditionalMsg().c_str());
+        PDLOG(INFO, "update task status from %s to kDone. op_id %lu task_type %s %s",
+                task->GetReadableStatus().c_str(), task->GetOpId(),
+                task->GetReadableType().c_str(), task->GetAdditionalMsg().c_str());
         task->SetStatus(::openmldb::api::TaskStatus::kDone);
         return;
     }
     auto cur_task = task->seq_task_.front();
     auto task_status = cur_task->GetStatus();
     if (task_status == ::openmldb::api::TaskStatus::kInited) {
-        PDLOG(INFO, "seq task starts running. op_id %lu task type %s %s", cur_task->GetOpId(),
-              cur_task->GetReadableType().c_str(), cur_task->GetAdditionalMsg().c_str());
+        PDLOG(INFO, "seq task starts running. op_id %lu task type %s %s",
+                cur_task->GetOpId(), cur_task->GetReadableType().c_str(), cur_task->GetAdditionalMsg().c_str());
         cur_task->SetStatus(::openmldb::api::TaskStatus::kDoing);
         cur_task->fun_();
     } else if (task_status == ::openmldb::api::TaskStatus::kFailed ||
-               task_status == ::openmldb::api::TaskStatus::kCanceled) {
-        PDLOG(INFO, "update task status from %s to %s. op_id %lu task_type %s %s", task->GetReadableStatus().c_str(),
-              cur_task->GetReadableStatus().c_str(), task->GetOpId(), task->GetReadableType().c_str(),
-              task->GetAdditionalMsg().c_str());
+            task_status == ::openmldb::api::TaskStatus::kCanceled) {
+        PDLOG(INFO, "update task status from %s to %s. op_id %lu task_type %s %s",
+                task->GetReadableStatus().c_str(), cur_task->GetReadableStatus().c_str(),
+                task->GetOpId(), task->GetReadableType().c_str(), task->GetAdditionalMsg().c_str());
         task->SetStatus(task_status);
         return;
     } else if (task_status == ::openmldb::api::TaskStatus::kDone) {
@@ -8792,7 +8807,7 @@ base::Status NameServerImpl::CreateDatabase(const std::string& db_name, bool if_
                     continue;
                 }
                 auto status = std::atomic_load_explicit(&kv.second->client_, std::memory_order_relaxed)
-                                  ->CreateDatabaseRemote(db_name, zone_info_);
+                        ->CreateDatabaseRemote(db_name, zone_info_);
                 if (!status.OK()) {
                     PDLOG(WARNING, "create remote database failed, msg is [%s]", status.msg.c_str());
                     return status;
@@ -8837,7 +8852,7 @@ void NameServerImpl::ShowDatabase(RpcController* controller, const GeneralReques
     {
         std::lock_guard<std::mutex> lock(mu_);
         for (const auto& db : databases_) {
-            if (db != INTERNAL_DB && db != INFORMATION_SCHEMA_DB && db != PRE_AGG_DB) {
+            if (db != INTERNAL_DB && db != INFORMATION_SCHEMA_DB && db!= PRE_AGG_DB) {
                 response->add_db(db);
             }
         }
@@ -8908,7 +8923,7 @@ void NameServerImpl::DropDatabase(RpcController* controller, const DropDatabaseR
                 continue;
             }
             auto status = std::atomic_load_explicit(&kv.second->client_, std::memory_order_relaxed)
-                              ->DropDatabaseRemote(request->db(), zone_info_);
+                    ->DropDatabaseRemote(request->db(), zone_info_);
             if (!status.OK()) {
                 PDLOG(WARNING, "drop remote database failed, msg is [%s]", status.msg.c_str());
                 ::openmldb::base::SetResponseStatus(status, response);
@@ -9207,7 +9222,7 @@ base::Status NameServerImpl::CreateProcedureInternal(const api::CreateProcedureR
     auto sp_info = std::make_shared<api::ProcedureInfo>(sp_request.sp_info());
     const std::string& sp_db_name = sp_info->db_name();
     const std::string& sp_name = sp_info->sp_name();
-    const std::string sp_data_path = absl::StrCat(zk_path_.db_sp_data_path_, "/", sp_db_name, ".", sp_name);
+    const std::string sp_data_path = absl::StrCat(zk_path_.db_sp_data_path_ , "/", sp_db_name, ".", sp_name);
     auto status = CreateProcedureOnTablet(sp_request);
     do {
         if (!status.OK()) {
@@ -9717,8 +9732,8 @@ void NameServerImpl::CreateFunction(RpcController* controller, const CreateFunct
     for (const auto& tablet : tablets) {
         std::string msg;
         if (!tablet->client_->CreateFunction(request->fun(), &msg)) {
-            PDLOG(WARNING, "create function failed. endpoint %s, msg %s", tablet->client_->GetEndpoint().c_str(),
-                  msg.c_str());
+            PDLOG(WARNING, "create function failed. endpoint %s, msg %s",
+                    tablet->client_->GetEndpoint().c_str(), msg.c_str());
             response->set_msg(msg);
             break;
         }
@@ -9740,8 +9755,8 @@ void NameServerImpl::CreateFunction(RpcController* controller, const CreateFunct
         fun->SerializeToString(&value);
         std::string fun_node = zk_path_.external_function_path_ + "/" + fun->name();
         if (!zk_client_->CreateNode(fun_node, value)) {
-            PDLOG(WARNING, "create function node[%s] failed! value[%s] value_size[%u]", fun_node.c_str(), value.c_str(),
-                  value.length());
+            PDLOG(WARNING, "create function node[%s] failed! value[%s] value_size[%u]",
+                  fun_node.c_str(), value.c_str(), value.length());
             return;
         }
     }
@@ -9752,7 +9767,7 @@ void NameServerImpl::CreateFunction(RpcController* controller, const CreateFunct
 }
 
 void NameServerImpl::DropFunction(RpcController* controller, const DropFunctionRequest* request,
-                                  DropFunctionResponse* response, Closure* done) {
+                                    DropFunctionResponse* response, Closure* done) {
     brpc::ClosureGuard done_guard(done);
     response->set_code(base::kRPCRunError);
     std::shared_ptr<::openmldb::common::ExternalFun> fun;
@@ -9796,7 +9811,7 @@ void NameServerImpl::DropFunction(RpcController* controller, const DropFunctionR
 }
 
 void NameServerImpl::ShowFunction(RpcController* controller, const ShowFunctionRequest* request,
-                                  ShowFunctionResponse* response, Closure* done) {
+                                    ShowFunctionResponse* response, Closure* done) {
     brpc::ClosureGuard done_guard(done);
     std::lock_guard<std::mutex> lock(mu_);
     if (request->has_name() && !request->name().empty()) {
@@ -9814,7 +9829,11 @@ void NameServerImpl::ShowFunction(RpcController* controller, const ShowFunctionR
 
 base::Status NameServerImpl::InitGlobalVarTable() {
     std::map<std::string, std::string> default_value = {
-        {"execute_mode", "offline"}, {"enable_trace", "false"}, {"sync_job", "false"}, {"job_timeout", "20000"}};
+        {"execute_mode", "offline"},
+        {"enable_trace", "false"},
+        {"sync_job", "false"},
+        {"job_timeout", "20000"}
+    };
     // get table_info
     std::string db = INFORMATION_SCHEMA_DB;
     std::string table = GLOBAL_VARIABLES;
@@ -9981,7 +10000,8 @@ void NameServerImpl::SyncDeployStats() {
         }
 
         std::string time = row->GetTimeAsStr(statistics::TimeUnit::SECOND);
-        auto insert_sql = absl::StrCat(insert_deploy_stat, " ( '", row->deploy_name_, "', '", time, "', ", row->count_,
+        auto insert_sql = absl::StrCat(insert_deploy_stat, " ( '", row->deploy_name_, "', '",
+                                       time, "', ", row->count_,
                                        ",'", row->GetTotalAsStr(statistics::TimeUnit::SECOND), "' )");
 
         hybridse::sdk::Status st;
@@ -10073,7 +10093,8 @@ std::shared_ptr<Task> NameServerImpl::CreateTaskInternal(const TaskMeta* task_me
         case ::openmldb::api::TaskType::kMakeSnapshot: {
             auto meta = dynamic_cast<const MakeSnapshotTaskMeta*>(task_meta);
             boost::function<bool()> fun =
-                boost::bind(&TabletClient::MakeSnapshot, client, meta->tid, meta->pid, meta->end_offset, task_info);
+                boost::bind(&TabletClient::MakeSnapshot, client,
+                        meta->tid, meta->pid, meta->end_offset, task_info);
             task->fun_ = boost::bind(&NameServerImpl::WrapTaskFun, this, fun, task_info);
             break;
         }
@@ -10093,8 +10114,9 @@ std::shared_ptr<Task> NameServerImpl::CreateTaskInternal(const TaskMeta* task_me
         }
         case ::openmldb::api::TaskType::kSendSnapshot: {
             auto meta = dynamic_cast<const SendSnapshotTaskMeta*>(task_meta);
-            boost::function<bool()> fun = boost::bind(&TabletClient::SendSnapshot, client, meta->tid, meta->remote_tid,
-                                                      meta->pid, meta->des_endpoint, task_info);
+            boost::function<bool()> fun =
+                boost::bind(&TabletClient::SendSnapshot, client, meta->tid, meta->remote_tid,
+                        meta->pid, meta->des_endpoint, task_info);
             task->fun_ = boost::bind(&NameServerImpl::WrapTaskFun, this, fun, task_info);
             break;
         }
@@ -10111,7 +10133,8 @@ std::shared_ptr<Task> NameServerImpl::CreateTaskInternal(const TaskMeta* task_me
             } else {
                 table_meta.set_mode(::openmldb::api::TableMode::kTableFollower);
             }
-            boost::function<bool()> fun = boost::bind(&TabletClient::LoadTable, client, table_meta, task_info);
+            boost::function<bool()> fun =
+                boost::bind(&TabletClient::LoadTable, client, table_meta, task_info);
             task->fun_ = boost::bind(&NameServerImpl::WrapTaskFun, this, fun, task_info);
             break;
         }
@@ -10122,11 +10145,11 @@ std::shared_ptr<Task> NameServerImpl::CreateTaskInternal(const TaskMeta* task_me
                 if (meta->task_id != INVALID_PARENT_ID) {
                     task_info->set_task_id(meta->task_id);
                 }
-                fun = boost::bind(&TabletClient::AddReplica, client, meta->tid, meta->pid, meta->des_endpoint,
-                                  meta->remote_tid, task_info);
+                fun = boost::bind(&TabletClient::AddReplica, client,
+                        meta->tid, meta->pid, meta->des_endpoint, meta->remote_tid, task_info);
             } else {
-                fun =
-                    boost::bind(&TabletClient::AddReplica, client, meta->tid, meta->pid, meta->des_endpoint, task_info);
+                fun = boost::bind(&TabletClient::AddReplica, client,
+                        meta->tid, meta->pid, meta->des_endpoint, task_info);
             }
             task->fun_ = boost::bind(&NameServerImpl::WrapTaskFun, this, fun, task_info);
             break;
@@ -10148,44 +10171,46 @@ std::shared_ptr<Task> NameServerImpl::CreateTaskInternal(const TaskMeta* task_me
         case ::openmldb::api::TaskType::kAddTableInfo: {
             auto meta = dynamic_cast<const AddTableInfoTaskMeta*>(task_meta);
             if (meta->is_remote) {
-                task->fun_ = boost::bind(&NameServerImpl::AddTableInfo, this, meta->alias, meta->endpoint, meta->name,
-                                         meta->db, meta->remote_tid, meta->pid, task_info);
+                task->fun_ = boost::bind(&NameServerImpl::AddTableInfo, this,
+                        meta->alias, meta->endpoint, meta->name, meta->db,
+                        meta->remote_tid, meta->pid, task_info);
             } else {
-                task->fun_ = boost::bind(&NameServerImpl::AddTableInfo, this, meta->name, meta->db, meta->endpoint,
-                                         meta->pid, task_info);
+                task->fun_ = boost::bind(&NameServerImpl::AddTableInfo, this,
+                        meta->name, meta->db, meta->endpoint, meta->pid, task_info);
             }
             break;
         }
         case ::openmldb::api::TaskType::kDelTableInfo: {
             auto meta = dynamic_cast<const DelTableInfoTaskMeta*>(task_meta);
             if (meta->has_flag) {
-                task->fun_ = boost::bind(&NameServerImpl::DelTableInfo, this, meta->name, meta->db, meta->endpoint,
-                                         meta->pid, task_info, meta->flag);
+                task->fun_ = boost::bind(&NameServerImpl::DelTableInfo, this,
+                        meta->name, meta->db, meta->endpoint, meta->pid, task_info, meta->flag);
             } else {
-                task->fun_ = boost::bind(&NameServerImpl::DelTableInfo, this, meta->name, meta->db, meta->endpoint,
-                                         meta->pid, task_info);
+                task->fun_ = boost::bind(&NameServerImpl::DelTableInfo, this,
+                        meta->name, meta->db, meta->endpoint, meta->pid, task_info);
             }
             break;
         }
         case ::openmldb::api::TaskType::kUpdateTableInfo: {
             auto meta = dynamic_cast<const UpdateTableInfoTaskMeta*>(task_meta);
-            task->fun_ = boost::bind(&NameServerImpl::UpdateTableInfo, this, meta->src_endpoint, meta->name, meta->db,
-                                     meta->pid, meta->des_endpoint, task_info);
+            task->fun_ = boost::bind(&NameServerImpl::UpdateTableInfo, this,
+                    meta->src_endpoint, meta->name, meta->db, meta->pid, meta->des_endpoint, task_info);
             break;
         }
         case ::openmldb::api::TaskType::kSendIndexRequest: {
             auto meta = dynamic_cast<const SendIndexRequestTaskMeta*>(task_meta);
-            boost::function<bool()> fun = boost::bind(&TabletClient::SendIndexData, client, meta->tid, meta->pid,
-                                                      meta->pid_endpoint_map, task_info);
+            boost::function<bool()> fun =
+                boost::bind(&TabletClient::SendIndexData, client, meta->tid, meta->pid,
+                        meta->pid_endpoint_map, task_info);
             task->fun_ = boost::bind(&NameServerImpl::WrapTaskFun, this, fun, task_info);
             break;
         }
         case ::openmldb::api::TaskType::kSendIndexData: {
             auto meta = dynamic_cast<const SendIndexDataTaskMeta*>(task_meta);
             for (const auto& kv : meta->pid_endpoint_map) {
-                auto sub_task =
-                    CreateTask<SendIndexRequestTaskMeta>(meta->task_info->op_id(), meta->task_info->op_type(),
-                                                         kv.second, meta->tid, kv.first, meta->pid_endpoint_map);
+                auto sub_task = CreateTask<SendIndexRequestTaskMeta>(
+                            meta->task_info->op_id(), meta->task_info->op_type(), kv.second,
+                            meta->tid, kv.first, meta->pid_endpoint_map);
                 task->sub_task_.push_back(sub_task);
                 PDLOG(INFO, "add subtask kSendIndexData. op_id[%lu] tid[%u] pid[%u] endpoint[%s]",
                       meta->task_info->op_id(), meta->tid, kv.first, kv.second.c_str());
@@ -10196,16 +10221,17 @@ std::shared_ptr<Task> NameServerImpl::CreateTaskInternal(const TaskMeta* task_me
         case ::openmldb::api::TaskType::kLoadIndexRequest: {
             auto meta = dynamic_cast<const LoadIndexRequestTaskMeta*>(task_meta);
             boost::function<bool()> fun =
-                boost::bind(&TabletClient::LoadIndexData, client, meta->tid, meta->pid, meta->partition_num, task_info);
+                boost::bind(&TabletClient::LoadIndexData, client, meta->tid, meta->pid,
+                        meta->partition_num, task_info);
             task->fun_ = boost::bind(&NameServerImpl::WrapTaskFun, this, fun, task_info);
             break;
         }
         case ::openmldb::api::TaskType::kLoadIndexData: {
             auto meta = dynamic_cast<const LoadIndexDataTaskMeta*>(task_meta);
             for (const auto& kv : meta->pid_endpoint_map) {
-                auto sub_task =
-                    CreateTask<LoadIndexRequestTaskMeta>(meta->task_info->op_id(), meta->task_info->op_type(),
-                                                         kv.second, meta->tid, kv.first, meta->pid_endpoint_map.size());
+                auto sub_task = CreateTask<LoadIndexRequestTaskMeta>(
+                            meta->task_info->op_id(), meta->task_info->op_type(), kv.second,
+                            meta->tid, kv.first, meta->pid_endpoint_map.size());
                 task->sub_task_.push_back(sub_task);
                 PDLOG(INFO, "add subtask kLoadIndexData. op_id[%lu] tid[%u] pid[%u] endpoint[%s]",
                       meta->task_info->op_id(), meta->tid, kv.first, kv.second.c_str());
@@ -10216,8 +10242,8 @@ std::shared_ptr<Task> NameServerImpl::CreateTaskInternal(const TaskMeta* task_me
         case ::openmldb::api::TaskType::kExtractIndexRequest: {
             auto meta = dynamic_cast<const ExtractIndexRequestTaskMeta*>(task_meta);
             boost::function<bool()> fun =
-                boost::bind(&TabletClient::ExtractIndexData, client, meta->tid, meta->pid, meta->partition_num,
-                            meta->column_key, meta->offset, true, task_info);
+                boost::bind(&TabletClient::ExtractIndexData, client, meta->tid, meta->pid,
+                        meta->partition_num, meta->column_key, meta->offset, true, task_info);
             task->fun_ = boost::bind(&NameServerImpl::WrapTaskFun, this, fun, task_info);
             break;
         }
@@ -10226,8 +10252,9 @@ std::shared_ptr<Task> NameServerImpl::CreateTaskInternal(const TaskMeta* task_me
             for (const auto& kv : meta->pid_endpoint_map) {
                 auto iter = meta->pid_offset_map.find(kv.first);
                 auto sub_task = CreateTask<ExtractIndexRequestTaskMeta>(
-                    meta->task_info->op_id(), meta->task_info->op_type(), kv.second, meta->tid, kv.first,
-                    meta->partition_num, meta->column_key, iter->second);
+                            meta->task_info->op_id(), meta->task_info->op_type(), kv.second,
+                            meta->tid, kv.first, meta->partition_num, meta->column_key,
+                            iter->second);
                 task->sub_task_.push_back(sub_task);
                 PDLOG(INFO, "add subtask kExtractIndexData. op_id[%lu] tid[%u] pid[%u] endpoint[%s]",
                       meta->task_info->op_id(), meta->tid, kv.first, kv.second.c_str());
@@ -10238,7 +10265,8 @@ std::shared_ptr<Task> NameServerImpl::CreateTaskInternal(const TaskMeta* task_me
         case ::openmldb::api::TaskType::kAddIndexToTabletRequest: {
             auto meta = dynamic_cast<const AddIndexToTabletRequestTaskMeta*>(task_meta);
             boost::function<bool()> fun =
-                boost::bind(&TabletClient::AddMultiIndex, client, meta->tid, meta->pid, meta->column_key, task_info);
+                boost::bind(&TabletClient::AddMultiIndex, client, meta->tid, meta->pid,
+                        meta->column_key, task_info);
             task->fun_ = boost::bind(&NameServerImpl::WrapTaskFun, this, fun, task_info);
             break;
         }
@@ -10248,8 +10276,8 @@ std::shared_ptr<Task> NameServerImpl::CreateTaskInternal(const TaskMeta* task_me
                 for (const auto& part_meta : part.partition_meta()) {
                     const std::string& ep = part_meta.endpoint();
                     auto sub_task = CreateTask<AddIndexToTabletRequestTaskMeta>(
-                        meta->task_info->op_id(), meta->task_info->op_type(), ep, meta->table_info.tid(), part.pid(),
-                        meta->column_key);
+                                meta->task_info->op_id(), meta->task_info->op_type(), ep,
+                                meta->table_info.tid(), part.pid(), meta->column_key);
                     task->sub_task_.push_back(sub_task);
                     PDLOG(INFO, "add subtask AddIndexToTablet. op_id[%lu] tid[%u] pid[%u] endpoint[%s]",
                           meta->task_info->op_id(), meta->table_info.tid(), part.pid(), ep.c_str());
@@ -10260,14 +10288,14 @@ std::shared_ptr<Task> NameServerImpl::CreateTaskInternal(const TaskMeta* task_me
         }
         case ::openmldb::api::TaskType::kAddIndexToTableInfo: {
             auto meta = dynamic_cast<const AddIndexToTableInfoTaskMeta*>(task_meta);
-            task->fun_ = boost::bind(&NameServerImpl::AddIndexToTableInfo, this, meta->name, meta->db, meta->column_key,
-                                     task_info);
+            task->fun_ = boost::bind(&NameServerImpl::AddIndexToTableInfo, this,
+                    meta->name, meta->db, meta->column_key, task_info);
             break;
         }
         case ::openmldb::api::TaskType::kCheckBinlogSyncProgress: {
             auto meta = dynamic_cast<const CheckBinlogSyncProgressTaskMeta*>(task_meta);
-            task->fun_ = boost::bind(&NameServerImpl::CheckBinlogSyncProgress, this, meta->name, meta->db, meta->pid,
-                                     meta->follower, meta->offset_delta, task_info);
+            task->fun_ = boost::bind(&NameServerImpl::CheckBinlogSyncProgress, this,
+                    meta->name, meta->db, meta->pid, meta->follower, meta->offset_delta, task_info);
             break;
         }
         case ::openmldb::api::TaskType::kChangeLeader: {
@@ -10276,8 +10304,8 @@ std::shared_ptr<Task> NameServerImpl::CreateTaskInternal(const TaskMeta* task_me
         }
         case ::openmldb::api::TaskType::kSelectLeader: {
             auto meta = dynamic_cast<const SelectLeaderTaskMeta*>(task_meta);
-            task->fun_ = boost::bind(&NameServerImpl::SelectLeader, this, meta->name, meta->db, meta->tid, meta->pid,
-                                     meta->follower_endpoint, task_info);
+            task->fun_ = boost::bind(&NameServerImpl::SelectLeader, this, meta->name, meta->db,
+                    meta->tid, meta->pid, meta->follower_endpoint, task_info);
             break;
         }
         case ::openmldb::api::TaskType::kUpdateLeaderInfo: {
@@ -10286,22 +10314,22 @@ std::shared_ptr<Task> NameServerImpl::CreateTaskInternal(const TaskMeta* task_me
         }
         case ::openmldb::api::TaskType::kRecoverTable: {
             auto meta = dynamic_cast<const RecoverTableTaskMeta*>(task_meta);
-            task->fun_ = boost::bind(&NameServerImpl::RecoverEndpointTable, this, meta->name, meta->db, meta->pid,
-                                     meta->endpoint, meta->offset_delta, meta->concurrency, task_info);
+            task->fun_ = boost::bind(&NameServerImpl::RecoverEndpointTable, this, meta->name, meta->db,
+                    meta->pid, meta->endpoint, meta->offset_delta, meta->concurrency, task_info);
             break;
         }
         case ::openmldb::api::TaskType::kUpdatePartitionStatus: {
             auto meta = dynamic_cast<const UpdatePartitionStatusTaskMeta*>(task_meta);
-            task->fun_ = boost::bind(&NameServerImpl::UpdatePartitionStatus, this, meta->name, meta->db, meta->endpoint,
-                                     meta->pid, meta->is_leader, meta->is_alive, task_info);
+            task->fun_ = boost::bind(&NameServerImpl::UpdatePartitionStatus, this, meta->name, meta->db,
+                    meta->endpoint, meta->pid, meta->is_leader, meta->is_alive, task_info);
             break;
         }
         case ::openmldb::api::TaskType::kCreateTableRemote: {
             auto meta = dynamic_cast<const CreateTableRemoteTaskMeta*>(task_meta);
             auto cluster = GetHealthCluster(meta->alias);
             if (!cluster) {
-                PDLOG(WARNING, "replica[%s] not available op_index[%lu]", meta->alias.c_str(),
-                      meta->task_info->op_id());
+                PDLOG(WARNING, "replica[%s] not available op_index[%lu]",
+                        meta->alias.c_str(), meta->task_info->op_id());
                 return {};
             }
             std::string cluster_endpoint =
@@ -10316,8 +10344,8 @@ std::shared_ptr<Task> NameServerImpl::CreateTaskInternal(const TaskMeta* task_me
             auto meta = dynamic_cast<const DropTableRemoteTaskMeta*>(task_meta);
             auto cluster = GetHealthCluster(meta->alias);
             if (!cluster) {
-                PDLOG(WARNING, "replica[%s] not available op_index[%lu]", meta->alias.c_str(),
-                      meta->task_info->op_id());
+                PDLOG(WARNING, "replica[%s] not available op_index[%lu]",
+                        meta->alias.c_str(), meta->task_info->op_id());
                 return {};
             }
             std::string cluster_endpoint =
@@ -10332,26 +10360,26 @@ std::shared_ptr<Task> NameServerImpl::CreateTaskInternal(const TaskMeta* task_me
             auto meta = dynamic_cast<const AddReplicaNSRemoteTaskMeta*>(task_meta);
             auto cluster = GetHealthCluster(meta->alias);
             if (!cluster) {
-                PDLOG(WARNING, "replica[%s] not available op_index[%lu]", meta->alias.c_str(),
-                      meta->task_info->op_id());
+                PDLOG(WARNING, "replica[%s] not available op_index[%lu]",
+                        meta->alias.c_str(), meta->task_info->op_id());
                 return {};
             }
             std::string cluster_endpoint =
                 std::atomic_load_explicit(&cluster->client_, std::memory_order_relaxed)->GetEndpoint();
             task->task_info_->set_endpoint(cluster_endpoint);
-            boost::function<bool()> fun = boost::bind(
-                &NsClient::AddReplicaNS, std::atomic_load_explicit(&cluster->client_, std::memory_order_relaxed),
-                meta->name, meta->endpoint_vec, meta->pid, zone_info_, *task_info);
+            boost::function<bool()> fun = boost::bind(&NsClient::AddReplicaNS,
+                    std::atomic_load_explicit(&cluster->client_, std::memory_order_relaxed),
+                    meta->name, meta->endpoint_vec, meta->pid, zone_info_, *task_info);
             task->fun_ = boost::bind(&NameServerImpl::WrapTaskFun, this, fun, task_info);
             break;
         }
         case ::openmldb::api::TaskType::kAddTableIndex: {
             auto meta = dynamic_cast<const AddTableIndexTaskMeta*>(task_meta);
-            auto status = FillAddIndexTask(meta->task_info->op_id(), meta->task_info->op_type(), meta->name, meta->db,
-                                           meta->column_key, &task->seq_task_);
+            auto status = FillAddIndexTask(meta->task_info->op_id(), meta->task_info->op_type(),
+                    meta->name, meta->db, meta->column_key, &task->seq_task_);
             if (!status.OK()) {
-                PDLOG(WARNING, "FillAddIndexTask failed. op_id %lu msg %s", meta->task_info->op_id(),
-                      status.GetMsg().c_str());
+                PDLOG(WARNING, "FillAddIndexTask failed. op_id %lu msg %s",
+                        meta->task_info->op_id(), status.GetMsg().c_str());
                 return {};
             }
             task->fun_ = boost::bind(&NameServerImpl::RunSeqTask, this, task);
@@ -10361,14 +10389,15 @@ std::shared_ptr<Task> NameServerImpl::CreateTaskInternal(const TaskMeta* task_me
             auto meta = dynamic_cast<const AddMultiTableIndexTaskMeta*>(task_meta);
             for (const auto& cur_table_index : meta->table_index) {
                 auto sub_task = CreateTask<AddTableIndexTaskMeta>(
-                    meta->task_info->op_id(), meta->task_info->op_type(), cur_table_index.name(), cur_table_index.db(),
-                    schema::IndexUtil::Convert2Vector(cur_table_index.column_key()));
+                            meta->task_info->op_id(), meta->task_info->op_type(),
+                            cur_table_index.name(), cur_table_index.db(),
+                            schema::IndexUtil::Convert2Vector(cur_table_index.column_key()));
                 if (!sub_task) {
                     return {};
                 }
                 task->sub_task_.push_back(sub_task);
-                PDLOG(INFO, "add subtask kAddTableIndex. op_id[%lu] table name %s db %s", meta->task_info->op_id(),
-                      cur_table_index.name().c_str(), cur_table_index.db().c_str());
+                PDLOG(INFO, "add subtask kAddTableIndex. op_id[%lu] table name %s db %s",
+                      meta->task_info->op_id(), cur_table_index.name().c_str(), cur_table_index.db().c_str());
             }
             task->fun_ = boost::bind(&NameServerImpl::RunSubTask, this, task);
             break;
@@ -10377,14 +10406,14 @@ std::shared_ptr<Task> NameServerImpl::CreateTaskInternal(const TaskMeta* task_me
             auto meta = dynamic_cast<const CreateProcedureTaskMeta*>(task_meta);
             api::CreateProcedureRequest request;
             request.mutable_sp_info()->CopyFrom(meta->sp_info);
-            boost::function<base::Status()> wrap_fun =
-                boost::bind(&NameServerImpl::CreateProcedureInternal, this, request);
+            boost::function<base::Status()> wrap_fun = boost::bind(&NameServerImpl::CreateProcedureInternal,
+                    this, request);
             task->fun_ = boost::bind(&NameServerImpl::WrapNormalTaskFun, this, wrap_fun, task_info);
             break;
         }
-        case ::openmldb::api::TaskType::kDumpIndexData:     // deprecated
+        case ::openmldb::api::TaskType::kDumpIndexData:  // deprecated
         case ::openmldb::api::TaskType::kUpdateTableAlive:  // deprecated
-        case ::openmldb::api::TaskType::kTableSyncTask:     // deprecated
+        case ::openmldb::api::TaskType::kTableSyncTask:  // deprecated
             break;
     }
     return task;
@@ -10407,8 +10436,8 @@ bool NameServerImpl::IsExistDataBase(const std::string& db) {
     return databases_.find(db) != databases_.end();
 }
 
-void NameServerImpl::DeploySQL(RpcController* controller, const DeploySQLRequest* request, DeploySQLResponse* response,
-                               Closure* done) {
+void NameServerImpl::DeploySQL(RpcController* controller, const DeploySQLRequest* request,
+                                     DeploySQLResponse* response, Closure* done) {
     brpc::ClosureGuard done_guard(done);
     if (!running_.load(std::memory_order_acquire)) {
         response->set_code(::openmldb::base::ReturnCode::kNameserverIsNotLeader);
@@ -10425,7 +10454,7 @@ void NameServerImpl::DeploySQL(RpcController* controller, const DeploySQLRequest
         return;
     }
     if (auto procedure = GetProcedure(db, deploy_name);
-        procedure && procedure->type() == ::openmldb::type::ProcedureType::kReqDeployment) {
+            procedure && procedure->type() == ::openmldb::type::ProcedureType::kReqDeployment) {
         base::SetResponseStatus(ReturnCode::kProcedureAlreadyExists, "deployment already exists", response);
         PDLOG(WARNING, "deployment[%s] already exists in db[%s]", deploy_name.c_str(), db.c_str());
         return;

--- a/src/nameserver/name_server_impl.cc
+++ b/src/nameserver/name_server_impl.cc
@@ -17,16 +17,15 @@
 #include "nameserver/name_server_impl.h"
 
 #include <algorithm>
-#include <set>
-#include <random>
-#include <iterator>
 #include <iostream>
+#include <iterator>
+#include <random>
+#include <set>
 #include <vector>
 
-
+#include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"
-#include "absl/strings/numbers.h"
 #include "absl/time/time.h"
 #include "nameserver/system_table.h"
 #include "sdk/db_sdk.h"
@@ -44,10 +43,10 @@
 #include "base/strings.h"
 #include "boost/algorithm/string.hpp"
 #include "boost/bind.hpp"
+#include "codec/row_codec.h"
 #include "gflags/gflags.h"
 #include "schema/index_util.h"
 #include "schema/schema_adapter.h"
-#include "codec/row_codec.h"
 
 DECLARE_string(endpoint);
 DECLARE_string(zk_cluster);
@@ -74,7 +73,6 @@ DECLARE_int32(make_snapshot_check_interval);
 DECLARE_bool(use_name);
 DECLARE_bool(enable_distsql);
 DECLARE_uint32(sync_deploy_stats_timeout);
-
 
 namespace openmldb {
 namespace nameserver {

--- a/src/nameserver/name_server_impl.h
+++ b/src/nameserver/name_server_impl.h
@@ -654,6 +654,7 @@ class NameServerImpl : public NameServer {
 
     void DropProcedureOnTablet(const std::string& db_name, const std::string& sp_name);
 
+    std::shared_ptr<TabletInfo> GetTabletUnlock(const std::string& endpoint);
     std::shared_ptr<TabletInfo> GetTablet(const std::string& endpoint);
 
     std::vector<std::shared_ptr<TabletInfo>> GetAllHealthTablet();

--- a/src/test/util.cc
+++ b/src/test/util.cc
@@ -182,7 +182,7 @@ void ProcessSQLs(sdk::SQLRouter* sr, std::initializer_list<absl::string_view> sq
     hybridse::sdk::Status status;
     for (auto sql : sqls) {
         sr->ExecuteSQL(std::string(sql), &status);
-        EXPECT_TRUE(status.IsOK()) << "running sql=" << sql << " failed: code=" << status.code << ", msg=" << status.msg
+        ASSERT_TRUE(status.IsOK()) << "running sql=" << sql << " failed: code=" << status.code << ", msg=" << status.msg
                                    << "\n"
                                    << status.trace;
     }

--- a/src/test/util.cc
+++ b/src/test/util.cc
@@ -190,7 +190,7 @@ void ProcessSQLs(sdk::SQLRouter* sr, std::initializer_list<absl::string_view> sq
 
 void ExpectResultSetStrEq(const std::vector<std::vector<CellExpectInfo>>& expect, hybridse::sdk::ResultSet* rs,
                           bool ordered) {
-    ASSERT_EQ(expect.size(), rs->Size() + 1);
+    ASSERT_EQ(expect.size(), static_cast<uint64_t>(rs->Size()) + 1);
     size_t idx = 0;
     // schema check
     ASSERT_EQ(expect.front().size(), rs->GetSchema()->GetColumnCnt());

--- a/src/test/util.cc
+++ b/src/test/util.cc
@@ -182,7 +182,7 @@ void ProcessSQLs(sdk::SQLRouter* sr, std::initializer_list<absl::string_view> sq
     hybridse::sdk::Status status;
     for (auto sql : sqls) {
         sr->ExecuteSQL(std::string(sql), &status);
-        ASSERT_TRUE(status.IsOK()) << "running sql=" << sql << " failed: code=" << status.code << ", msg=" << status.msg
+        EXPECT_TRUE(status.IsOK()) << "running sql=" << sql << " failed: code=" << status.code << ", msg=" << status.msg
                                    << "\n"
                                    << status.trace;
     }


### PR DESCRIPTION
cicd workflow cpp job failed on deploy, cuz tablet may overwrite index by old zk info(slow notify, and no version, so it replace new), so make tablet sync zk info after zk info update.