### PR TITLE
feat: Add Object Table for Authz in __INTERNAL_DB

### DIFF
--- a/src/nameserver/name_server_impl.cc
+++ b/src/nameserver/name_server_impl.cc
@@ -5560,6 +5560,10 @@ void NameServerImpl::OnLocked() {
         CreateSystemTableOrExit(SystemTableType::kUser);
     }
 
+    if (FLAGS_system_table_replica_num > 0 && db_table_info_[INTERNAL_DB].count(OBJECT_INFO_NAME) == 0) {
+        CreateSystemTableOrExit(SystemTableType::kObject);
+    }
+
     if (FLAGS_system_table_replica_num > 0 && db_table_info_[INTERNAL_DB].count(PRE_AGG_META_NAME) == 0) {
         CreateSystemTableOrExit(SystemTableType::kPreAggMetaInfo);
     }

--- a/src/nameserver/system_table.cc
+++ b/src/nameserver/system_table.cc
@@ -28,6 +28,7 @@ static absl::flat_hash_map<SystemTableType, SystemTableInfo const> CreateSystemT
         {SystemTableType::kGlobalVariable, {INFORMATION_SCHEMA_DB, GLOBAL_VARIABLES}},
         {SystemTableType::kDeployResponseTime, {INFORMATION_SCHEMA_DB, DEPLOY_RESPONSE_TIME}},
         {SystemTableType::kUser, {INTERNAL_DB, USER_INFO_NAME}},
+        {SystemTableType::kObject, {INTERNAL_DB, OBJECT_INFO_NAME}},
     };
     return map;
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** 
This PR introduces a new feature that adds an object table to OpenMLDB for authorization purposes. The table is accessible in the __INTERNAL_DB database and is named OBJECT. This feature allows for enhanced security measures by facilitating permission checks and other authorization mechanisms through the newly introduced table.


**What is the current behavior?** 
Currently, OpenMLDB lacks a dedicated object table for authorization purposes, limiting the ability to implement fine-grained access control and permission checks within the database.


**What is the new behavior (if this is a feature change)?**
With this change, OpenMLDB introduces an OBJECT table under the __INTERNAL_DB database, which can be interacted with using the DESCRIBE OBJECT; command. This table is designed to store authorization-related information, enabling developers and database administrators to implement more sophisticated authz mechanisms. This feature enhances OpenMLDB's security model by allowing for detailed permission settings and access control at a granular level.
