### PR TITLE
ci: reduce disk usage for java jobs 

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -68,8 +68,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('java/**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
 
       - name: prepare release
         if: github.event_name == 'push'
@@ -124,6 +122,7 @@ jobs:
       - name: maven coverage
         working-directory: java
         run: |
+          rm -rv ~/.m2/repository/com/4paradigm/
           ./mvnw --batch-mode prepare-package
           ./mvnw --batch-mode scoverage:report
 
@@ -160,8 +159,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('java/**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
 
       - name: Cache thirdparty
         uses: actions/cache@v3
@@ -236,6 +233,10 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_TOKEN: ${{ secrets.OSSRH_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - name: cleanup
+        run: |
+          rm -rv ~/.m2/repository/com/4paradigm/
+
 
   python-sdk:
     runs-on: ubuntu-latest

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -122,7 +122,7 @@ jobs:
       - name: maven coverage
         working-directory: java
         run: |
-          rm -rv ~/.m2/repository/com/4paradigm/
+          rm -rfv ~/.m2/repository/com/4paradigm/
           ./mvnw --batch-mode prepare-package
           ./mvnw --batch-mode scoverage:report
 
@@ -235,7 +235,7 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: cleanup
         run: |
-          rm -rv ~/.m2/repository/com/4paradigm/
+          rm -rfv ~/.m2/repository/com/4paradigm/
 
 
   python-sdk:

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -355,7 +355,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>2.2.1</version>
+                    <version>3.3.0</version>
                     <executions>
                         <execution>
                             <id>attach-sources</id>
@@ -364,6 +364,9 @@
                             </goals>
                         </execution>
                     </executions>
+                    <configuration>
+                        <excludeResources>true</excludeResources>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
1. don't pack resources for source-jars
2. don't include local installed openmldb jars, they are not dependency
3. don't fallback cache if key miss-match

fixes `No space left on device ` ERROR on recent builds