### PR TITLE
feat: offline map type

### DIFF
--- a/hybridse/include/base/fe_slice.h
+++ b/hybridse/include/base/fe_slice.h
@@ -16,14 +16,15 @@
 
 #ifndef HYBRIDSE_INCLUDE_BASE_FE_SLICE_H_
 #define HYBRIDSE_INCLUDE_BASE_FE_SLICE_H_
+
 #include <assert.h>
 #include <memory.h>
 #include <stddef.h>
 #include <string.h>
-#include <memory>
+
 #include <string>
+
 #include "base/raw_buffer.h"
-#include "boost/smart_ptr/local_shared_ptr.hpp"
 
 namespace hybridse {
 namespace base {

--- a/hybridse/include/base/raw_buffer.h
+++ b/hybridse/include/base/raw_buffer.h
@@ -16,10 +16,9 @@
 
 #ifndef HYBRIDSE_INCLUDE_BASE_RAW_BUFFER_H_
 #define HYBRIDSE_INCLUDE_BASE_RAW_BUFFER_H_
-#include <assert.h>
+
 #include <stddef.h>
 #include <string.h>
-#include <string>
 
 #include "glog/logging.h"
 

--- a/hybridse/include/codec/row.h
+++ b/hybridse/include/codec/row.h
@@ -18,14 +18,9 @@
 #define HYBRIDSE_INCLUDE_CODEC_ROW_H_
 
 #include <cstdint>
-#include <map>
 #include <string>
-#include <unordered_map>
-#include <utility>
 #include <vector>
 #include "base/fe_slice.h"
-#include "base/raw_buffer.h"
-#include "proto/fe_type.pb.h"
 
 namespace hybridse {
 namespace codec {

--- a/hybridse/src/codegen/aggregate_ir_builder.cc
+++ b/hybridse/src/codegen/aggregate_ir_builder.cc
@@ -736,8 +736,7 @@ base::Status AggregateIRBuilder::BuildMulti(const std::string& base_funcname,
         std::vector<std::pair<size_t, NativeValue>> outputs;
         agg_generator.GenOutputs(&builder, &outputs);
         for (auto pair : outputs) {
-            output_encoder.BuildEncodePrimaryField(output_arg, pair.first,
-                                                   pair.second);
+            CHECK_STATUS(output_encoder.BuildEncodePrimaryField(output_arg, pair.first, pair.second));
         }
     }
     builder.CreateRetVoid();

--- a/hybridse/src/codegen/buf_ir_builder.h
+++ b/hybridse/src/codegen/buf_ir_builder.h
@@ -36,11 +36,14 @@ class BufNativeEncoderIRBuilder : public RowEncodeIRBuilder {
 
     ~BufNativeEncoderIRBuilder() override;
 
+    ABSL_MUST_USE_RESULT
     base::Status Init() noexcept;
 
     // the output_ptr like int8_t**
+    ABSL_MUST_USE_RESULT
     base::Status BuildEncode(::llvm::Value* output_ptr) override;
 
+    ABSL_MUST_USE_RESULT
     base::Status BuildEncodePrimaryField(::llvm::Value* buf, size_t idx, const NativeValue& val);
 
  private:

--- a/hybridse/src/codegen/buf_ir_builder_test.cc
+++ b/hybridse/src/codegen/buf_ir_builder_test.cc
@@ -187,7 +187,6 @@ void RunEncode(::hybridse::type::TableDef& table, // NOLINT
     auto jit = std::unique_ptr<vm::HybridSeJitWrapper>(
         vm::HybridSeJitWrapper::Create());
     jit->Init();
-    vm::HybridSeJitWrapper::InitJitSymbols(jit.get());
     ASSERT_TRUE(jit->AddModule(std::move(m), std::move(ctx)));
     auto load_fn_jit = jit->FindFunction("fn");
     void (*decode)(int8_t**) =
@@ -307,7 +306,6 @@ void LoadValue(T* result, bool* is_null,
     auto jit = std::unique_ptr<vm::HybridSeJitWrapper>(
         vm::HybridSeJitWrapper::Create());
     jit->Init();
-    vm::HybridSeJitWrapper::InitJitSymbols(jit.get());
     ASSERT_TRUE(jit->AddModule(std::move(m), std::move(ctx)));
     auto load_fn_jit = jit->FindFunction("fn");
 
@@ -438,7 +436,6 @@ void RunColCase(T expected, type::TableDef& table,  // NOLINT
     auto jit = std::unique_ptr<vm::HybridSeJitWrapper>(
         vm::HybridSeJitWrapper::Create());
     jit->Init();
-    vm::HybridSeJitWrapper::InitJitSymbols(jit.get());
     ASSERT_TRUE(jit->AddModule(std::move(m), std::move(ctx)));
     jit->AddExternalFunction("print_list_i16",
                              reinterpret_cast<void*>(&PrintListInt16));

--- a/hybridse/src/codegen/fn_ir_builder_test.cc
+++ b/hybridse/src/codegen/fn_ir_builder_test.cc
@@ -82,7 +82,6 @@ void CheckResult(node::FnNodeFnDef *fn_def, R exp, V1 a, V2 b) {
     m->print(::llvm::errs(), NULL, true, true);
     auto jit = std::unique_ptr<vm::HybridSeJitWrapper>(vm::HybridSeJitWrapper::Create());
     jit->Init();
-    vm::HybridSeJitWrapper::InitJitSymbols(jit.get());
     ASSERT_TRUE(jit->AddModule(std::move(m), std::move(ctx)));
     auto test_fn = (R(*)(V1, V2))jit->FindFunction(fn_def->header_->GeIRFunctionName());
     R result = test_fn(a, b);

--- a/hybridse/src/codegen/fn_let_ir_builder_test.h
+++ b/hybridse/src/codegen/fn_let_ir_builder_test.h
@@ -134,7 +134,6 @@ void CheckFnLetBuilderWithParameterRow(::hybridse::node::NodeManager* manager, v
     auto jit = std::unique_ptr<vm::HybridSeJitWrapper>(
         vm::HybridSeJitWrapper::Create());
     jit->Init();
-    vm::HybridSeJitWrapper::InitJitSymbols(jit.get());
 
     ASSERT_TRUE(jit->AddModule(std::move(m), std::move(ctx)));
     auto address = jit->FindFunction("test_at_fn");

--- a/hybridse/src/codegen/insert_row_builder.cc
+++ b/hybridse/src/codegen/insert_row_builder.cc
@@ -21,7 +21,9 @@
 #include <utility>
 #include <vector>
 
+#include "absl/cleanup/cleanup.h"
 #include "absl/status/status.h"
+#include "absl/strings/str_join.h"
 #include "base/fe_status.h"
 #include "codegen/buf_ir_builder.h"
 #include "codegen/context.h"
@@ -29,39 +31,36 @@
 #include "node/node_manager.h"
 #include "passes/resolve_fn_and_attrs.h"
 #include "udf/default_udf_library.h"
-#include "vm/engine.h"
 #include "vm/jit_wrapper.h"
 
 namespace hybridse {
 namespace codegen {
 
-InsertRowBuilder::InsertRowBuilder(const codec::Schema* schema) : schema_(schema) {}
-
-absl::Status InsertRowBuilder::Init() {
-    ::hybridse::vm::Engine::InitializeGlobalLLVM();
-
-    jit_ = std::unique_ptr<vm::HybridSeJitWrapper>(vm::HybridSeJitWrapper::Create());
-    if (!jit_->Init()) {
-        jit_ = nullptr;
-        return absl::InternalError("fail to init jit");
-    }
-    if (!vm::HybridSeJitWrapper::InitJitSymbols(jit_.get())) {
-        jit_ = nullptr;
-        return absl::InternalError("fail to init jit symbols");
-    }
-    return absl::OkStatus();
-}
+InsertRowBuilder::InsertRowBuilder(vm::HybridSeJitWrapper* jit, const codec::Schema* schema)
+    : schema_(schema), jit_(jit) {}
 
 absl::StatusOr<std::shared_ptr<int8_t>> InsertRowBuilder::ComputeRow(const node::ExprListNode* values) {
-    EnsureInitialized();
     return ComputeRow(values->children_);
 }
 
 absl::StatusOr<std::shared_ptr<int8_t>> InsertRowBuilder::ComputeRow(absl::Span<node::ExprNode* const> values) {
-    EnsureInitialized();
+    auto rs = ComputeRowUnsafe(values);
+    CHECK_ABSL_STATUSOR(rs);
+
+    auto managed_row = std::shared_ptr<int8_t>(rs.value(), std::free);
+    return managed_row;
+}
+
+absl::StatusOr<int8_t*> InsertRowBuilder::ComputeRowUnsafe(absl::Span<node::ExprNode* const> values) {
+    absl::Cleanup clean = [&]() { fn_counter_++; };
+
+    DLOG(INFO) << absl::StrJoin(values, ", ", [](std::string* str, const node::ExprNode* const expr) {
+        absl::StrAppend(str, expr->GetExprString());
+    });
 
     std::unique_ptr<llvm::LLVMContext> llvm_ctx = llvm::make_unique<llvm::LLVMContext>();
-    std::unique_ptr<llvm::Module> llvm_module = llvm::make_unique<llvm::Module>("insert_row_builder", *llvm_ctx);
+    std::unique_ptr<llvm::Module> llvm_module =
+        llvm::make_unique<llvm::Module>(absl::StrCat("insert_row_builder_", fn_counter_.load()), *llvm_ctx);
     vm::SchemasContext empty_sc;
     node::NodeManager nm;
     codec::Schema empty_param_types;
@@ -78,7 +77,7 @@ absl::StatusOr<std::shared_ptr<int8_t>> InsertRowBuilder::ComputeRow(absl::Span<
         transformed.push_back(out);
     }
 
-    std::string fn_name = absl::StrCat("gen_insert_row_", fn_counter_++);
+    std::string fn_name = absl::StrCat("gen_insert_row_", fn_counter_.load());
     auto fs = BuildFn(&dump_ctx, fn_name, transformed);
     CHECK_ABSL_STATUSOR(fs);
 
@@ -98,9 +97,7 @@ absl::StatusOr<std::shared_ptr<int8_t>> InsertRowBuilder::ComputeRow(absl::Span<
     int8_t* insert_row = nullptr;
     encode(&insert_row);
 
-    auto managed_row = std::shared_ptr<int8_t>(insert_row, std::free);
-
-    return managed_row;
+    return insert_row;
 }
 
 absl::StatusOr<llvm::Function*> InsertRowBuilder::BuildFn(CodeGenContext* ctx, llvm::StringRef fn_name,
@@ -135,7 +132,7 @@ absl::StatusOr<llvm::Function*> InsertRowBuilder::BuildFn(CodeGenContext* ctx, l
         BufNativeEncoderIRBuilder encode_builder(ctx, &columns, schema_);
         CHECK_STATUS_TO_ABSL(encode_builder.Init());
 
-        encode_builder.BuildEncode(row_ptr_ptr);
+        CHECK_STATUS_TO_ABSL(encode_builder.BuildEncode(row_ptr_ptr));
 
         builder->CreateRetVoid();
     }
@@ -143,7 +140,5 @@ absl::StatusOr<llvm::Function*> InsertRowBuilder::BuildFn(CodeGenContext* ctx, l
     return fn;
 }
 
-// build the function that transform a single insert row values into encoded row
-absl::StatusOr<llvm::Function*> InsertRowBuilder::BuildEncodeFn() { return absl::OkStatus(); }
 }  // namespace codegen
 }  // namespace hybridse

--- a/hybridse/src/codegen/insert_row_builder_test.cc
+++ b/hybridse/src/codegen/insert_row_builder_test.cc
@@ -54,9 +54,8 @@ TEST_F(InsertRowBuilderTest, encode) {
 
     auto jit = std::shared_ptr<vm::HybridSeJitWrapper>(vm::HybridSeJitWrapper::Create());
     ASSERT_TRUE(jit->Init());
-    ASSERT_TRUE(vm::HybridSeJitWrapper::InitJitSymbols(jit.get()));
 
-    InsertRowBuilder builder(jit, &sc);
+    InsertRowBuilder builder(jit.get(), &sc);
 
     auto as = builder.ComputeRow(dynamic_cast<node::ExprListNode*>(exprlist));
     ASSERT_TRUE(as.ok()) << as.status();

--- a/hybridse/src/codegen/insert_row_builder_test.cc
+++ b/hybridse/src/codegen/insert_row_builder_test.cc
@@ -22,6 +22,7 @@
 #include "node/sql_node.h"
 #include "plan/plan_api.h"
 #include "vm/sql_ctx.h"
+#include "vm/engine.h"
 
 namespace hybridse {
 namespace codegen {
@@ -51,11 +52,11 @@ TEST_F(InsertRowBuilderTest, encode) {
         map_ty->mutable_value_type()->set_base_type(type::kVarchar);
     }
 
-    InsertRowBuilder builder(&sc);
-    {
-        auto s = builder.Init();
-        ASSERT_TRUE(s.ok()) << s;
-    }
+    auto jit = std::shared_ptr<vm::HybridSeJitWrapper>(vm::HybridSeJitWrapper::Create());
+    ASSERT_TRUE(jit->Init());
+    ASSERT_TRUE(vm::HybridSeJitWrapper::InitJitSymbols(jit.get()));
+
+    InsertRowBuilder builder(jit, &sc);
 
     auto as = builder.ComputeRow(dynamic_cast<node::ExprListNode*>(exprlist));
     ASSERT_TRUE(as.ok()) << as.status();
@@ -67,5 +68,6 @@ TEST_F(InsertRowBuilderTest, encode) {
 //
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
+    ::hybridse::vm::Engine::InitializeGlobalLLVM();
     return RUN_ALL_TESTS();
 }

--- a/hybridse/src/codegen/ir_base_builder_test.h
+++ b/hybridse/src/codegen/ir_base_builder_test.h
@@ -197,14 +197,12 @@ class ModuleTestFunction {
                        std::unique_ptr<::llvm::LLVMContext> llvm_ctx) {
         llvm::InitializeNativeTarget();
         llvm::InitializeNativeTargetAsmPrinter();
-        jit = std::unique_ptr<vm::HybridSeJitWrapper>(
-            vm::HybridSeJitWrapper::Create());
-        jit->Init();
-        InitBuiltinJitSymbols(jit.get());
-        if (library != nullptr) {
-            library->InitJITSymbols(jit.get());
-        } else {
-            udf::DefaultUdfLibrary::get()->InitJITSymbols(jit.get());
+        base::Status s;
+        jit =
+            std::unique_ptr<vm::HybridSeJitWrapper>(vm::HybridSeJitWrapper::CreateWithDefaultSymbols(library, &s, {}));
+        if (jit == nullptr || !s.isOK()) {
+            LOG(WARNING) << "create jit failed" << s;
+            return;
         }
 
         llvm::errs() << *(module.get()) << "\n";

--- a/hybridse/src/codegen/map_ir_builder.cc
+++ b/hybridse/src/codegen/map_ir_builder.cc
@@ -81,6 +81,13 @@ absl::StatusOr<NativeValue> MapIRBuilder::Construct(CodeGenContextBase* ctx, abs
     }
 
     auto builder = ctx->GetBuilder();
+    if (args.empty()) {
+        if (!Set(ctx->GetCurrentBlock(), map_alloca, SZ_IDX, builder->getInt32(0))) {
+            return absl::InternalError("setting map size=0 for map failed");
+        }
+        return NativeValue::Create(map_alloca);
+    }
+
     auto* original_size = builder->getInt32(args.size() / 2);
     auto* key_vec = builder->CreateAlloca(key_type_, original_size, "key_vec");
     auto* value_vec = builder->CreateAlloca(value_type_, original_size, "value_vec");
@@ -210,15 +217,18 @@ absl::StatusOr<NativeValue> MapIRBuilder::ExtractElement(CodeGenContextBase* ctx
 
         auto builder = ctx->GetBuilder();
 
-        auto s = ctx->CreateBranch(
+        builder->CreateStore(builder->getInt1(true), out_null_alloca_param);
+
+        auto s = ctx->CreateBranchNot(
             builder->CreateOr(arr_is_null_param, key_is_null_param),
-            [&]() -> base::Status {
-                builder->CreateStore(builder->getInt1(true), out_null_alloca_param);
-                return {};
-            },
             [&]() -> base::Status {
                 ::llvm::Value* sz = nullptr;
                 CHECK_TRUE(Load(ctx->GetCurrentBlock(), map_ptr_param, SZ_IDX, &sz), common::kCodegenError);
+
+                CHECK_STATUS(ctx->CreateBranch(builder->CreateICmpSLE(sz, builder->getInt32(0)), [&]() -> base::Status {
+                    builder->CreateRetVoid();
+                    return {};
+                }));
 
                 ::llvm::Value* keys = nullptr;
                 CHECK_TRUE(Load(ctx->GetCurrentBlock(), map_ptr_param, KEY_VEC_IDX, &keys), common::kCodegenError);
@@ -393,6 +403,12 @@ absl::StatusOr<llvm::Function*> MapIRBuilder::BuildEncodeByteSizeFn(CodeGenConte
         auto& key_vec = elements_vec[1];
         auto& value_vec = elements_vec[2];
         auto& value_null_vec = elements_vec[3];
+
+        CHECK_STATUS_TO_ABSL(
+            ctx->CreateBranch(builder->CreateICmpSLE(map_size, builder->getInt32(0)), [&]() -> base::Status {
+                builder->CreateRet(CodecSizeForPrimitive(builder, builder->getInt32Ty()));
+                return {};
+            }));
 
         auto keys_sz = CalEncodeSizeForArray(ctx, key_vec, map_size);
         CHECK_ABSL_STATUSOR(keys_sz);
@@ -712,61 +728,71 @@ absl::StatusOr<llvm::Value*> MapIRBuilder::EncodeBaseValue(CodeGenContextBase* c
 
 absl::StatusOr<llvm::Value*> MapIRBuilder::Decode(CodeGenContextBase* ctx, llvm::Value* row_ptr) const {
     auto* builder = ctx->GetBuilder();
-    auto* map_sz = builder->CreateLoad(builder->getInt32Ty(), row_ptr);
+    auto* map_sz = builder->CreateLoad(builder->getInt32Ty(),
+                                       builder->CreatePointerCast(row_ptr, builder->getInt32Ty()->getPointerTo()));
 
     llvm::Value* map_alloca = nullptr;
     if (!Allocate(ctx->GetCurrentBlock(), &map_alloca)) {
         return absl::InternalError("fail to allocate map");
     }
+    if (!Set(ctx->GetCurrentBlock(), map_alloca, SZ_IDX, builder->getInt32(0))) {
+        return absl::InternalError("fail to set default size for map");
+    }
 
-    // only work if allocation happens in the top function, otherwise vectors will be cleared
-    llvm::Value* key_vec = builder->CreateAlloca(key_type_, map_sz, "map_key_vec");
-    llvm::Value* value_vec = builder->CreateAlloca(value_type_, map_sz, "map_value_vec");
-    llvm::Value* value_nulls_vec = builder->CreateAlloca(builder->getInt1Ty(), map_sz, "map_nulls_vec");
+    CHECK_STATUS_TO_ABSL(ctx->CreateBranch(builder->CreateICmpSGT(map_sz, builder->getInt32(0)), [&]() -> base::Status {
+        // only work if allocation happens in the top function, otherwise vectors will be cleared
+        llvm::Value* key_vec = builder->CreateAlloca(key_type_, map_sz, "map_key_vec");
+        llvm::Value* value_vec = builder->CreateAlloca(value_type_, map_sz, "map_value_vec");
+        llvm::Value* value_nulls_vec = builder->CreateAlloca(builder->getInt1Ty(), map_sz, "map_nulls_vec");
 
-    llvm::Value* idx0_alloca = builder->CreateAlloca(builder->getInt32Ty());
-    builder->CreateStore(builder->getInt32(0), idx0_alloca);
-    // also allocate space for pointer type that points to
-    CHECK_STATUS_TO_ABSL(ctx->CreateWhile(
-        [&](llvm::Value** cond) -> base::Status {
-            *cond = ctx->GetBuilder()->CreateICmpSLT(builder->CreateLoad(idx0_alloca), map_sz);
-            return {};
-        },
-        [&]() -> base::Status {
-            llvm::Value* idx = builder->CreateLoad(idx0_alloca);
-            if (key_type_->isPointerTy()) {
-                auto* ele_val = builder->CreateAlloca(key_type_->getPointerElementType());
-                builder->CreateStore(ele_val, builder->CreateGEP(key_type_, key_vec, idx));
-            }
-            if (value_type_->isPointerTy()) {
-                auto* ele_val = builder->CreateAlloca(value_type_->getPointerElementType());
-                builder->CreateStore(ele_val, builder->CreateGEP(value_type_, value_vec, idx));
-            }
+        llvm::Value* idx0_alloca = builder->CreateAlloca(builder->getInt32Ty());
+        builder->CreateStore(builder->getInt32(0), idx0_alloca);
+        // also allocate space for pointer type that points to
+        CHECK_STATUS(ctx->CreateWhile(
+            [&](llvm::Value** cond) -> base::Status {
+                *cond = ctx->GetBuilder()->CreateICmpSLT(builder->CreateLoad(idx0_alloca), map_sz);
+                return {};
+            },
+            [&]() -> base::Status {
+                llvm::Value* idx = builder->CreateLoad(idx0_alloca);
+                if (key_type_->isPointerTy()) {
+                    auto* ele_val = builder->CreateAlloca(key_type_->getPointerElementType());
+                    builder->CreateStore(ele_val, builder->CreateGEP(key_type_, key_vec, idx));
+                }
+                if (value_type_->isPointerTy()) {
+                    auto* ele_val = builder->CreateAlloca(value_type_->getPointerElementType());
+                    builder->CreateStore(ele_val, builder->CreateGEP(value_type_, value_vec, idx));
+                }
 
-            builder->CreateStore(builder->CreateAdd(builder->getInt32(1), idx), idx0_alloca);
-            return {};
-        }));
+                builder->CreateStore(builder->CreateAdd(builder->getInt32(1), idx), idx0_alloca);
+                return {};
+            }));
 
-    auto s0 = BuildGetPtrOffset(builder, row_ptr, builder->getInt32(4), builder->getInt8Ty()->getPointerTo());
-    CHECK_ABSL_STATUSOR(s0);
-    auto key_vec_res = DecodeArrayValue(ctx, s0.value(), map_sz, key_vec, key_type_);
-    CHECK_ABSL_STATUSOR(key_vec_res);
+        auto s0 = BuildGetPtrOffset(builder, row_ptr, builder->getInt32(4), builder->getInt8Ty()->getPointerTo());
+        CHECK_TRUE(s0.ok(), common::kCodegenError, s0.status());
+        auto key_vec_res = DecodeArrayValue(ctx, s0.value(), map_sz, key_vec, key_type_);
+        CHECK_TRUE(key_vec_res.ok(), common::kCodegenError, key_vec_res.status());
 
-    auto s1 = BuildGetPtrOffset(builder, row_ptr, builder->CreateAdd(builder->getInt32(4), key_vec_res.value()),
-                                builder->getInt8Ty()->getPointerTo());
-    CHECK_ABSL_STATUSOR(s1);
-    auto value_vec_res = DecodeArrayValue(ctx, s1.value(), map_sz, value_vec, value_type_);
-    CHECK_ABSL_STATUSOR(value_vec_res);
+        auto s1 = BuildGetPtrOffset(builder, row_ptr, builder->CreateAdd(builder->getInt32(4), key_vec_res.value()),
+                                    builder->getInt8Ty()->getPointerTo());
+        CHECK_TRUE(s1.ok(), common::kCodegenError, s1.status());
+        auto value_vec_res = DecodeArrayValue(ctx, s1.value(), map_sz, value_vec, value_type_);
+        CHECK_TRUE(value_vec_res.ok(), common::kCodegenError, value_vec_res.status());
 
-    auto s2 = BuildGetPtrOffset(
-        builder, row_ptr,
-        builder->CreateAdd(builder->getInt32(4), builder->CreateAdd(key_vec_res.value(), value_vec_res.value())),
-        builder->getInt8Ty()->getPointerTo());
-    CHECK_ABSL_STATUSOR(s2);
-    auto value_null_vec_res = DecodeArrayValue(ctx, s2.value(), map_sz, value_nulls_vec, builder->getInt1Ty());
-    CHECK_ABSL_STATUSOR(value_null_vec_res);
+        auto s2 = BuildGetPtrOffset(
+            builder, row_ptr,
+            builder->CreateAdd(builder->getInt32(4), builder->CreateAdd(key_vec_res.value(), value_vec_res.value())),
+            builder->getInt8Ty()->getPointerTo());
+        CHECK_TRUE(s2.ok(), common::kCodegenError, s2.status());
+        auto value_null_vec_res = DecodeArrayValue(ctx, s2.value(), map_sz, value_nulls_vec, builder->getInt1Ty());
+        CHECK_TRUE(value_null_vec_res.ok(), common::kCodegenError, value_null_vec_res.status());
 
-    CHECK_ABSL_STATUS(Set(ctx, map_alloca, {map_sz, key_vec, value_vec, value_nulls_vec}));
+        {
+            auto s = Set(ctx, map_alloca, {map_sz, key_vec, value_vec, value_nulls_vec});
+            CHECK_TRUE(s.ok(), common::kCodegenError, s);
+        }
+        return {};
+    }));
 
     return map_alloca;
 }
@@ -837,7 +863,8 @@ absl::StatusOr<llvm::Value*> MapIRBuilder::DecodeBaseValue(CodeGenContextBase* c
                                                            llvm::Value* base_ptr, llvm::Type* type) const {
     auto builder = ctx->GetBuilder();
     if (type->isIntegerTy() || type->isFloatTy() || type->isDoubleTy()) {
-        builder->CreateStore(builder->CreateLoad(type, ptr), base_ptr);
+        builder->CreateStore(builder->CreateLoad(type, builder->CreatePointerCast(ptr, type->getPointerTo())),
+                             base_ptr);
         return CodecSizeForPrimitive(builder, type);
     }
     // struct pointer

--- a/hybridse/src/sdk/hybridse_interface_core.i
+++ b/hybridse/src/sdk/hybridse_interface_core.i
@@ -196,6 +196,7 @@ using hybridse::node::DataType;
 %include "node/node_enum.h"
 %include "node/plan_node.h"
 %include "node/sql_node.h"
+%include "node/node_manager.h"
 %include "vm/catalog.h"
 %include "vm/simple_catalog.h"
 %include "vm/schemas_context.h"
@@ -208,3 +209,4 @@ using hybridse::node::DataType;
 %include "vm/mem_catalog.h"
 
 %template(VectorDataType) std::vector<hybridse::node::DataType>;
+%template(ExprNodeVector) std::vector<hybridse::node::ExprNode*>;

--- a/hybridse/src/udf/default_udf_library.cc
+++ b/hybridse/src/udf/default_udf_library.cc
@@ -17,23 +17,24 @@
 #include "udf/default_udf_library.h"
 
 #include <algorithm>
+#include <functional>
 #include <limits>
+#include <queue>
 #include <string>
 #include <tuple>
 #include <unordered_set>
 #include <utility>
 #include <vector>
-#include <queue>
-#include <functional>
 
+#include "absl/cleanup/cleanup.h"
 #include "codegen/date_ir_builder.h"
 #include "codegen/string_ir_builder.h"
 #include "codegen/timestamp_ir_builder.h"
 #include "udf/containers.h"
+#include "udf/default_defs/date_and_time_def.h"
+#include "udf/default_defs/expr_def.h"
 #include "udf/udf.h"
 #include "udf/udf_registry.h"
-#include "udf/default_defs/expr_def.h"
-#include "udf/default_defs/date_and_time_def.h"
 
 using openmldb::base::Date;
 using openmldb::base::StringRef;
@@ -46,7 +47,8 @@ namespace hybridse {
 namespace udf {
 
 DefaultUdfLibrary* DefaultUdfLibrary::MakeDefaultUdf() {
-    LOG(INFO) << "Creating DefaultUdfLibrary";
+    absl::Time begin = absl::Now();
+    absl::Cleanup clean = [&]() { LOG(INFO) << "Created DefaultUdfLibrary in " << absl::Now() - begin; };
     return new DefaultUdfLibrary();
 }
 

--- a/hybridse/src/vm/jit.h
+++ b/hybridse/src/vm/jit.h
@@ -17,10 +17,8 @@
 #ifndef HYBRIDSE_SRC_VM_JIT_H_
 #define HYBRIDSE_SRC_VM_JIT_H_
 
-#include <map>
 #include <memory>
 #include <string>
-#include "llvm/ExecutionEngine/GenericValue.h"
 #include "llvm/ExecutionEngine/Orc/LLJIT.h"
 #include "vm/jit_wrapper.h"
 

--- a/hybridse/src/vm/jit.h
+++ b/hybridse/src/vm/jit.h
@@ -100,10 +100,6 @@ class HybridSeLlvmJitWrapper : public HybridSeJitWrapper {
 
     hybridse::vm::RawPtrHandle FindFunction(const std::string& funcname) override;
 
-    // llvm::Module* GetModule() {
-    // }
-    // llvm::LLVMContext* GetLlvmContext();
-
  private:
     std::unique_ptr<HybridSeJit> jit_;
     std::unique_ptr<::llvm::orc::MangleAndInterner> mi_;

--- a/hybridse/src/vm/jit_wrapper.cc
+++ b/hybridse/src/vm/jit_wrapper.cc
@@ -50,10 +50,12 @@ bool HybridSeJitWrapper::AddModuleFromBuffer(const base::RawBuffer& buf) {
     auto mem_buf = ::llvm::MemoryBuffer::getMemBuffer(buf_str);
     auto llvm_module = parseIR(*mem_buf, diagnostic, *llvm_ctx);
     if (llvm_module == nullptr) {
-        LOG(WARNING) << "Parse module failed: module string is\n" << buf_str;
+        LOG(WARNING) << "Parse module failed: module string is:\n" << buf_str;
         std::string err_msg;
         llvm::raw_string_ostream err_msg_stream(err_msg);
-        diagnostic.print("", err_msg_stream);
+        diagnostic.print("llvm_module_from_buf", err_msg_stream);
+        err_msg_stream.flush();
+        LOG(WARNING) << err_msg;
         return false;
     }
     return this->AddModule(std::move(llvm_module), std::move(llvm_ctx));

--- a/hybridse/src/vm/jit_wrapper.cc
+++ b/hybridse/src/vm/jit_wrapper.cc
@@ -43,6 +43,8 @@
 namespace hybridse {
 namespace vm {
 
+static void InitBuiltinJitSymbols(HybridSeJitWrapper* jit_ptr);
+
 bool HybridSeJitWrapper::AddModuleFromBuffer(const base::RawBuffer& buf) {
     std::string buf_str(buf.addr, buf.size);
     ::llvm::SMDiagnostic diagnostic;
@@ -61,14 +63,41 @@ bool HybridSeJitWrapper::AddModuleFromBuffer(const base::RawBuffer& buf) {
     return this->AddModule(std::move(llvm_module), std::move(llvm_ctx));
 }
 
+HybridSeJitWrapper::HybridSeJitWrapper() {}
+
+base::Status HybridSeJitWrapper::InitJitSymbols() {
+    // default builitin
+    InitBuiltinJitSymbols(this);
+    // udf external functions
+    if (lib_ == nullptr) {
+        lib_ = udf::DefaultUdfLibrary::get();
+    }
+    lib_->InitJITSymbols(this);
+    return {};
+}
+
 bool HybridSeJitWrapper::InitJitSymbols(HybridSeJitWrapper* jit) {
+    // default builitin
     InitBuiltinJitSymbols(jit);
+    // udf external functions
     udf::DefaultUdfLibrary::get()->InitJITSymbols(jit);
     return true;
 }
 
 HybridSeJitWrapper* HybridSeJitWrapper::Create() {
     return Create(JitOptions());
+}
+
+HybridSeJitWrapper* HybridSeJitWrapper::CreateWithDefaultSymbols(udf::UdfLibrary* lib, base::Status* status,
+                                                                 const JitOptions& options) {
+    auto jit = vm::HybridSeJitWrapper::Create(options);
+    jit->SetLib(lib);
+    if (!jit->Init()) {
+        LOG(WARNING) << "fail to init jit";
+        *status = {common::kCodegenError, "fail to init jit"};
+        return nullptr;
+    }
+    return jit;
 }
 
 HybridSeJitWrapper* HybridSeJitWrapper::Create(const JitOptions& jit_options) {

--- a/hybridse/src/vm/jit_wrapper_test.cc
+++ b/hybridse/src/vm/jit_wrapper_test.cc
@@ -83,7 +83,6 @@ void simple_test(const EngineOptions &options) {
     ASSERT_FALSE(ir_str.empty());
     HybridSeJitWrapper *jit = HybridSeJitWrapper::Create();
     ASSERT_TRUE(jit->Init());
-    HybridSeJitWrapper::InitJitSymbols(jit);
 
     base::RawBuffer ir_buf(const_cast<char *>(ir_str.data()), ir_str.size());
     ASSERT_TRUE(jit->AddModuleFromBuffer(ir_buf));
@@ -151,7 +150,6 @@ TEST_F(JitWrapperTest, test_window) {
     ASSERT_FALSE(ir_str.empty());
     HybridSeJitWrapper *jit = HybridSeJitWrapper::Create();
     ASSERT_TRUE(jit->Init());
-    HybridSeJitWrapper::InitJitSymbols(jit);
 
     base::RawBuffer ir_buf(const_cast<char *>(ir_str.data()), ir_str.size());
     ASSERT_TRUE(jit->AddModuleFromBuffer(ir_buf));

--- a/hybridse/src/vm/sql_compiler.cc
+++ b/hybridse/src/vm/sql_compiler.cc
@@ -108,17 +108,12 @@ bool SqlCompiler::Compile(SqlContext& ctx, Status& status) {  // NOLINT
         m->print(::llvm::errs(), NULL, true, true);
         return false;
     }
-    // ::llvm::errs() << *(m.get());
     auto jit = std::shared_ptr<HybridSeJitWrapper>(
-        HybridSeJitWrapper::Create(ctx.jit_options));
-    if (jit == nullptr || !jit->Init()) {
-        status.msg = "fail to init jit let";
-        status.code = common::kJitError;
+        HybridSeJitWrapper::CreateWithDefaultSymbols(ctx.udf_library, &status, ctx.jit_options));
+    if (!status.isOK()) {
         LOG(WARNING) << status;
         return false;
     }
-    InitBuiltinJitSymbols(jit.get());
-    ctx.udf_library->InitJITSymbols(jit.get());
     if (!jit->OptModule(m.get())) {
         LOG(WARNING) << "fail to opt ir module for sql " << ctx.sql;
         return false;

--- a/java/hybridse-sdk/src/main/java/com/_4paradigm/hybridse/sdk/JitManager.java
+++ b/java/hybridse-sdk/src/main/java/com/_4paradigm/hybridse/sdk/JitManager.java
@@ -54,20 +54,9 @@ public class JitManager {
             if(!jit.Init()){
                 throw new RuntimeException("Fail to init jit");
             }
-            HybridSeJitWrapper.InitJitSymbols(jit);
             jits.put(tag, jit);
         }
         return jits.get(tag);
-    }
-
-
-    public static synchronized void rmoveJit(String tag) {
-        // HybridSeJitWrapper is a proxy class to C pointer, Java do not automatic
-        // lifetime of C pointer, so it must made explicitly
-        HybridSeJitWrapper e = jits.remove(tag);
-        if (e != null) {
-            HybridSeJitWrapper.DeleteJit(e);
-        }
     }
 
     private static JitOptions getJitOptions() {
@@ -145,6 +134,8 @@ public class JitManager {
      * @param tag module tag
      */
     public static synchronized void removeModule(String tag) {
+        // HybridSeJitWrapper is a proxy class to C pointer, Java do not automatic
+        // lifetime of C pointer, so it must made explicitly
         initializedModuleTags.remove(tag);
         HybridSeJitWrapper jit = jits.remove(tag);
         if (jit != null) {

--- a/java/hybridse-sdk/src/main/java/com/_4paradigm/hybridse/sdk/JitManager.java
+++ b/java/hybridse-sdk/src/main/java/com/_4paradigm/hybridse/sdk/JitManager.java
@@ -60,6 +60,16 @@ public class JitManager {
         return jits.get(tag);
     }
 
+
+    public static synchronized void rmoveJit(String tag) {
+        // HybridSeJitWrapper is a proxy class to C pointer, Java do not automatic
+        // lifetime of C pointer, so it must made explicitly
+        HybridSeJitWrapper e = jits.remove(tag);
+        if (e != null) {
+            HybridSeJitWrapper.DeleteJit(e);
+        }
+    }
+
     private static JitOptions getJitOptions() {
         JitOptions options = new JitOptions();
         try (InputStream input = JitManager.class.getClassLoader().getResourceAsStream("jit.properties")) {

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/SparkRowCodec.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/SparkRowCodec.scala
@@ -18,17 +18,23 @@ package com._4paradigm.openmldb.batch
 
 import java.sql.{Date, Timestamp}
 
-import com._4paradigm.hybridse.codec.{RowBuilder, RowView, Row => NativeRow}
+import com._4paradigm.hybridse.codec.{RowBuilder, RowView, Row => NativeRow, RowBuilder2}
+import com._4paradigm.std.{ExprNodeVector}
 import com._4paradigm.hybridse.sdk.HybridSeException
+import com._4paradigm.hybridse.sdk.JitManager
 import com._4paradigm.hybridse.vm.CoreAPI
+import com._4paradigm.hybridse.node.{NodeManager, ExprNode}
 import com._4paradigm.openmldb.batch.utils.HybridseUtil
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{BooleanType, DateType, DoubleType, FloatType, IntegerType, LongType, ShortType,
-  StringType, StructType, TimestampType}
+  StringType, StructType, TimestampType, MapType, ArrayType, DataType}
 import org.slf4j.LoggerFactory
 import java.util.Calendar
+import java.text.SimpleDateFormat
+import scala.collection.JavaConverters.asScalaBufferConverter
 
 import scala.collection.mutable
+import com._4paradigm.hybridse.`type`.TypeOuterClass.ColumnDef
 
 
 class SparkRowCodec(sliceSchemas: Array[StructType]) {
@@ -36,6 +42,9 @@ class SparkRowCodec(sliceSchemas: Array[StructType]) {
   private val logger = LoggerFactory.getLogger(this.getClass)
   private val sliceNum = sliceSchemas.length
   private val columnDefSegmentList = sliceSchemas.map(HybridseUtil.getHybridseSchema)
+
+  private val newEncoder =
+    columnDefSegmentList.foldLeft(false)((res, sc) => res || requireNewEncoder(sc.asScala.toArray))
 
   // for encode
   private var rowBuilders = columnDefSegmentList.map(cols => new RowBuilder(cols))
@@ -50,6 +59,32 @@ class SparkRowCodec(sliceSchemas: Array[StructType]) {
 
 
   def encode(row: Row): NativeRow = {
+    if (newEncoder) {
+      val jit = JitManager.getJit("rowbuilder2")
+      var newRowBuilder = new RowBuilder2(jit, sliceSchemas.size)
+      for (i <- 0 until columnDefSegmentList.size) {
+        val s = newRowBuilder.InitSchema(i, columnDefSegmentList(i))
+        if (!s.isOK()) {
+          throw new HybridSeException(s.str())
+        }
+      }
+      var s = newRowBuilder.Init()
+      if (!s.isOK()) {
+        throw new HybridSeException(s.str())
+      }
+
+      var nm = new NodeManager();
+      var vec = sparkRowToNativeExprVec(row, nm)
+
+      var nativeRow = new NativeRow()
+      s = newRowBuilder.Build(vec, nativeRow)
+      if (!s.isOK()) {
+        throw new HybridSeException(s.str())
+      }
+      JitManager.removeModule("rowbuilder2")
+      return nativeRow
+    }
+
     var result: NativeRow = null
     // collect slice size and string raw bytes
     val sliceSizes = Array.fill(sliceNum)(0)
@@ -153,7 +188,7 @@ class SparkRowCodec(sliceSchemas: Array[StructType]) {
     }
   }
 
-  def encodeSingle(row: Row, outBuf: Long, outSize: Int,
+  private def encodeSingle(row: Row, outBuf: Long, outSize: Int,
                    sliceStrings: Seq[Array[Byte]], sliceIndex: Int): Unit = {
     val rowBuilder = rowBuilders(sliceIndex)
     val schema = sliceSchemas(sliceIndex)
@@ -216,7 +251,7 @@ class SparkRowCodec(sliceSchemas: Array[StructType]) {
   }
 
 
-  def decodeSingle(nativeRow: NativeRow, output: Array[Any], sliceIndex: Int): Unit = {
+  private def decodeSingle(nativeRow: NativeRow, output: Array[Any], sliceIndex: Int): Unit = {
     val rowView = rowViews(sliceIndex)
     val schema = sliceSchemas(sliceIndex)
 
@@ -276,6 +311,111 @@ class SparkRowCodec(sliceSchemas: Array[StructType]) {
     })
   }
 
+  private def requireNewEncoder(schema: Array[ColumnDef]): Boolean = {
+    schema.foldLeft(false)((res, col) => {
+      res || col.getSchema().hasArrayType() || col.getSchema().hasMapType()
+    })
+  }
+
+  private def sparkRowToNativeExprVec(row: Row, nm: NodeManager): ExprNodeVector = {
+    var vec = new ExprNodeVector()
+
+    var idx = 0
+    sliceSchemas.foreach(st => {
+      st.foreach(col => {
+        var expr = sparkColToNativeExpr(row, idx, col.dataType, nm)
+        vec.add(expr)
+        idx += 1
+      })
+    })
+
+    vec
+  }
+
+  private def sparkColToNativeExpr(row: Row, idx: Int, dataType: DataType, nm: NodeManager): ExprNode = {
+      if (row.isNullAt(idx)) {
+        nm.MakeConstNode()
+      } else {
+        dataType match {
+          case ShortType =>
+            nm.MakeConstNode(row.getShort(idx))
+          case IntegerType =>
+            nm.MakeConstNode(row.getInt(idx))
+          case LongType =>
+            nm.MakeConstNode(row.getLong(idx))
+          case FloatType =>
+            nm.MakeConstNode(row.getFloat(idx))
+          case DoubleType =>
+            nm.MakeConstNode(row.getDouble(idx))
+          case BooleanType =>
+            nm.MakeConstNode(row.getBoolean(idx))
+          case StringType => {
+            // generally safe, native ConstNode copyed the string
+            val str = row.getString(idx)
+            nm.MakeConstNode(str)
+          }
+          case TimestampType => {
+            var args = nm.MakeExprList()
+            args.AddChild(nm.MakeConstNode(row.getTimestamp(idx).getTime))
+            nm.MakeFuncNode("timestamp", args, null)
+          }
+          case DateType => {
+            val date = row.getDate(idx)
+            val fmt = new SimpleDateFormat("yyyy-MM-dd")
+            var str = fmt.format(date)
+            var args = nm.MakeExprList()
+            args.AddChild(nm.MakeConstNode(str))
+            nm.MakeFuncNode("date", args, null)
+          }
+          case MapType(keyType, valType, valContainsNull) => {
+            var mapVal = row.getMap[Any, Any](idx)
+            // logger.warn(s"map val ${mapVal}")
+            var args = nm.MakeExprList()
+            mapVal.foreach(kv => {
+              args.AddChild(valToNativeExpr(kv._1, keyType, nm))
+              args.AddChild(valToNativeExpr(kv._2, valType, nm))
+            })
+            nm.MakeFuncNode("map", args, null)
+          }
+          case _ => throw new IllegalArgumentException(
+            s"Spark type ${dataType} not supported")
+        }
+      }
+  }
+
+  private def valToNativeExpr(v: Any, dataType: DataType, nm: NodeManager): ExprNode = {
+    dataType match {
+      case ShortType => nm.MakeConstNode(v.asInstanceOf[Short])
+      case IntegerType => nm.MakeConstNode(v.asInstanceOf[Int])
+      case LongType => nm.MakeConstNode(v.asInstanceOf[Long])
+      case FloatType => nm.MakeConstNode(v.asInstanceOf[Float])
+      case DoubleType => nm.MakeConstNode(v.asInstanceOf[Double])
+      case BooleanType => nm.MakeConstNode(v.asInstanceOf[Boolean])
+      case StringType => nm.MakeConstNode(v.asInstanceOf[String])
+      case TimestampType =>
+        var args = nm.MakeExprList()
+        args.AddChild(nm.MakeConstNode(v.asInstanceOf[Long]))
+        nm.MakeFuncNode("timestamp", args, null)
+      case DateType =>
+        // date from string literal
+        var args = nm.MakeExprList()
+        args.AddChild(nm.MakeConstNode(v.asInstanceOf[String]))
+        nm.MakeFuncNode("date", args, null)
+      case MapType(keyType, valType, _) => {
+        var mapVal = v.asInstanceOf[Map[Any, Any]]
+        var args = nm.MakeExprList()
+        mapVal.foreach(kv => {
+          args.AddChild(valToNativeExpr(kv._1, keyType, nm))
+          args.AddChild(valToNativeExpr(kv._2, valType, nm))
+        })
+        // TODO(someone): support empty map, since 'map()' inferred as map<void, void>
+        // we need construst a extra cast operation to hint the true type from schema
+        nm.MakeFuncNode("map", args, null)
+      }
+      case _ => throw new IllegalArgumentException(
+        s"Spark type ${dataType} not supported")
+    }
+  }
 
   def delete(): Unit = {
     if (rowViews != null) {

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/SimpleProjectPlan.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/nodes/SimpleProjectPlan.scala
@@ -96,7 +96,11 @@ object SimpleProjectPlan {
         val sparkCol = SparkColumnUtil.getColumnFromIndex(inputDf, colIndex)
         val sparkType = inputDf.schema(colIndex).dataType
         val schemaType = DataTypeUtil.sparkTypeToHybridseProtoType(sparkType)
-        val innerType = DataTypeUtil.hybridseProtoTypeToOpenmldbType(schemaType)
+        if (!schemaType.hasBaseType()) {
+          throw new UnsupportedHybridSeException(
+            s"expression output type does not expect to be ${schemaType} for simple project")
+        }
+        val innerType = DataTypeUtil.hybridseProtoTypeToOpenmldbType(schemaType.getBaseType())
         sparkCol -> innerType
 
       case ExprType.kExprPrimary =>

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/utils/HybridseUtil.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/utils/HybridseUtil.scala
@@ -17,7 +17,7 @@
 package com._4paradigm.openmldb.batch.utils
 
 import java.util
-import com._4paradigm.hybridse.`type`.TypeOuterClass.{ColumnDef, Database, TableDef}
+import com._4paradigm.hybridse.`type`.TypeOuterClass.{ColumnDef, Database, TableDef, Type => HybridseProtoType}
 import com._4paradigm.hybridse.node.ConstNode
 import com._4paradigm.hybridse.sdk.UnsupportedHybridSeException
 import com._4paradigm.hybridse.vm.{PhysicalLoadDataNode, PhysicalOpNode, PhysicalSelectIntoNode}
@@ -70,10 +70,13 @@ object HybridseUtil {
   def getTableDef(tableName: String, dataFrame: DataFrame): TableDef = {
     val tblBulder = TableDef.newBuilder()
     dataFrame.schema.foreach(field => {
-      tblBulder.addColumns(ColumnDef.newBuilder()
+      var sc = DataTypeUtil.sparkTypeToHybridseProtoType(field.dataType)
+      tblBulder.addColumns(
+        ColumnDef.newBuilder()
         .setName(field.name)
         .setIsNotNull(!field.nullable)
-        .setType(DataTypeUtil.sparkTypeToHybridseProtoType(field.dataType))
+        .setSchema(sc)
+        .setType(if (sc.hasBaseType()) {sc.getBaseType()} else {HybridseProtoType.kNull})
         .build()
       )
     })
@@ -84,17 +87,20 @@ object HybridseUtil {
   def getHybridseSchema(structType: StructType): java.util.List[ColumnDef] = {
     val list = new util.ArrayList[ColumnDef]()
     structType.foreach(field => {
+      var sc = DataTypeUtil.sparkTypeToHybridseProtoType(field.dataType)
       list.add(ColumnDef.newBuilder()
         .setName(field.name)
         .setIsNotNull(!field.nullable)
-        .setType(DataTypeUtil.sparkTypeToHybridseProtoType(field.dataType)).build())
+        .setSchema(sc)
+        .setType(if (sc.hasBaseType()) {sc.getBaseType()} else {HybridseProtoType.kNull})
+        .build())
     })
     list
   }
 
   def getSparkSchema(columns: java.util.List[ColumnDef]): StructType = {
     StructType(columns.asScala.map(col => {
-      StructField(col.getName, DataTypeUtil.hybridseProtoTypeToSparkType(col.getType), !col.getIsNotNull)
+      StructField(col.getName, DataTypeUtil.hybridseProtoTypeToSparkType(col.getSchema), !col.getIsNotNull)
     }))
   }
 

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/TestProject.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/TestProject.scala
@@ -20,7 +20,7 @@ import com._4paradigm.openmldb.batch.SparkTestSuite
 import com._4paradigm.openmldb.batch.api.OpenmldbSession
 import com._4paradigm.openmldb.batch.utils.SparkUtil
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType, MapType}
 
 
 class TestProject extends SparkTestSuite {
@@ -43,4 +43,27 @@ class TestProject extends SparkTestSuite {
 
   }
 
+  test("Test end2end row project with map values") {
+    val spark = getSparkSession
+    val sess = new OpenmldbSession(spark)
+
+    val data = Seq(
+      Row(1, Map.apply(1 -> "11", 12 -> "99")),
+      Row(2, Map.apply(13 -> "99")))
+      // Row(2, Map.empty[Int, String]))
+    val schema = StructType(List(
+      StructField("id", IntegerType),
+      StructField("val", MapType(IntegerType, StringType))))
+    val df = spark.createDataFrame(spark.sparkContext.makeRDD(data), schema)
+
+    sess.registerTable("t1", df)
+    df.createOrReplaceTempView("t1")
+
+    val sqlText = "select id, val[12] as ele from t1"
+    val outputDf = sess.sql(sqlText)
+    outputDf.show()
+
+    val sparksqlOutputDf = sess.sparksql(sqlText)
+    assert(SparkUtil.approximateDfEqual(outputDf.getSparkDf(), sparksqlOutputDf, false))
+  }
 }

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/TestUnsafeRowProject.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/TestUnsafeRowProject.scala
@@ -20,7 +20,7 @@ import com._4paradigm.openmldb.batch.SparkTestSuite
 import com._4paradigm.openmldb.batch.api.OpenmldbSession
 import com._4paradigm.openmldb.batch.utils.SparkUtil
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.types.{IntegerType, StructField, StructType, MapType, StringType}
+import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
 
 class TestUnsafeRowProject extends SparkTestSuite {
@@ -54,30 +54,6 @@ class TestUnsafeRowProject extends SparkTestSuite {
 
     val sqlText = "SELECT id * 2, user + 1000 FROM t1"
     val outputDf = sess.sql(sqlText)
-
-    val sparksqlOutputDf = sess.sparksql(sqlText)
-    assert(SparkUtil.approximateDfEqual(outputDf.getSparkDf(), sparksqlOutputDf, false))
-  }
-
-  test("Test end2end UnsafeRow optimization for row project 2") {
-    // getSparkSession.conf.set("spark.openmldb.unsaferow.opt", true)
-    val spark = getSparkSession
-    val sess = new OpenmldbSession(spark)
-
-    val data = Seq(
-      Row(1, Map.apply(1 -> "11", 12 -> "99")))
-      // Row(2, Map.empty[Int, String]))
-    val schema = StructType(List(
-      StructField("id", IntegerType),
-      StructField("val", MapType(IntegerType, StringType))))
-    val df = spark.createDataFrame(spark.sparkContext.makeRDD(data), schema)
-
-    sess.registerTable("t1", df)
-    df.createOrReplaceTempView("t1")
-
-    val sqlText = "select id, val[12] as ele from t1"
-    val outputDf = sess.sql(sqlText)
-    outputDf.show()
 
     val sparksqlOutputDf = sess.sparksql(sqlText)
     assert(SparkUtil.approximateDfEqual(outputDf.getSparkDf(), sparksqlOutputDf, false))

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/TestUnsafeRowProject.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/end2end/TestUnsafeRowProject.scala
@@ -20,7 +20,7 @@ import com._4paradigm.openmldb.batch.SparkTestSuite
 import com._4paradigm.openmldb.batch.api.OpenmldbSession
 import com._4paradigm.openmldb.batch.utils.SparkUtil
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
+import org.apache.spark.sql.types.{IntegerType, StructField, StructType, MapType, StringType}
 
 
 class TestUnsafeRowProject extends SparkTestSuite {
@@ -59,4 +59,27 @@ class TestUnsafeRowProject extends SparkTestSuite {
     assert(SparkUtil.approximateDfEqual(outputDf.getSparkDf(), sparksqlOutputDf, false))
   }
 
+  test("Test end2end UnsafeRow optimization for row project 2") {
+    // getSparkSession.conf.set("spark.openmldb.unsaferow.opt", true)
+    val spark = getSparkSession
+    val sess = new OpenmldbSession(spark)
+
+    val data = Seq(
+      Row(1, Map.apply(1 -> "11", 12 -> "99")))
+      // Row(2, Map.empty[Int, String]))
+    val schema = StructType(List(
+      StructField("id", IntegerType),
+      StructField("val", MapType(IntegerType, StringType))))
+    val df = spark.createDataFrame(spark.sparkContext.makeRDD(data), schema)
+
+    sess.registerTable("t1", df)
+    df.createOrReplaceTempView("t1")
+
+    val sqlText = "select id, val[12] as ele from t1"
+    val outputDf = sess.sql(sqlText)
+    outputDf.show()
+
+    val sparksqlOutputDf = sess.sparksql(sqlText)
+    assert(SparkUtil.approximateDfEqual(outputDf.getSparkDf(), sparksqlOutputDf, false))
+  }
 }

--- a/src/sdk/sql_cluster_router.cc
+++ b/src/sdk/sql_cluster_router.cc
@@ -475,14 +475,15 @@ bool SQLClusterRouter::GetMultiRowInsertInfo(const std::string& db, const std::s
     // TODO(someone):
     // 1. default value from table definition
     // 2. parameters
-    ::hybridse::codegen::InsertRowBuilder insert_builder(&sc);
-    {
-        auto s = insert_builder.Init();
-        if (!s.ok()) {
-            SET_STATUS_AND_WARN(status, StatusCode::kCmdError, s.ToString());
-            return false;
-        }
+    ::hybridse::vm::Engine::InitializeGlobalLLVM();
+    auto jit = std::shared_ptr<hybridse::vm::HybridSeJitWrapper>(hybridse::vm::HybridSeJitWrapper::Create());
+    if (!jit->Init()) {
+        return false;
     }
+    if (!hybridse::vm::HybridSeJitWrapper::InitJitSymbols(jit.get())) {
+        return false;
+    }
+    ::hybridse::codegen::InsertRowBuilder insert_builder(jit, &sc);
 
     size_t total_rows_size = insert_stmt->values_.size();
     for (size_t i = 0; i < total_rows_size; i++) {

--- a/src/sdk/sql_cluster_router.cc
+++ b/src/sdk/sql_cluster_router.cc
@@ -480,10 +480,7 @@ bool SQLClusterRouter::GetMultiRowInsertInfo(const std::string& db, const std::s
     if (!jit->Init()) {
         return false;
     }
-    if (!hybridse::vm::HybridSeJitWrapper::InitJitSymbols(jit.get())) {
-        return false;
-    }
-    ::hybridse::codegen::InsertRowBuilder insert_builder(jit, &sc);
+    ::hybridse::codegen::InsertRowBuilder insert_builder(jit.get(), &sc);
 
     size_t total_rows_size = insert_stmt->values_.size();
     for (size_t i = 0; i < total_rows_size; i++) {


### PR DESCRIPTION
feat
-----
- query with map data type from offline
- native row builder for offline 

limitation 
------
- not able to native encode empty map value, native row builder need some work to take the correct type for empty map, since a empty map is translated to `map()` expression that will inferred as `map<void, void>`, it does not consider type in input schema
- each row will encoded with distinct native instance due to #3748, a jit can not add multiple modules
- unsaferow encoding for map values
