### PR TITLE
fix(#3763): lock tox version to 4.12.1

### DIFF
--- a/python/openmldb_sdk/setup.py
+++ b/python/openmldb_sdk/setup.py
@@ -35,7 +35,7 @@ setup(
     ],
     extras_require={'test': [
         "pytest",
-        "tox",
+        "tox==4.12.1",
     ]},
     include_package_data=True,
     package_data={'': ['*.so']},


### PR DESCRIPTION
fixes #3763 
