### PR TITLE
test: add automatic table cleanup after go sdk tests

### DIFF
--- a/go/go_sdk_test.go
+++ b/go/go_sdk_test.go
@@ -37,6 +37,15 @@ func Test_driver(t *testing.T) {
 		_, err := db.ExecContext(ctx, createTableStmt)
 		assert.NoError(t, err, "fail to exec %s", createTableStmt)
 	}
+
+	defer func() {
+		dropTableStmt := "DROP TABLE demo;"
+		_, err := db.ExecContext(ctx, dropTableStmt)
+		if err != nil {
+			t.Errorf("fail to drop table: %s", err)
+		}
+	}()
+
 	{
 		insertValueStmt := `INSERT INTO demo VALUES (1, "bb"), (2, "bb");`
 		_, err := db.ExecContext(ctx, insertValueStmt)


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
This PR introduces a test enhancement in the Go SDK. It adds automatic cleanup logic for database table created during tests, ensuring that tests can be rerun without the need for manual table deletion.


* **What is the current behavior?** (You can also link to an open issue here)
Currently, the tests in the Go SDK create demo table in the database to verify various functionalities. However, it's not automatically cleaned up after the tests are completed. This behavior requires manual intervention to delete the table before tests can be rerun, leading to inefficiencies in the development process.


* **What is the new behavior (if this is a feature change)?**
With this change, the Go SDK tests now include cleanup logic that automatically deletes demo table created during the testing process. This ensures that the database is restored to its initial state after the tests complete, allowing for tests to be rerun multiple times without manual cleanup. This improvement streamlines the testing process, making it more efficient and less error-prone.
