### PR TITLE
build: fix git-commit-id-plugin

### DIFF
--- a/java/openmldb-batch/pom.xml
+++ b/java/openmldb-batch/pom.xml
@@ -423,7 +423,7 @@
             <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
-                <version>2.2.4</version>
+                <version>4.9.10</version>
                 <executions>
                     <execution>
                         <id>get-the-git-infos</id>

--- a/java/openmldb-taskmanager/pom.xml
+++ b/java/openmldb-taskmanager/pom.xml
@@ -325,7 +325,7 @@
             <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
-                <version>2.2.4</version>
+                <version>4.9.10</version>
                 <executions>
                     <execution>
                         <id>get-the-git-infos</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -381,7 +381,8 @@
                 <plugin>
                   <groupId>pl.project13.maven</groupId>
                   <artifactId>git-commit-id-plugin</artifactId>
-                  <version>2.2.4</version>
+                   <!-- version 4.xx is the last version supports java 1.8 -->
+                  <version>4.9.10</version>
                   <executions>
                     <execution>
                       <id>get-the-git-infos</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -76,6 +76,9 @@
 
         <!-- Compatible with Spark 3.2.1 -->
         <guava.version>14.0.1</guava.version>
+
+        <!-- workaround to make git-commit-id work in Git worktree, refer https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/215 -->
+        <maven.gitcommitid.nativegit>true</maven.gitcommitid.nativegit>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
1. upgrade to 4.9.10
2. support in Git worktree, by using native git