### PR TITLE
fix: replace Unrecognized VM option MaxPermSize with MaxMetaspaceSize

### DIFF
--- a/java/openmldb-batchjob/pom.xml
+++ b/java/openmldb-batchjob/pom.xml
@@ -16,8 +16,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
 
     <spark.scope>provided</spark.scope>
   </properties>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -294,7 +294,7 @@
                     <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
                     <junitxml>.</junitxml>
                     <filereports>WDF TestSuite.txt</filereports>
-                    <argLine>-Xmx8192m -XX:MaxPermSize=2048m -Duser.timezone=GMT+8</argLine>
+                    <argLine>-Xmx8192m -XX:MaxMetaspaceSize=2048m -Duser.timezone=GMT+8</argLine>
                     <skipTests>${scalatest.skip}</skipTests>
                     <systemProperties>
                         <property>


### PR DESCRIPTION
replace Unrecognized VM option MaxPermSize with MaxMetaspaceSize and upgrade openmldb-batchjob maven.compiler.source and maven.compiler.target to 1.8

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
https://github.com/4paradigm/OpenMLDB/issues/3755


* **What is the new behavior (if this is a feature change)?**

