### PR TITLE
fix: `twine` and `urllib` mismatch

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -260,7 +260,7 @@ jobs:
 
       - name: prepare python deps
         run: |
-          pip install twine "urllib3>=1.26.0,<2.0.0"
+          pip install twine==3.7.0
           yum install -y net-tools
 
       - name: test sqlalchemy and generate coverage report

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -260,7 +260,6 @@ jobs:
 
       - name: prepare python deps
         run: |
-          pip install twine==3.7.0
           yum install -y net-tools
 
       - name: test sqlalchemy and generate coverage report
@@ -288,6 +287,7 @@ jobs:
         if: >
           github.repository == '4paradigm/OpenMLDB' && startsWith(github.ref, 'refs/tags/v')
         run: |
+          pip install twine "urllib3>=1.26.0,<2.0.0"
           cp python/openmldb_sdk/dist/openmldb*.whl .
           cp python/openmldb_tool/dist/openmldb*.whl .
           twine upload openmldb*.whl


### PR DESCRIPTION
https://github.com/4paradigm/OpenMLDB/actions/runs/5610579829/jobs/10265741147 

`twine` and `urllib` mismatch issue has been resolved in #3343. but openmldb-tool will install 1.25 urllib  after twine installed.