### PR TITLE
fix(codegen): handle nullable for date type

### DIFF
--- a/cases/query/const_query.yaml
+++ b/cases/query/const_query.yaml
@@ -126,3 +126,15 @@ cases:
       columns: ['c1 bool', 'c2 int16', 'c3 int', 'c4 double', 'c5 string', 'c6 date', 'c7 timestamp' ]
       rows:
         - [ true, 3, 13, 10.0, 'a string', '2020-05-22', 1590115420000 ]
+  - id: 10
+    mode: procedure-unsupport
+    sql: |
+      select
+        datediff(Date(timestamp(-1)), Date("2021-05-01")) as out1,
+        datediff(Date(timestamp(-2177481600)), Date("2021-05-01")) as out2,
+        datediff(cast(NULL as date), Date("2021-05-01")) as out3
+        ;
+    expect:
+      columns: ["out1 int", "out2 int", "out3 int"]
+      data: |
+        NULL, NULL, NULL

--- a/hybridse/src/codegen/array_ir_builder.cc
+++ b/hybridse/src/codegen/array_ir_builder.cc
@@ -17,6 +17,7 @@
 #include "codegen/array_ir_builder.h"
 
 #include <string>
+#include "codegen/ir_base_builder.h"
 
 namespace hybridse {
 namespace codegen {

--- a/hybridse/src/codegen/cast_expr_ir_builder.cc
+++ b/hybridse/src/codegen/cast_expr_ir_builder.cc
@@ -126,6 +126,11 @@ Status CastExprIRBuilder::UnSafeCast(const NativeValue& value,
             StringIRBuilder string_ir_builder(block_->getModule());
             CHECK_STATUS(string_ir_builder.CreateNull(block_, output));
             return base::Status::OK();
+
+        } else if (TypeIRBuilder::IsDatePtr(type)) {
+            DateIRBuilder date_ir(block_->getModule());
+            CHECK_STATUS(date_ir.CreateNull(block_, output));
+            return base::Status::OK();
         } else {
             *output = NativeValue::CreateNull(type);
         }

--- a/hybridse/src/codegen/date_ir_builder.cc
+++ b/hybridse/src/codegen/date_ir_builder.cc
@@ -44,6 +44,15 @@ void DateIRBuilder::InitStructType() {
     struct_type_ = stype;
     return;
 }
+
+base::Status DateIRBuilder::CreateNull(::llvm::BasicBlock* block, NativeValue* output) {
+    ::llvm::Value* value = nullptr;
+    CHECK_TRUE(CreateDefault(block, &value), common::kCodegenError, "Fail to construct string")
+    ::llvm::IRBuilder<> builder(block);
+    *output = NativeValue::CreateWithFlag(value, builder.getInt1(true));
+    return base::Status::OK();
+}
+
 bool DateIRBuilder::CreateDefault(::llvm::BasicBlock* block,
                                   ::llvm::Value** output) {
     return NewDate(block, output);
@@ -123,11 +132,10 @@ base::Status DateIRBuilder::CastFrom(::llvm::BasicBlock* block,
 
         auto cast_func = m_->getOrInsertFunction(
             fn_name,
-            ::llvm::FunctionType::get(
-                builder.getVoidTy(),
-                {src.GetType(), builder.getInt1Ty(), dist->getType(), builder.getInt1Ty()->getPointerTo()}, false));
+            ::llvm::FunctionType::get(builder.getVoidTy(),
+                                      {src.GetType(), dist->getType(), builder.getInt1Ty()->getPointerTo()}, false));
 
-        builder.CreateCall(cast_func, {src.GetValue(&builder), src.GetIsNull(&builder), dist, is_null_ptr});
+        builder.CreateCall(cast_func, {src.GetValue(&builder), dist, is_null_ptr});
 
         ::llvm::Value* should_return_null = builder.CreateLoad(is_null_ptr);
         null_ir_builder.CheckAnyNull(block, src, &should_return_null);

--- a/hybridse/src/codegen/date_ir_builder.h
+++ b/hybridse/src/codegen/date_ir_builder.h
@@ -16,13 +16,9 @@
 
 #ifndef HYBRIDSE_SRC_CODEGEN_DATE_IR_BUILDER_H_
 #define HYBRIDSE_SRC_CODEGEN_DATE_IR_BUILDER_H_
+
 #include "base/fe_status.h"
-#include "codegen/cast_expr_ir_builder.h"
-#include "codegen/null_ir_builder.h"
-#include "codegen/scope_var.h"
 #include "codegen/struct_ir_builder.h"
-#include "llvm/IR/IRBuilder.h"
-#include "proto/fe_type.pb.h"
 
 namespace hybridse {
 namespace codegen {

--- a/hybridse/src/codegen/date_ir_builder.h
+++ b/hybridse/src/codegen/date_ir_builder.h
@@ -27,17 +27,17 @@ class DateIRBuilder : public StructTypeIRBuilder {
  public:
     explicit DateIRBuilder(::llvm::Module* m);
     ~DateIRBuilder();
-    void InitStructType();
-    bool CreateDefault(::llvm::BasicBlock* block, ::llvm::Value** output);
+    void InitStructType() override;
+
+    base::Status CreateNull(::llvm::BasicBlock* block, NativeValue* output);
+    bool CreateDefault(::llvm::BasicBlock* block, ::llvm::Value** output) override;
+
     bool NewDate(::llvm::BasicBlock* block, ::llvm::Value** output);
     bool NewDate(::llvm::BasicBlock* block, ::llvm::Value* date,
                  ::llvm::Value** output);
-    bool CopyFrom(::llvm::BasicBlock* block, ::llvm::Value* src,
-                  ::llvm::Value* dist);
-    base::Status CastFrom(::llvm::BasicBlock* block, const NativeValue& src,
-                          NativeValue* output);
-    base::Status CastFrom(::llvm::BasicBlock* block, ::llvm::Value* src,
-                          ::llvm::Value** output);
+    bool CopyFrom(::llvm::BasicBlock* block, ::llvm::Value* src, ::llvm::Value* dist);
+    base::Status CastFrom(::llvm::BasicBlock* block, const NativeValue& src, NativeValue* output);
+
     bool GetDate(::llvm::BasicBlock* block, ::llvm::Value* date,
                  ::llvm::Value** output);
     bool SetDate(::llvm::BasicBlock* block, ::llvm::Value* date,

--- a/hybridse/src/codegen/ir_base_builder.h
+++ b/hybridse/src/codegen/ir_base_builder.h
@@ -19,7 +19,6 @@
 
 #include <string>
 #include <vector>
-#include "glog/logging.h"
 #include "llvm/IR/IRBuilder.h"
 #include "node/sql_node.h"
 #include "node/type_node.h"

--- a/hybridse/src/codegen/native_value.cc
+++ b/hybridse/src/codegen/native_value.cc
@@ -17,7 +17,6 @@
 #include "codegen/native_value.h"
 #include <dlfcn.h>
 #include <execinfo.h>
-#include <signal.h>
 #include "codegen/context.h"
 #include "codegen/ir_base_builder.h"
 

--- a/hybridse/src/codegen/predicate_expr_ir_builder.cc
+++ b/hybridse/src/codegen/predicate_expr_ir_builder.cc
@@ -17,6 +17,7 @@
 #include "codegen/predicate_expr_ir_builder.h"
 #include "codegen/date_ir_builder.h"
 #include "codegen/ir_base_builder.h"
+#include "codegen/null_ir_builder.h"
 #include "codegen/string_ir_builder.h"
 #include "codegen/timestamp_ir_builder.h"
 #include "codegen/type_ir_builder.h"

--- a/hybridse/src/codegen/struct_ir_builder.h
+++ b/hybridse/src/codegen/struct_ir_builder.h
@@ -16,12 +16,10 @@
 
 #ifndef HYBRIDSE_SRC_CODEGEN_STRUCT_IR_BUILDER_H_
 #define HYBRIDSE_SRC_CODEGEN_STRUCT_IR_BUILDER_H_
+
 #include "base/fe_status.h"
-#include "codegen/cast_expr_ir_builder.h"
-#include "codegen/scope_var.h"
+#include "codegen/native_value.h"
 #include "codegen/type_ir_builder.h"
-#include "llvm/IR/IRBuilder.h"
-#include "proto/fe_type.pb.h"
 
 namespace hybridse {
 namespace codegen {

--- a/hybridse/src/codegen/timestamp_ir_builder.cc
+++ b/hybridse/src/codegen/timestamp_ir_builder.cc
@@ -15,14 +15,15 @@
  */
 
 #include "codegen/timestamp_ir_builder.h"
+
 #include <string>
 #include <vector>
+
 #include "codegen/arithmetic_expr_ir_builder.h"
 #include "codegen/ir_base_builder.h"
 #include "codegen/null_ir_builder.h"
 #include "codegen/predicate_expr_ir_builder.h"
 #include "glog/logging.h"
-#include "node/sql_node.h"
 
 using hybridse::common::kCodegenError;
 

--- a/hybridse/src/codegen/timestamp_ir_builder.h
+++ b/hybridse/src/codegen/timestamp_ir_builder.h
@@ -16,12 +16,9 @@
 
 #ifndef HYBRIDSE_SRC_CODEGEN_TIMESTAMP_IR_BUILDER_H_
 #define HYBRIDSE_SRC_CODEGEN_TIMESTAMP_IR_BUILDER_H_
+
 #include "base/fe_status.h"
-#include "codegen/cast_expr_ir_builder.h"
-#include "codegen/scope_var.h"
 #include "codegen/struct_ir_builder.h"
-#include "llvm/IR/IRBuilder.h"
-#include "proto/fe_type.pb.h"
 
 namespace hybridse {
 namespace codegen {

--- a/hybridse/src/codegen/timestamp_ir_builder.h
+++ b/hybridse/src/codegen/timestamp_ir_builder.h
@@ -30,8 +30,8 @@ class TimestampIRBuilder : public StructTypeIRBuilder {
     void InitStructType();
     bool CreateDefault(::llvm::BasicBlock* block, ::llvm::Value** output);
     bool NewTimestamp(::llvm::BasicBlock* block, ::llvm::Value** output);
-    bool NewTimestamp(::llvm::BasicBlock* block, ::llvm::Value* ts,
-                      ::llvm::Value** output);
+    bool NewTimestamp(::llvm::BasicBlock* block, ::llvm::Value* ts, ::llvm::Value** output);
+
     bool CopyFrom(::llvm::BasicBlock* block, ::llvm::Value* src,
                   ::llvm::Value* dist);
     base::Status CastFrom(::llvm::BasicBlock* block, const NativeValue& src,

--- a/hybridse/src/codegen/type_ir_builder.cc
+++ b/hybridse/src/codegen/type_ir_builder.cc
@@ -15,6 +15,7 @@
  */
 
 #include "codegen/type_ir_builder.h"
+
 #include "codegen/ir_base_builder.h"
 #include "glog/logging.h"
 #include "node/node_manager.h"

--- a/hybridse/src/codegen/type_ir_builder.h
+++ b/hybridse/src/codegen/type_ir_builder.h
@@ -18,11 +18,10 @@
 #define HYBRIDSE_SRC_CODEGEN_TYPE_IR_BUILDER_H_
 
 #include <string>
-#include <vector>
+
 #include "base/fe_status.h"
-#include "codec/fe_row_codec.h"
-#include "codegen/ir_base_builder.h"
-#include "node/node_enum.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Type.h"
 #include "node/sql_node.h"
 #include "node/type_node.h"
 

--- a/hybridse/src/codegen/udf_ir_builder.cc
+++ b/hybridse/src/codegen/udf_ir_builder.cc
@@ -15,19 +15,17 @@
  */
 
 #include "codegen/udf_ir_builder.h"
-#include <iostream>
-#include <utility>
+
 #include <vector>
+
 #include "codegen/context.h"
-#include "codegen/date_ir_builder.h"
 #include "codegen/fn_ir_builder.h"
+#include "codegen/ir_base_builder.h"
 #include "codegen/list_ir_builder.h"
 #include "codegen/null_ir_builder.h"
-#include "codegen/timestamp_ir_builder.h"
+#include "codegen/type_ir_builder.h"
 #include "llvm/IR/Attributes.h"
-#include "node/node_manager.h"
 #include "node/sql_node.h"
-#include "udf/udf.h"
 #include "udf/udf_registry.h"
 
 using ::hybridse::common::kCodegenError;
@@ -162,7 +160,7 @@ Status UdfIRBuilder::BuildLambdaCall(
 Status UdfIRBuilder::BuildCodeGenUdfCall(
     const node::UdfByCodeGenDefNode* fn,
     const std::vector<NativeValue>& args, NativeValue* output) {
-    auto gen_impl = fn->GetGenImpl();
+    std::shared_ptr<udf::LlvmUdfGenBase> gen_impl = fn->GetGenImpl();
 
     ::llvm::Value* ret_null = nullptr;
     for (size_t i = 0; i < fn->GetArgSize(); ++i) {

--- a/hybridse/src/codegen/udf_ir_builder.h
+++ b/hybridse/src/codegen/udf_ir_builder.h
@@ -17,13 +17,9 @@
 #ifndef HYBRIDSE_SRC_CODEGEN_UDF_IR_BUILDER_H_
 #define HYBRIDSE_SRC_CODEGEN_UDF_IR_BUILDER_H_
 
-#include <map>
-#include <string>
 #include <vector>
 #include "base/fe_status.h"
 #include "codegen/expr_ir_builder.h"
-#include "codegen/scope_var.h"
-#include "llvm/IR/Module.h"
 
 #include "node/sql_node.h"
 namespace hybridse {

--- a/hybridse/src/udf/default_udf_library.cc
+++ b/hybridse/src/udf/default_udf_library.cc
@@ -26,7 +26,6 @@
 #include <queue>
 #include <functional>
 
-#include "absl/strings/str_cat.h"
 #include "codegen/date_ir_builder.h"
 #include "codegen/string_ir_builder.h"
 #include "codegen/timestamp_ir_builder.h"
@@ -2169,11 +2168,7 @@ void DefaultUdfLibrary::InitTypeUdf() {
         )");
 
     RegisterExternal("date")
-        .args<Timestamp>(reinterpret_cast<void*>(
-            static_cast<void (*)(Timestamp*, Date*, bool*)>(
-                v1::timestamp_to_date)))
-        .return_by_arg(true)
-        .returns<Nullable<Date>>()
+        .args<Nullable<Timestamp>>(v1::timestamp_to_date)
         .doc(R"(
             @brief Cast timestamp or string expression to date (date >= 1900-01-01)
 
@@ -2192,11 +2187,7 @@ void DefaultUdfLibrary::InitTypeUdf() {
             @endcode
             @since 0.1.0)");
     RegisterExternal("date")
-        .args<StringRef>(reinterpret_cast<void*>(
-            static_cast<void (*)(StringRef*, Date*, bool*)>(
-                v1::string_to_date)))
-        .return_by_arg(true)
-        .returns<Nullable<Date>>();
+        .args<Nullable<StringRef>>(v1::string_to_date);
 
     RegisterExternal("timestamp")
         .args<Date>(reinterpret_cast<void*>(

--- a/hybridse/src/udf/default_udf_library.cc
+++ b/hybridse/src/udf/default_udf_library.cc
@@ -2168,7 +2168,7 @@ void DefaultUdfLibrary::InitTypeUdf() {
         )");
 
     RegisterExternal("date")
-        .args<Nullable<Timestamp>>(v1::timestamp_to_date)
+        .args<Timestamp>(v1::timestamp_to_date)
         .doc(R"(
             @brief Cast timestamp or string expression to date (date >= 1900-01-01)
 
@@ -2187,7 +2187,7 @@ void DefaultUdfLibrary::InitTypeUdf() {
             @endcode
             @since 0.1.0)");
     RegisterExternal("date")
-        .args<Nullable<StringRef>>(v1::string_to_date);
+        .args<StringRef>(v1::string_to_date);
 
     RegisterExternal("timestamp")
         .args<Date>(reinterpret_cast<void*>(

--- a/hybridse/src/udf/udf.cc
+++ b/hybridse/src/udf/udf.cc
@@ -389,11 +389,7 @@ void bool_to_string(bool v, StringRef *output) {
     }
 }
 
-void timestamp_to_date(Timestamp *timestamp, bool arg_is_null, Date *output, bool *is_null) {
-    if (arg_is_null) {
-        *is_null = true;
-        return;
-    }
+void timestamp_to_date(Timestamp *timestamp, Date *output, bool *is_null) {
     time_t time = (timestamp->ts_ + TZ_OFFSET) / 1000;
     struct tm t;
     memset(&t, 0, sizeof(struct tm));
@@ -769,12 +765,7 @@ void string_to_double(StringRef *str, double *out, bool *is_null_ptr) {
     }
     return;
 }
-void string_to_date(StringRef *str, bool arg_is_null, Date *output, bool *is_null) {
-    if (arg_is_null) {
-        *is_null = true;
-        return;
-    }
-
+void string_to_date(StringRef *str, Date *output, bool *is_null) {
     if (19 == str->size_) {
         struct tm timeinfo;
         memset(&timeinfo, 0, sizeof(struct tm));

--- a/hybridse/src/udf/udf.h
+++ b/hybridse/src/udf/udf.h
@@ -26,10 +26,6 @@
 #include "absl/strings/ascii.h"
 #include "base/string_ref.h"
 #include "base/type.h"
-#include "codec/list_iterator_codec.h"
-#include "codec/type_codec.h"
-#include "node/node_manager.h"
-#include "proto/fe_type.pb.h"
 #include "udf/literal_traits.h"
 #include "udf/openmldb_udf.h"
 
@@ -363,7 +359,7 @@ void date_format(Date *date, StringRef *format,
 
 void timestamp_to_string(Timestamp *timestamp,
                          StringRef *output);
-void timestamp_to_date(Timestamp *timestamp, Date *output, bool *is_null);
+void timestamp_to_date(Timestamp *timestamp, bool arg_is_null, Date *output, bool *is_null);
 
 void date_to_string(Date *date, StringRef *output);
 
@@ -383,7 +379,7 @@ void regexp_like(StringRef *name, StringRef *pattern, StringRef *flags, bool *ou
 void regexp_like(StringRef *name, StringRef *pattern, bool *out, bool *is_null);
 
 void date_to_timestamp(Date *date, Timestamp *output, bool *is_null);
-void string_to_date(StringRef *str, Date *output, bool *is_null);
+void string_to_date(StringRef *str, bool arg_is_null, Date *output, bool *is_null);
 absl::StatusOr<absl::Time> string_to_time(absl::string_view str);
 
 void string_to_timestamp(StringRef *str, Timestamp *output, bool *is_null);

--- a/hybridse/src/udf/udf.h
+++ b/hybridse/src/udf/udf.h
@@ -359,7 +359,7 @@ void date_format(Date *date, StringRef *format,
 
 void timestamp_to_string(Timestamp *timestamp,
                          StringRef *output);
-void timestamp_to_date(Timestamp *timestamp, bool arg_is_null, Date *output, bool *is_null);
+void timestamp_to_date(Timestamp *timestamp, Date *output, bool *is_null);
 
 void date_to_string(Date *date, StringRef *output);
 
@@ -379,7 +379,7 @@ void regexp_like(StringRef *name, StringRef *pattern, StringRef *flags, bool *ou
 void regexp_like(StringRef *name, StringRef *pattern, bool *out, bool *is_null);
 
 void date_to_timestamp(Date *date, Timestamp *output, bool *is_null);
-void string_to_date(StringRef *str, bool arg_is_null, Date *output, bool *is_null);
+void string_to_date(StringRef *str, Date *output, bool *is_null);
 absl::StatusOr<absl::Time> string_to_time(absl::string_view str);
 
 void string_to_timestamp(StringRef *str, Timestamp *output, bool *is_null);


### PR DESCRIPTION
Also fix include headers as iwyu. 

Fixes #3194

More general problem is described in #926, which should handling later 

always returns allocated structure even it is null, for the cases:
1. construct timestamp from number, even number is < 0
2. construct date from timestamp, even timestamp is null
3. construct date from null literal
