### PR TITLE
build: support build on no tag

### DIFF
--- a/.github/workflows/other-os-build.yml
+++ b/.github/workflows/other-os-build.yml
@@ -21,6 +21,10 @@ on:
         description: 'The branch, tag or SHA to checkout, otherwise use the branch'
         required: false
         default: ''
+      ZETASQL_LIB_URL:
+        description: 'zetasql lib url, default is built by src, if you want to use prebuilt, set it. Only for centos6'
+        required: false
+        default: ''
 
 env:
   NPROC: 2 # default Parallel build number for GitHub's Linux runner
@@ -35,6 +39,7 @@ jobs:
       OS: linux
       SQL_JAVASDK_ENABLE: ${{ github.event.inputs.JAVA_SDK }}
       SQL_PYSDK_ENABLE: ${{ github.event.inputs.PYTHON_SDK }} # python whl will be built when make, no prerequirement
+      ZETASQL_LIB_URL: ${{ github.event.inputs.ZETASQL_LIB_URL }}
       TESTING_ENABLE: OFF
       NPROC: 8
     steps:
@@ -75,7 +80,7 @@ jobs:
       - uses: addnab/docker-run-action@v3
         with:
           image: ghcr.io/4paradigm/centos6_gcc7_hybridsql
-          options: -v ${{ github.workspace }}:/root/OpenMLDB -e USE_DEPS_CACHE=${{ steps.deps-cache.outputs.cache-hit }} -e OPENMLDB_PREFIX=${{ env.OPENMLDB_PREFIX }} -e SQL_PYSDK_ENABLE=${{ env.SQL_PYSDK_ENABLE }} -e SQL_JAVASDK_ENABLE=${{ env.SQL_JAVASDK_ENABLE }}
+          options: -v ${{ github.workspace }}:/root/OpenMLDB -e USE_DEPS_CACHE=${{ steps.deps-cache.outputs.cache-hit }} -e OPENMLDB_PREFIX=${{ env.OPENMLDB_PREFIX }} -e SQL_PYSDK_ENABLE=${{ env.SQL_PYSDK_ENABLE }} -e SQL_JAVASDK_ENABLE=${{ env.SQL_JAVASDK_ENABLE }} -e ZETASQL_LIB_URL=${{ env.ZETASQL_LIB_URL }}
           shell: bash
           run: |
             cd /root/OpenMLDB
@@ -89,6 +94,10 @@ jobs:
               make thirdparty CMAKE_INSTALL_PREFIX=${OPENMLDB_PREFIX} BUILD_BUNDLE=ON THIRD_PARTY_CMAKE_FLAGS=-DMAKEOPTS=-j8
               # 5.8G	./.deps, avail 8G
               rm -rf .deps/build # GitHub runner disk space is limited
+            fi
+            if [[ "${ZETASQL_LIB_URL}" != "" ]]; then
+              echo "replace zetasql lib by ${ZETASQL_LIB_URL}"
+              curl -SLo .deps/usr/lib/libzetasql.a ${ZETASQL_LIB_URL}
             fi
             echo "build"
             # 1.4G	./.deps, avail 13G

--- a/.github/workflows/other-os-build.yml
+++ b/.github/workflows/other-os-build.yml
@@ -46,7 +46,8 @@ jobs:
       - name: prepare release
         run: |
           VERSION="snapshot"
-          TAG=$(git tag -l | grep $(git describe HEAD))
+          # if not tag, return error, just ignore it to use snapshot as the version
+          TAG=$(git tag -l | grep $(git describe HEAD)) || true
           if [[ "${TAG}" == "v"* ]]; then
             VERSION=${TAG#v}
             bash steps/prepare_release.sh "$VERSION"
@@ -172,7 +173,7 @@ jobs:
         run: |
           VERSION="snapshot"
           # use repo ref not event ref
-          TAG=$(git tag -l | grep $(git describe HEAD))
+          TAG=$(git tag -l | grep $(git describe HEAD)) || true
           if [[ "${TAG}" == "v"* ]]; then
             VERSION=${TAG#v}
             bash steps/prepare_release.sh "$VERSION"
@@ -242,7 +243,7 @@ jobs:
       - name: prepare release
         run: |
           VERSION="snapshot"
-          TAG=$(git tag -l | grep $(git describe HEAD))
+          TAG=$(git tag -l | grep $(git describe HEAD)) || true
           if [[ "${TAG}" == "v"* ]]; then
             VERSION=${TAG#v}
             bash steps/prepare_release.sh "$VERSION"

--- a/steps/centos6_build.sh
+++ b/steps/centos6_build.sh
@@ -37,20 +37,21 @@ function tool_install() {
     chmod +x bazel
 }
 
-if [ "$USE_DEPS_CACHE" == "true" ]; then
-    echo "use deps cache, exit"
-    exit 0
-else
-    echo "not use deps cache, install tools and build deps"
-fi
-
 if [ "$IN_WORKFLOW" == "true" ]; then
     echo "in workflow"
 else
     echo "in self build"
 fi
 
+echo "always install tools"
 tool_install
+
+if [ "$USE_DEPS_CACHE" == "true" ]; then
+    echo "use deps cache, exit"
+    exit 0
+else
+    echo "no deps cache, build deps"
+fi
 
 echo "set envs, if IN_WORKFLOW, you should set envs in workflow"
 new_path=$PATH:$(pwd)


### PR DESCRIPTION
if REF set empty, branch or commit, failed on grep HEAD. Ignore this error, just use snapshot to be the version. The doc is correct, no update about it.

zetasql lib built by workflow run is wierd, but can't solve it now. So we add zetasql lib url to replace it in workflow.