### PR TITLE
build(coverage): enable `TESTING_ENABLE_STRIP` for coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,6 +41,7 @@ jobs:
       SQL_JAVASDK_ENABLE: OFF
       NPROC: 2
       BUILD_SHARED_LIBS: ON
+      TESTING_ENABLE_STRIP: ON
     steps:
       - uses: actions/checkout@v3
         with:
@@ -60,7 +61,7 @@ jobs:
 
       - name: coverage configure
         run: |
-          make coverage-configure COVERAGE_NO_DEPS=ON
+          make coverage-configure
 
       - name: start service
         run: |
@@ -68,28 +69,7 @@ jobs:
       # make coverage-cpp will gen 16G build/ (no run), run test will take 2G more, so split make and test
       - name: Coverage CPP
         run: |
-          # rm some irrelevant files
-          rm -rf .deps/build
-          # only build tests: no build output by ctest, so we use cmake
-          # ctest --build-and-test . build --build-nocmake --build-generator "Unix Makefiles" -j $NPROC
-
-          # split make too, delete irrelavant files in the middle
-          cmake --build build --target help | grep -Eo "\S+_test$" | awk '{if(NR <80) printf(" %s ",$0)}' | xargs cmake --build build -j $NPROC --target
-          # rm some in the middle, leave ~7.4G
-          rm -f build/bin/* # no need anymore
-          find build -name "*.a" -type f -delete
-          du -d 1 -h build
-          df -h
-          cmake --build build --target help | grep -Eo "\S+_test$" | awk '{if(NR >=80) printf(" %s ",$0)}' | xargs cmake --build build -j $NPROC --target
-          # ~11G
-          # rm some irrelevant files, *.dir/Makefile/*.make can't be deleted, test in bin won't test by coverage
-          rm -f build/bin/*
-          find build \( -name "*.a" -o -name "*.o" -o -name "*.o.d" -o -name "cmake*.cmake" \) -delete
-          du -d 1 -h build
-          df -h
-          # Makefile target coverage, not the cmake target(won't build tests again), total 119(120-api_server_test)
-          cd build
-          SQL_CASE_BASE_DIR=$(pwd)/.. YAML_CASE_BASE_DIR=$(pwd)/.. make coverage
+          make coverage-cpp
 
       - name: debug
         if: always()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,18 +51,15 @@ function(compile_lib LIB_NAME DIR DEPEND_FILE_LIST)
     add_library(${LIB_NAME} STATIC ${FILE_LIST} $<TARGET_OBJECTS:openmldb_proto>)
 endfunction(compile_lib)
 
+set(TEST_LIBS
+    openmldb_test_base apiserver nameserver tablet query_response_time openmldb_sdk
+    openmldb_catalog schema client zk_client storage replica base openmldb_codec openmldb_proto log
+    common zookeeper_mt tcmalloc_minimal ${RocksDB_LIB} ${VM_LIBS} ${LLVM_LIBS} ${ZETASQL_LIBS} ${BRPC_LIBS})
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.1")
+    # GNU implementation prior to 9.1 requires linking with -lstdc++fs
+    list(APPEND TEST_LIBS stdc++fs)
+endif()
 function(compile_test_with_extra DIR DEPEND_FILE_LIST)
-    set(TEST_LIBS
-        openmldb_test_base
-        apiserver nameserver tablet query_response_time openmldb_sdk openmldb_catalog
-        schema client zk_client storage replica base openmldb_codec openmldb_proto log
-        common zookeeper_mt tcmalloc_minimal ${RocksDB_LIB}
-        ${VM_LIBS} ${LLVM_LIBS} ${ZETASQL_LIBS} ${BRPC_LIBS})
-
-    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.1")
-        # GNU implementation prior to 9.1 requires linking with -lstdc++fs
-        list(APPEND TEST_LIBS stdc++fs)
-    endif()
     file(GLOB_RECURSE SRC_FILES ${DIR}/*.cc)
     foreach(SRC_FILE ${SRC_FILES})
         if (SRC_FILE MATCHES ".*_test.cc")
@@ -88,6 +85,9 @@ function(compile_test_with_extra DIR DEPEND_FILE_LIST)
             add_test(${TEST_TARGET_NAME}
                 ${CMAKE_CURRENT_BINARY_DIR}/${TEST_TARGET_DIR}/${TEST_TARGET_NAME}
                 --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/${TEST_TARGET_DIR}/${TEST_TARGET_NAME}.xml)
+            if (TESTING_ENABLE_STRIP)
+                strip_exe(${TEST_TARGET_NAME})
+            endif()
         endif()
     endforeach()
     set(test_list ${test_list} PARENT_SCOPE)

--- a/src/sdk/CMakeLists.txt
+++ b/src/sdk/CMakeLists.txt
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# coverage test won't run tests below, but they are *_test, so if COVERAGE_NO_DEPS, disable build
-if(TESTING_ENABLE AND NOT COVERAGE_NO_DEPS)
+if(TESTING_ENABLE)
     set(THIRD_LIBS benchmark_main benchmark ${GTEST_LIBRARIES} yaml-cpp)
 
     add_library(mini_cluster_bm_common mini_cluster_bm.cc)


### PR DESCRIPTION
`TESTING_ENABLE_STRIP` reduce disk space usage down to 9G approximately. 

![image](https://github.com/4paradigm/OpenMLDB/assets/11715200/95807b2e-d94b-4ccd-9330-6f8c25290fa8)

