### PR TITLE
feat: support map data type in yaml testing framework

### DIFF
--- a/cases/query/udf_query.yaml
+++ b/cases/query/udf_query.yaml
@@ -619,3 +619,22 @@ cases:
     sql: |
       select c1 + 8 from (select 9 as c1)
 
+  - id: 18
+    mode: request-unsupport
+    inputs:
+      - name: t1
+        columns: ["col1 int32", "std_ts timestamp", "col2 map<int,string>"]
+        indexs: ["index1:col1:std_ts"]
+        # insert map values by insert stmts only
+        inserts:
+          - "insert into t1 values (1, timestamp(1000), map(12, 'abc'))"
+          - "insert into t1 values (2, timestamp(1000), map(13, 'abc'))"
+    sql: |
+      select col1, col2[12] as out from t1;
+    expect:
+      order: col1
+      columns: ["col1 int", "out string"]
+      data: |
+        1, abc
+        2, null
+

--- a/hybridse/examples/toydb/src/cmd/toydb_run_engine.cc
+++ b/hybridse/examples/toydb/src/cmd/toydb_run_engine.cc
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <utility>
 
 #include "absl/strings/match.h"
 #include "testing/toydb_engine_test_base.h"
@@ -104,8 +103,7 @@ int RunSingle(const std::string& yaml_path) {
 
 int main(int argc, char** argv) {
     ::google::ParseCommandLineFlags(&argc, &argv, false);
-    InitializeNativeTarget();
-    InitializeNativeTargetAsmPrinter();
+    ::hybridse::vm::Engine::InitializeGlobalLLVM();
     if (FLAGS_yaml_path != "") {
         return ::hybridse::vm::RunSingle(FLAGS_yaml_path);
     } else {

--- a/hybridse/examples/toydb/src/testing/toydb_engine_test.cc
+++ b/hybridse/examples/toydb/src/testing/toydb_engine_test.cc
@@ -15,7 +15,7 @@
  */
 
 #include "gtest/gtest.h"
-#include "gtest/internal/gtest-param-util.h"
+#include "vm/engine.h"
 #include "testing/toydb_engine_test_base.h"
 
 using namespace llvm;       // NOLINT (build/namespaces)
@@ -126,8 +126,7 @@ TEST_P(BatchRequestEngineTest, TestClusterBatchRequestEngine) {
 }  // namespace hybridse
 
 int main(int argc, char** argv) {
-    InitializeNativeTarget();
-    InitializeNativeTargetAsmPrinter();
+    ::hybridse::vm::Engine::InitializeGlobalLLVM();
     ::testing::InitGoogleTest(&argc, argv);
     // ::hybridse::vm::CoreAPI::EnableSignalTraceback();
     return RUN_ALL_TESTS();

--- a/hybridse/examples/toydb/src/testing/toydb_engine_test_base.h
+++ b/hybridse/examples/toydb/src/testing/toydb_engine_test_base.h
@@ -26,6 +26,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/strings/substitute.h"
 #include "case/case_data_mock.h"
 #include "case/sql_case.h"
 #include "glog/logging.h"
@@ -98,6 +99,14 @@ class ToydbBatchEngineTestRunner : public BatchEngineTestRunner {
             CheckSqliteCompatible(sql_case_, GetSession()->GetSchema(), output_rows);
         }
     }
+    const type::TableDef* GetTableDef(absl::string_view db, absl::string_view table) override {
+        auto it = name_table_map_.find(std::make_pair(std::string(db), std::string(table)));
+        if (it == name_table_map_.end()) {
+            return nullptr;
+        }
+
+        return &it->second->GetTableDef();
+    }
 
  private:
     std::shared_ptr<tablet::TabletCatalog> catalog_;
@@ -141,6 +150,15 @@ class ToydbRequestEngineTestRunner : public RequestEngineTestRunner {
             return false;
         }
         return table->Put(reinterpret_cast<char*>(row.buf()), row.size());
+    }
+
+    const type::TableDef* GetTableDef(absl::string_view db, absl::string_view table) override {
+        auto it = name_table_map_.find(std::make_pair(std::string(db), std::string(table)));
+        if (it == name_table_map_.end()) {
+            return nullptr;
+        }
+
+        return &it->second->GetTableDef();
     }
 
  private:
@@ -188,6 +206,15 @@ class ToydbBatchRequestEngineTestRunner : public BatchRequestEngineTestRunner {
         }
         return table->Put(reinterpret_cast<char*>(row.buf()), row.size());
     }
+
+    const type::TableDef* GetTableDef(absl::string_view db, absl::string_view table) override {
+            auto it = name_table_map_.find(std::make_pair(std::string(db), std::string(table)));
+            if (it == name_table_map_.end()) {
+                return nullptr;
+            }
+
+            return &it->second->GetTableDef();
+        }
 
  private:
     std::shared_ptr<tablet::TabletCatalog> catalog_;

--- a/hybridse/include/case/sql_case.h
+++ b/hybridse/include/case/sql_case.h
@@ -118,10 +118,10 @@ class SqlCase {
     const codec::Schema ExtractParameterTypes() const;
 
     bool ExtractInputData(std::vector<hybridse::codec::Row>& rows,  // NOLINT
-                          int32_t input_idx = 0) const;
-    bool ExtractInputData(
-        const TableInfo& info,
-        std::vector<hybridse::codec::Row>& rows) const;  // NOLINT
+                          int32_t input_idx, const codec::Schema& sc) const;
+    bool ExtractInputData(const TableInfo& info,
+                          std::vector<hybridse::codec::Row>& rows,  // NOLINT
+                          const codec::Schema&) const;
     bool ExtractOutputData(
         std::vector<hybridse::codec::Row>& rows) const;  // NOLINT
 
@@ -331,6 +331,10 @@ std::vector<SqlCase> InitCases(std::string yaml_path, std::vector<std::string> f
 void InitCases(std::string yaml_path, std::vector<SqlCase>& cases);  // NOLINT
 void InitCases(std::string yaml_path, std::vector<SqlCase>& cases, // NOLINT
                const std::vector<std::string>& filters);
+
+// TODO(someone): consider move the function to production code so others will take usage.
+absl::StatusOr<std::vector<codec::Row>> ExtractInsertRow(vm::HybridSeJitWrapper*, absl::string_view insert,
+                                                         const codec::Schema* table_schema);
 }  // namespace sqlcase
 }  // namespace hybridse
 #endif  // HYBRIDSE_INCLUDE_CASE_SQL_CASE_H_

--- a/hybridse/include/plan/plan_api.h
+++ b/hybridse/include/plan/plan_api.h
@@ -29,6 +29,8 @@ using hybridse::base::Status;
 using hybridse::node::NodeManager;
 using hybridse::node::NodePointVector;
 using hybridse::node::PlanNodeList;
+
+// TODO(someone): rm class PlanAPI
 class PlanAPI {
  public:
     // parse SQL string to logic plan. ASTNode and LogicNode saved in SqlContext
@@ -47,6 +49,22 @@ class PlanAPI {
     static const std::string GenerateName(const std::string prefix, int id);
 };
 
+// Parse the input str and SQL type and convert to TypeNode representation
+//
+// unimplemnted, reserved for later usage
+absl::StatusOr<node::TypeNode*> ParseType(absl::string_view, NodeManager*);
+
+// parse the input string as table elements and extract those element that is table_column_definition,
+// then returns the corresponding proto representation.
+//
+// it expect input `str` joined every element by comma(,), then a CREATE TABLE SQL is created with the
+// format of 'CREATE TABLE t1 ( {str} )'.
+// SQL parse allows three kind of table element, which is:
+// - table_column_definition
+// - table_index_definition
+// - table_constraint_definition
+// while this method extract table_column_definition only
+absl::StatusOr<codec::Schema> ParseTableColumSchema(absl::string_view str);
 }  // namespace plan
 }  // namespace hybridse
 #endif  // HYBRIDSE_INCLUDE_PLAN_PLAN_API_H_

--- a/hybridse/src/case/sql_case.cc
+++ b/hybridse/src/case/sql_case.cc
@@ -16,6 +16,7 @@
 
 #include "case/sql_case.h"
 
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <optional>
@@ -23,7 +24,6 @@
 #include <string>
 #include <vector>
 
-#include "absl/cleanup/cleanup.h"
 #include "absl/strings/ascii.h"
 #include "absl/strings/substitute.h"
 #include "absl/synchronization/mutex.h"
@@ -34,7 +34,11 @@
 #include "codec/fe_row_codec.h"
 #include "glog/logging.h"
 #include "node/sql_node.h"
-#include "yaml-cpp/yaml.h"
+#include "plan/plan_api.h"
+#include "vm/engine.h"
+#include "zetasql/parser/parser.h"
+#include "planv2/ast_node_converter.h"
+#include "vm/jit_wrapper.h"
 
 namespace hybridse {
 namespace sqlcase {
@@ -43,6 +47,23 @@ using hybridse::codec::Row;
 static absl::Mutex mtx;
 // working directory, where the yaml file lives
 static std::filesystem::path working_dir;
+
+static vm::HybridSeJitWrapper* createJitWrapper() {
+    hybridse::vm::Engine::InitializeGlobalLLVM();
+    base::Status s;
+    auto wrapper = vm::HybridSeJitWrapper::CreateWithDefaultSymbols(&s);
+    if (!s.isOK()) {
+        LOG(ERROR) << "fail to get jit: " << s;
+        std::exit(1);
+    }
+    return wrapper;
+}
+
+static vm::HybridSeJitWrapper* getJitWrapper() {
+    // ensuare call once by local static
+    static vm::HybridSeJitWrapper* wrapper = createJitWrapper();
+    return wrapper;
+}
 
 bool SqlCase::TTLParse(const std::string& org_type_str,
                        std::vector<int64_t>& ttls) {
@@ -271,6 +292,20 @@ bool SqlCase::ExtractSchema(const std::vector<std::string>& columns,
         LOG(WARNING) << "Invalid Schema Format";
         return false;
     }
+    // expect the string of table column schema:
+    // 1. {name}<colon>{type}
+    //    legacy specification, issues may arrise when dealing with type contains options
+    // 2. {name}<any space>{type}
+    //    favored specification, which is exactly the same as SQL table column schema,
+    //    you may nest any composed type like map in {type}
+
+    auto column_list = absl::StrJoin(columns, ",");
+    auto rs = plan::ParseTableColumSchema(column_list);
+    if (rs.ok()) {
+        table.mutable_columns()->CopyFrom(rs.value());
+        return true;
+    }
+    // fallback legacy approach
     try {
         for (auto col : columns) {
             boost::trim(col);
@@ -409,13 +444,15 @@ bool SqlCase::AddInput(const TableInfo& table_data) {
     return true;
 }
 bool SqlCase::ExtractInputData(std::vector<Row>& rows,
-                               int32_t input_idx) const {
-    return ExtractInputData(inputs_[input_idx], rows);
+                               int32_t input_idx,
+                               const codec::Schema& sc) const {
+    return ExtractInputData(inputs_[input_idx], rows, sc);
 }
 bool SqlCase::ExtractInputData(const TableInfo& input,
-                               std::vector<Row>& rows) const {
+                               std::vector<Row>& rows,
+                               const codec::Schema& sc) const {
     try {
-        if (input.data_.empty() && input.rows_.empty()) {
+        if (input.data_.empty() && input.rows_.empty() && input.inserts_.empty()) {
             LOG(WARNING) << "Empty Data String";
             return false;
         }
@@ -425,7 +462,20 @@ bool SqlCase::ExtractInputData(const TableInfo& input,
             return false;
         }
 
-        if (!input.data_.empty()) {
+        if (!input.inserts_.empty()) {
+            for (auto& sql : input.inserts_) {
+                // shit happens, resue jit cause duplcate symbols
+                // FIXME(#3748): use getJitWrapper
+                auto jit = std::unique_ptr<vm::HybridSeJitWrapper>(createJitWrapper());
+                auto rs = ExtractInsertRow(jit.get(), sql, &sc);
+                if (!rs.ok()) {
+                    LOG(ERROR) << rs.status();
+                    return false;
+                }
+
+                rows.insert(rows.end(), rs.value().begin(), rs.value().end());
+            }
+        } else if (!input.data_.empty()) {
             if (!ExtractRows(table.columns(), input.data_, rows)) {
                 return false;
             }
@@ -1712,6 +1762,49 @@ std::string SqlCase::SqlCaseBaseDir() {
         return std::string(value);
     }
     return "";
+}
+
+absl::StatusOr<std::vector<codec::Row>> ExtractInsertRow(vm::HybridSeJitWrapper* jit, absl::string_view insert,
+                                                         const codec::Schema* table_schema) {
+    zetasql::ParserOptions parser_opts;
+    zetasql::LanguageOptions language_opts;
+    language_opts.EnableLanguageFeature(zetasql::FEATURE_V_1_3_COLUMN_DEFAULT_VALUE);
+    parser_opts.set_language_options(&language_opts);
+    std::unique_ptr<zetasql::ParserOutput> parser_output;
+    auto zetasql_status = zetasql::ParseStatement(insert, parser_opts, &parser_output);
+    CHECK_ABSL_STATUS(zetasql_status);
+
+    node::SqlNode* sql_node = nullptr;
+    node::NodeManager nm;
+    CHECK_STATUS_TO_ABSL(plan::ConvertStatement(parser_output->statement(), &nm, &sql_node));
+
+    auto* insert_stmt = sql_node->GetAsOrNull<node::InsertStmt>();
+    if (insert_stmt == nullptr) {
+        return absl::FailedPreconditionError("not a insert statement");
+    }
+
+    if (!insert_stmt->columns_.empty()) {
+        // implementation limitation
+        return absl::UnimplementedError("insert with custom columns not support");
+    }
+
+    codec::RowBuilder2 builder(jit, std::vector<codec::Schema>{*table_schema});
+
+    CHECK_STATUS_TO_ABSL(builder.Init());
+
+    std::vector<codec::Row> rows;
+    for (auto expr : insert_stmt->values_) {
+        auto expr_list = expr->GetAsOrNull<node::ExprListNode>();
+        if (expr_list == nullptr) {
+            return absl::FailedPreconditionError(
+                absl::Substitute("unexpected insert statement value: $0", expr->GetExprString()));
+        }
+        codec::Row row;
+        CHECK_STATUS_TO_ABSL(builder.Build(expr_list->children_, &row));
+        rows.push_back(row);
+    }
+
+    return rows;
 }
 }  // namespace sqlcase
 }  // namespace hybridse

--- a/hybridse/src/case/sql_case_test.cc
+++ b/hybridse/src/case/sql_case_test.cc
@@ -538,10 +538,10 @@ TEST_F(SqlCaseTest, ExtractSqlCase) {
     // Check Data
     {
         type::TableDef output_table;
+        ASSERT_TRUE(sql_case.ExtractInputTableDef(output_table));
         std::vector<hybridse::codec::Row> rows;
-        ASSERT_TRUE(sql_case.ExtractInputData(rows));
+        ASSERT_TRUE(sql_case.ExtractInputData(rows, 0, output_table.columns()));
         ASSERT_EQ(5u, rows.size());
-        sql_case.ExtractInputTableDef(output_table);
         hybridse::codec::RowView row_view(output_table.columns());
 
         {

--- a/hybridse/src/codec/fe_row_codec.cc
+++ b/hybridse/src/codec/fe_row_codec.cc
@@ -19,12 +19,12 @@
 #include <string>
 #include <utility>
 
+#include "absl/strings/str_join.h"
 #include "codec/type_codec.h"
 #include "gflags/gflags.h"
 #include "codegen/insert_row_builder.h"
 #include "glog/logging.h"
 #include "proto/fe_common.pb.h"
-#include "vm/engine.h"
 
 DECLARE_bool(enable_spark_unsaferow_format);
 
@@ -1103,7 +1103,11 @@ base::Status RowBuilder2::Build(const std::vector<node::ExprNode*>& values, code
     auto expect_cols =
         std::accumulate(schemas_.begin(), schemas_.end(), 0, [](int val, const auto& e) { return val + e.size(); });
     CHECK_TRUE(values.size() == expect_cols, common::kCodegenEncodeError, "pass in expr number do not match, expect ",
-               expect_cols, " but got ", values.size());
+               expect_cols, " but got ", values.size(), ": (",
+               absl::StrJoin(
+                   values, ", ",
+                   [](std::string* out, const node::ExprNode* expr) { absl::StrAppend(out, expr->GetExprString()); }),
+               ")");
 
     int col_idx = 0;
     Row row;

--- a/hybridse/src/node/node_manager.cc
+++ b/hybridse/src/node/node_manager.cc
@@ -439,7 +439,7 @@ CreateStmt *NodeManager::MakeCreateTableNode(bool op_if_not_exist, const std::st
                                           const std::string &table_name, SqlNodeList *column_desc_list,
                                           SqlNodeList *table_option_list) {
     CreateStmt *node_ptr = new CreateStmt(db_name, table_name, op_if_not_exist);
-    FillSqlNodeList2NodeVector(column_desc_list, *(node_ptr->MutableColumnDefList()));
+    FillSqlNodeList2NodeVector(column_desc_list, *(node_ptr->MutableTableElementList()));
     FillSqlNodeList2NodeVector(table_option_list, *(node_ptr->MutableTableOptionList()));
     return RegisterNode(node_ptr);
 }

--- a/hybridse/src/passes/physical/batch_request_optimize_test.cc
+++ b/hybridse/src/passes/physical/batch_request_optimize_test.cc
@@ -18,6 +18,7 @@
 #include "gtest/gtest.h"
 #include "testing/engine_test_base.h"
 #include "vm/sql_compiler.h"
+#include "vm/engine.h"
 
 namespace hybridse {
 namespace vm {
@@ -253,7 +254,6 @@ TEST_P(BatchRequestOptimizeTest, test_with_common_columns) {
 int main(int argc, char** argv) {
     ::testing::GTEST_FLAG(color) = "yes";
     ::testing::InitGoogleTest(&argc, argv);
-    InitializeNativeTarget();
-    InitializeNativeTargetAsmPrinter();
+    ::hybridse::vm::Engine::InitializeGlobalLLVM();
     return RUN_ALL_TESTS();
 }

--- a/hybridse/src/plan/planner.cc
+++ b/hybridse/src/plan/planner.cc
@@ -452,9 +452,9 @@ base::Status Planner::CreateSetPlanNode(const node::SetNode *root, node::PlanNod
 base::Status Planner::CreateCreateTablePlan(const node::SqlNode *root, node::PlanNode **output) {
     CHECK_TRUE(nullptr != root, common::kPlanError, "fail to create table plan with null node")
     auto create_tree = dynamic_cast<const node::CreateStmt *>(root);
-    auto* out = node_manager_->MakeCreateTablePlanNode(create_tree->GetDbName(), create_tree->GetTableName(),
-                                                     create_tree->GetColumnDefList(), create_tree->GetTableOptionList(),
-                                                     create_tree->GetOpIfNotExist());
+    auto *out = node_manager_->MakeCreateTablePlanNode(
+        create_tree->GetDbName(), create_tree->GetTableName(), create_tree->GetTableElementList(),
+        create_tree->GetTableOptionList(), create_tree->GetOpIfNotExist());
     out->like_clause_ = create_tree->like_clause_;
     *output = out;
     return base::Status::OK();

--- a/hybridse/src/planv2/ast_node_converter.h
+++ b/hybridse/src/planv2/ast_node_converter.h
@@ -29,6 +29,8 @@ namespace plan {
 // ======================================================================================= //
 base::Status ConvertASTScript(const zetasql::ASTScript* body, node::NodeManager* node_manager,
                               node::SqlNodeList** output);
+base::Status ConvertStatement(const zetasql::ASTStatement* stmt, node::NodeManager* node_manager,
+                              node::SqlNode** output);
 
 // ======================================================================================= //
 // all interfaces below not consider public, which might moved later
@@ -36,8 +38,6 @@ base::Status ConvertASTScript(const zetasql::ASTScript* body, node::NodeManager*
 base::Status ConvertExprNode(const zetasql::ASTExpression* ast_expression, node::NodeManager* node_manager,
                              node::ExprNode** output);
 
-base::Status ConvertStatement(const zetasql::ASTStatement* stmt, node::NodeManager* node_manager,
-                              node::SqlNode** output);
 
 base::Status ConvertOrderBy(const zetasql::ASTOrderBy* order_by, node::NodeManager* node_manager,
                             node::OrderByNode** output);

--- a/hybridse/src/vm/engine_compile_test.cc
+++ b/hybridse/src/vm/engine_compile_test.cc
@@ -713,8 +713,7 @@ TEST_F(EngineCompileTest, ExternalFunctionTest) {
 }  // namespace hybridse
 
 int main(int argc, char** argv) {
-    InitializeNativeTarget();
-    InitializeNativeTargetAsmPrinter();
+    ::hybridse::vm::Engine::InitializeGlobalLLVM();
     ::testing::InitGoogleTest(&argc, argv);
     // ::hybridse::vm::CoreAPI::EnableSignalTraceback();
     return RUN_ALL_TESTS();

--- a/hybridse/src/vm/jit_wrapper.cc
+++ b/hybridse/src/vm/jit_wrapper.cc
@@ -99,6 +99,9 @@ HybridSeJitWrapper* HybridSeJitWrapper::CreateWithDefaultSymbols(udf::UdfLibrary
     }
     return jit;
 }
+HybridSeJitWrapper* HybridSeJitWrapper::CreateWithDefaultSymbols(base::Status* status, const JitOptions& options) {
+    return CreateWithDefaultSymbols(udf::DefaultUdfLibrary::get(), status, options);
+}
 
 HybridSeJitWrapper* HybridSeJitWrapper::Create(const JitOptions& jit_options) {
     if (jit_options.IsEnableMcjit()) {

--- a/hybridse/src/vm/jit_wrapper.h
+++ b/hybridse/src/vm/jit_wrapper.h
@@ -55,6 +55,7 @@ class HybridSeJitWrapper {
     // create the JIT wrapper with default builtin symbols imported already
     static HybridSeJitWrapper* CreateWithDefaultSymbols(udf::UdfLibrary*, base::Status*,
                                                         const JitOptions& jit_options = {});
+    static HybridSeJitWrapper* CreateWithDefaultSymbols(base::Status*, const JitOptions& jit_options = {});
 
     static HybridSeJitWrapper* Create(const JitOptions& jit_options);
     static HybridSeJitWrapper* Create();

--- a/src/sdk/mini_cluster_bm.cc
+++ b/src/sdk/mini_cluster_bm.cc
@@ -77,7 +77,7 @@ void BM_RequestQuery(benchmark::State& state, hybridse::sqlcase::SqlCase& sql_ca
         }
 
         std::vector<hybridse::codec::Row> request_rows;
-        if (!sql_case.ExtractInputData(sql_case.batch_request_, request_rows)) {
+        if (!sql_case.ExtractInputData(sql_case.batch_request_, request_rows, request_table.columns())) {
             state.SkipWithError("benchmark error: hybridse case input data invalid");
             return;
         }
@@ -243,7 +243,7 @@ void BM_BatchRequestQuery(benchmark::State& state, hybridse::sqlcase::SqlCase& s
         }
 
         std::vector<hybridse::codec::Row> request_rows;
-        if (!sql_case.ExtractInputData(sql_case.batch_request_, request_rows)) {
+        if (!sql_case.ExtractInputData(sql_case.batch_request_, request_rows, request_table.columns())) {
             state.SkipWithError("benchmark error: hybridse case input data invalid");
             return;
         }

--- a/src/sdk/sql_cluster_router.cc
+++ b/src/sdk/sql_cluster_router.cc
@@ -43,6 +43,7 @@
 #include "brpc/channel.h"
 #include "cmd/display.h"
 #include "codec/encrypt.h"
+#include "codegen/insert_row_builder.h"
 #include "common/timer.h"
 #include "glog/logging.h"
 #include "nameserver/system_table.h"
@@ -62,7 +63,6 @@
 #include "sdk/split.h"
 #include "udf/udf.h"
 #include "vm/catalog.h"
-#include "codegen/insert_row_builder.h"
 
 DECLARE_string(bucket_size);
 DECLARE_uint32(replica_num);

--- a/src/sdk/sql_sdk_base_test.cc
+++ b/src/sdk/sql_sdk_base_test.cc
@@ -16,7 +16,6 @@
 
 #include "sdk/sql_sdk_base_test.h"
 
-#include "absl/random/random.h"
 #include "absl/strings/ascii.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_replace.h"
@@ -411,11 +410,11 @@ void SQLSDKQueryTest::RequestExecuteSQL(hybridse::sqlcase::SqlCase& sql_case,  /
         if (!sql_case.inputs().empty()) {
             if (!has_batch_request) {
                 ASSERT_TRUE(sql_case.ExtractInputTableDef(insert_table, 0));
-                ASSERT_TRUE(sql_case.ExtractInputData(insert_rows, 0));
+                ASSERT_TRUE(sql_case.ExtractInputData(insert_rows, 0, insert_table.columns()));
                 sql_case.BuildInsertSqlListFromInput(0, &inserts);
             } else {
                 ASSERT_TRUE(sql_case.ExtractInputTableDef(sql_case.batch_request_, insert_table));
-                ASSERT_TRUE(sql_case.ExtractInputData(sql_case.batch_request_, insert_rows));
+                ASSERT_TRUE(sql_case.ExtractInputData(sql_case.batch_request_, insert_rows, insert_table.columns()));
             }
             CheckSchema(insert_table.columns(), *(request_row->GetSchema().get()));
             DLOG(INFO) << "Request Row:\n";
@@ -571,7 +570,7 @@ void SQLSDKQueryTest::BatchRequestExecuteSQLWithCommonColumnIndices(hybridse::sq
     } else {
         ASSERT_TRUE(sql_case.ExtractInputTableDef(sql_case.inputs_[0], batch_request_table));
         std::vector<hybridse::codec::Row> rows;
-        ASSERT_TRUE(sql_case.ExtractInputData(sql_case.inputs_[0], rows));
+        ASSERT_TRUE(sql_case.ExtractInputData(sql_case.inputs_[0], rows, batch_request_table.columns()));
         request_rows.push_back(rows.back());
     }
     CheckSchema(batch_request_table.columns(), *(request_row->GetSchema().get()));
@@ -798,7 +797,7 @@ void DeploymentEnv::CallDeployProcedure() const {
     std::vector<hybridse::codec::Row> insert_rows;
     std::vector<std::string> inserts;
     ASSERT_TRUE(sql_case_->ExtractInputTableDef(insert_table, 0));
-    ASSERT_TRUE(sql_case_->ExtractInputData(insert_rows, 0));
+    ASSERT_TRUE(sql_case_->ExtractInputData(insert_rows, 0, insert_table.columns()));
     sql_case_->BuildInsertSqlListFromInput(0, &inserts);
     test::SQLCaseTest::CheckSchema(insert_table.columns(), *(request_row->GetSchema().get()));
     LOG(INFO) << "Request Row:\n";
@@ -849,7 +848,7 @@ void DeploymentEnv::CallDeployProcedureTiny() const {
     hybridse::type::TableDef insert_table;
     std::vector<hybridse::codec::Row> insert_rows;
     ASSERT_TRUE(sql_case_->ExtractInputTableDef(insert_table, 0));
-    ASSERT_TRUE(sql_case_->ExtractInputData(insert_rows, 0));
+    ASSERT_TRUE(sql_case_->ExtractInputData(insert_rows, 0, insert_table.columns()));
 
     hybridse::codec::RowView row_view(insert_table.columns());
     for (size_t i = 0; i < insert_rows.size(); i++) {


### PR DESCRIPTION
allow map data type in YAML testing framework for input definition, you
may define input table's schema as:

  columns: ["col1 int", "col2 map<int, string>"]

which is exactly the same as the SQL syntax in CREATE TABLE statement.

And define table values with `inputs[*].inserts`:

  inserts:
    - insert into t1 values (1, map(12, "abc"))

just write down the insert statement SQL.

*LIMITATIONS*

- unsupported: map data type in `expect` field
- INSERT statement with custom columns definition, implementation
  limits, each insert value expression must matches exactly to the table column definition
