### PR TITLE
build(cpp sdk): do not extract path for interface target

### DIFF
--- a/src/sdk/CMakeLists.txt
+++ b/src/sdk/CMakeLists.txt
@@ -299,6 +299,10 @@ list(REMOVE_ITEM ABSL_LLVM_LIBS "")
 
 # Find path of libraries in ${ABSL_LLVM_LIBS}
 foreach(X  IN LISTS ABSL_LLVM_LIBS)
+    get_target_property(type ${X} TYPE)
+    if (${type} STREQUAL "INTERFACE_LIBRARY")
+        continue()
+    endif()
     get_property(_loc TARGET ${X} PROPERTY LOCATION)
     list(APPEND ABSL_LLVM_PATH ${_loc})
 endforeach()


### PR DESCRIPTION
fixes the cmake configure error on cmake 3.18 from #2642 
```
CMake Error at src/sdk/CMakeLists.txt:302 (get_property):
  INTERFACE_LIBRARY targets may only have whitelisted properties.  The
  property "LOCATION" is not allowed.
```
