### PR TITLE
ci(mac): select xcode 14.0.1 for release jobs

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -146,7 +146,7 @@ jobs:
       comment_title: Linux Test Report
 
   macos-cpp:
-    runs-on: macos-latest
+    runs-on: macos-12
     if: github.repository == '4paradigm/OpenMLDB'
     env:
       OS: darwin
@@ -154,7 +154,13 @@ jobs:
       NPROC: 3
       CTEST_PARALLEL_LEVEL: 1 # parallel test level for ctest (make test)
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
+      # target on macOS >= 12.0
+      - name: Xcode Select Version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '14.0.1'
 
       - name: prepare release
         run: |

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -151,7 +151,7 @@ jobs:
     # mac job for java sdk. steps are almost same with job 'java-sdk'
     # except mvn deploy won't target all modules, just hybridse-native & openmldb-native
     # the job only run on tag push or manual workflow dispatch due to no test runs
-    runs-on: macos-latest
+    runs-on: macos-12
     needs:
       - java-sdk
     if: github.event_name == 'push'
@@ -160,7 +160,13 @@ jobs:
       OPENMLDB_BUILD_TARGET: "cp_native_so openmldb"
       NPROC: 3
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
+      # target on macOS >= 12.0
+      - name: Xcode Select Version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '14.0.1'
 
       - name: Cache local Maven repository
         uses: actions/cache@v3
@@ -312,7 +318,13 @@ jobs:
       SQL_PYSDK_ENABLE: ON
       OPENMLDB_BUILD_TARGET: "cp_python_sdk_so openmldb"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
+      # target on macOS >= 12.0
+      - name: Xcode Select Version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '14.0.1'
 
       - name: prepare release
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}


### PR DESCRIPTION
xcode 14.0.1 on macos-12, targeting on macOS 12.3 SDK, requires minos 12.0

fix #3793

