### PR TITLE
ci(pr title): fix running issue for pull-request-name-linter-action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,10 +7,11 @@ jobs:
   pr-name-lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
-        node-version: '14'
+        node-version: '18'
     - name: Install Dependencies
-      run: npm install @commitlint/config-conventional
-    - uses: JulienKode/pull-request-name-linter-action@v0.2.0
+      run: npm install @commitlint/config-conventional@18.5.0
+
+    - uses: JulienKode/pull-request-name-linter-action@v0.5.0


### PR DESCRIPTION
expect resolving issue with pr-name-lint job.
@commitlint/config-conventional 18.6.0 adds rule 'header-trim', which is not recognized by the workflow, ref https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/config-conventional/CHANGELOG.md

