### PR TITLE
feat: set `NPROC` in intergration test

### DIFF
--- a/.github/workflows/selfhost_intergration.yml
+++ b/.github/workflows/selfhost_intergration.yml
@@ -19,6 +19,7 @@ env:
   HYBRIDSE_SOURCE: local
   E_VERSION: ${{ github.event.inputs.EXEC_VERSION || 'main'}}
   ETYPE: ${{ github.event.inputs.EXEC_TEST_TYPE || 'all'}}
+  NPROC: 4
 
 jobs:
   build-openmldb:


### PR DESCRIPTION
`SELFHOST-INTEGRATION-TEST` takes too much time in build stage now as `OpenMLDB` use one thread to compile by default. we can set `NPROC` to compile in parallel