### PR TITLE
feat(udf): support `datediff` dates before 1900

### DIFF
--- a/hybridse/src/udf/default_udf_library.cc
+++ b/hybridse/src/udf/default_udf_library.cc
@@ -2591,16 +2591,21 @@ void DefaultUdfLibrary::InitTimeAndDateUdf() {
             });
 
     RegisterExternal("datediff")
-        .args<Date, Date>(reinterpret_cast<void*>(static_cast<void (*)(Date*, Date*, int32_t*, bool*)>(v1::date_diff)))
-        .return_by_arg(true)
-        .returns<Nullable<int32_t>>()
+        .args<Date, Date>(static_cast<void (*)(Date*, Date*, int32_t*, bool*)>(v1::date_diff))
         .doc(R"(
             @brief days difference from date1 to date2
 
             Supported date string style:
               - yyyy-mm-dd
               - yyyymmdd
-              - yyyy-mm-dd hh:mm:ss
+              - yyyy-mm-dd HH:MM:SS
+              - yyyy-mm-ddTHH:MM:SS.fff+HH:MM (RFC3399 format)
+
+            Dates from string are transformed into the same time zone (which is currently always UTC+8) before differentiation,
+            dates from date type by default is at UTC+8, you may see a +1/-1 difference if the two date string have different time zones.
+
+            Hint: since openmldb date type limits range from year 1900, to datadiff from/to a date before
+            1900, pass it as string.
 
             Example:
 
@@ -2614,20 +2619,11 @@ void DefaultUdfLibrary::InitTimeAndDateUdf() {
             @endcode
             @since 0.7.0)");
     RegisterExternal("datediff")
-        .args<StringRef, StringRef>(
-            reinterpret_cast<void*>(static_cast<void (*)(StringRef*, StringRef*, int32_t*, bool*)>(v1::date_diff)))
-        .return_by_arg(true)
-        .returns<Nullable<int32_t>>();
+        .args<StringRef, StringRef>(static_cast<void (*)(StringRef*, StringRef*, int32_t*, bool*)>(v1::date_diff));
     RegisterExternal("datediff")
-        .args<StringRef, Date>(
-            reinterpret_cast<void*>(static_cast<void (*)(StringRef*, Date*, int32_t*, bool*)>(v1::date_diff)))
-        .return_by_arg(true)
-        .returns<Nullable<int32_t>>();
+        .args<StringRef, Date>(static_cast<void (*)(StringRef*, Date*, int32_t*, bool*)>(v1::date_diff));
     RegisterExternal("datediff")
-        .args<Date, StringRef>(
-            reinterpret_cast<void*>(static_cast<void (*)(Date*, StringRef*, int32_t*, bool*)>(v1::date_diff)))
-        .return_by_arg(true)
-        .returns<Nullable<int32_t>>();
+        .args<Date, StringRef>(static_cast<void (*)(Date*, StringRef*, int32_t*, bool*)>(v1::date_diff));
 
     RegisterExternal("unix_timestamp")
         .args<Date>(reinterpret_cast<void*>(static_cast<void (*)(Date*, int64_t*, bool*)>(v1::date_to_unix_timestamp)))

--- a/hybridse/src/udf/udf.cc
+++ b/hybridse/src/udf/udf.cc
@@ -16,7 +16,6 @@
 
 #include "udf/udf.h"
 
-#include <absl/time/time.h>
 #include <stdint.h>
 #include <time.h>
 
@@ -28,6 +27,7 @@
 #include "absl/strings/ascii.h"
 #include "absl/strings/str_replace.h"
 #include "absl/time/civil_time.h"
+#include "absl/time/time.h"
 #include "base/iterator.h"
 #include "boost/date_time.hpp"
 #include "boost/date_time/gregorian/parsers.hpp"
@@ -37,7 +37,7 @@
 #include "codec/row.h"
 #include "codec/type_codec.h"
 #include "codegen/fn_ir_builder.h"
-#include "farmhash.h"  // NOLINT
+#include "farmhash.h"
 #include "node/node_manager.h"
 #include "node/sql_node.h"
 #include "re2/re2.h"
@@ -56,6 +56,20 @@ using hybridse::codec::Row;
 using openmldb::base::StringRef;
 using openmldb::base::Timestamp;
 using openmldb::base::Date;
+
+// strftime()-like formatting options with extensions
+// ref absl::FormatTime
+static constexpr char DATE_FMT_YMD_1[] = "%E4Y-%m-%d";
+static constexpr char DATE_FMT_YMD_2[] = "%E4Y%m%d";
+static constexpr char DATE_FMT_YMDHMS[] = "%E4Y-%m-%d %H:%M:%S";
+static constexpr char DATE_FMT_RF3399_FULL[] = "%Y-%m-%d%ET%H:%M:%E*S%Ez";
+
+// TODO(chenjing): 时区统一配置
+static constexpr int32_t TZ = 8;
+static const absl::TimeZone DEFAULT_TZ = absl::FixedTimeZone(TZ * 60 * 60);
+static constexpr time_t TZ_OFFSET = TZ * 3600000;
+static constexpr int MAX_ALLOC_SIZE = 2 * 1024 * 1024;  // 2M
+bthread_key_t B_THREAD_LOCAL_MEM_POOL_KEY;
 
 void hex(StringRef *str, StringRef *output) {
     std::ostringstream ss;
@@ -103,12 +117,6 @@ void unhex(StringRef *str, StringRef *output, bool* is_null) {
         output->data_ = buffer;
     }
 }
-
-// TODO(chenjing): 时区统一配置
-constexpr int32_t TZ = 8;
-constexpr time_t TZ_OFFSET = TZ * 3600000;
-constexpr int MAX_ALLOC_SIZE = 2 * 1024 * 1024;  // 2M
-bthread_key_t B_THREAD_LOCAL_MEM_POOL_KEY;
 
 void trivial_fun() {}
 
@@ -818,7 +826,26 @@ void string_to_date(StringRef *str, Date *output,
     return;
 }
 
-void date_diff(Date *date1, Date *date2, int *diff, bool *is_null) {
+absl::StatusOr<absl::Time> string_to_time(absl::string_view ref) {
+    absl::string_view fmt = DATE_FMT_RF3399_FULL;
+    if (19 == ref.size()) {
+        fmt = DATE_FMT_YMDHMS;
+    } else if (10 == ref.size()) {
+        fmt = DATE_FMT_YMD_1;
+    } else if (8 == ref.size()) {
+        fmt = DATE_FMT_YMD_2;
+    }
+    absl::Time tm;
+    std::string err;
+    bool ret = absl::ParseTime(fmt, ref, &tm, &err);
+
+    if (!ret) {
+        return absl::InvalidArgumentError(err);
+    }
+    return tm;
+}
+
+void date_diff(Date *date1, Date *date2, int32_t *diff, bool *is_null) {
     if (date1 == nullptr || date2 == nullptr || date1->date_ <= 0 || date2->date_ <= 0) {
         *is_null = true;
         return;
@@ -838,36 +865,61 @@ void date_diff(Date *date1, Date *date2, int *diff, bool *is_null) {
     *is_null = false;
 }
 
-void date_diff(StringRef *date1, StringRef *date2, int *diff, bool *is_null) {
-    Date d1;
-    string_to_date(date1, &d1, is_null);
-    if (*is_null) {
+void date_diff(StringRef *date1, StringRef *date2, int32_t *diff, bool *is_null) {
+    auto t1 = string_to_time(absl::string_view(date1->data_, date1->size_));
+    if (!t1.ok()) {
+        *is_null = true;
         return;
     }
-    Date d2;
-    string_to_date(date2, &d2, is_null);
-    if (*is_null) {
+    auto t2 = string_to_time(absl::string_view(date2->data_, date2->size_));
+    if (!t2.ok()) {
+        *is_null = true;
         return;
     }
-    date_diff(&d1, &d2, diff, is_null);
+
+    auto d1 = absl::ToCivilDay(t1.value(), DEFAULT_TZ);
+    auto d2 = absl::ToCivilDay(t2.value(), DEFAULT_TZ);
+
+    *diff = d1 - d2;
+    *is_null = false;
 }
 
-void date_diff(StringRef *date1, Date *date2, int *diff, bool *is_null) {
-    Date d1;
-    string_to_date(date1, &d1, is_null);
-    if (*is_null) {
+void date_diff(StringRef *date1, Date *date2, int32_t *diff, bool *is_null) {
+    auto t1 = string_to_time(absl::string_view(date1->data_, date1->size_));
+    if (!t1.ok()) {
+        *is_null = true;
         return;
     }
-    date_diff(&d1, date2, diff, is_null);
+    auto d1 = absl::ToCivilDay(t1.value(), DEFAULT_TZ);
+
+    int32_t year, month, day;
+    if (!Date::Decode(date2->date_, &year, &month, &day)) {
+        *is_null = true;
+        return;
+    }
+    auto d2 = absl::CivilDay(year, month, day);
+
+    *diff = d1 - d2;
+    *is_null = false;
 }
 
-void date_diff(Date *date1, StringRef *date2, int *diff, bool *is_null) {
-    Date d2;
-    string_to_date(date2, &d2, is_null);
-    if (*is_null) {
+void date_diff(Date *date1, StringRef *date2, int32_t *diff, bool *is_null) {
+    auto t2 = string_to_time(absl::string_view(date2->data_, date2->size_));
+    if (!t2.ok()) {
+        *is_null = true;
         return;
     }
-    date_diff(date1, &d2, diff, is_null);
+    auto d2 = absl::ToCivilDay(t2.value(), DEFAULT_TZ);
+
+    int32_t year, month, day;
+    if (!Date::Decode(date1->date_, &year, &month, &day)) {
+        *is_null = true;
+        return;
+    }
+    auto d1 = absl::CivilDay(year, month, day);
+
+    *diff = d1 - d2;
+    *is_null = false;
 }
 
 // cast string to timestamp with yyyy-mm-dd or YYYY-mm-dd HH:MM:SS

--- a/hybridse/src/udf/udf.h
+++ b/hybridse/src/udf/udf.h
@@ -367,10 +367,10 @@ void timestamp_to_date(Timestamp *timestamp, Date *output, bool *is_null);
 
 void date_to_string(Date *date, StringRef *output);
 
-void date_diff(Date *date1, Date *date2, int *diff, bool *is_null);
-void date_diff(StringRef *date1, StringRef *date2, int *diff, bool *is_null);
-void date_diff(StringRef *date1, Date *date2, int *diff, bool *is_null);
-void date_diff(Date *date1, StringRef *date2, int *diff, bool *is_null);
+void date_diff(Date *date1, Date *date2, int32_t *diff, bool *is_null);
+void date_diff(StringRef *date1, StringRef *date2, int32_t *diff, bool *is_null);
+void date_diff(StringRef *date1, Date *date2, int32_t *diff, bool *is_null);
+void date_diff(Date *date1, StringRef *date2, int32_t *diff, bool *is_null);
 
 void like(StringRef *name, StringRef *pattern,
         StringRef *escape, bool *out, bool *is_null);
@@ -384,6 +384,8 @@ void regexp_like(StringRef *name, StringRef *pattern, bool *out, bool *is_null);
 
 void date_to_timestamp(Date *date, Timestamp *output, bool *is_null);
 void string_to_date(StringRef *str, Date *output, bool *is_null);
+absl::StatusOr<absl::Time> string_to_time(absl::string_view str);
+
 void string_to_timestamp(StringRef *str, Timestamp *output, bool *is_null);
 void date_to_unix_timestamp(Date *date, int64_t *output, bool *is_null);
 void string_to_unix_timestamp(StringRef *str, int64_t *output, bool *is_null);


### PR DESCRIPTION
For `datadiff` function with at least one string parameter, the string date is allowed to be before year 1900. 
NOTE: openmldb date type only supports year after 1900.