### PR TITLE
fix: correct errors in the examples for 'LOAD DATA INFILE' statement.

### DIFF
--- a/docs/en/openmldb_sql/dml/LOAD_DATA_STATEMENT.md
+++ b/docs/en/openmldb_sql/dml/LOAD_DATA_STATEMENT.md
@@ -91,13 +91,13 @@ Read data from the `data.csv` file into the `t1` table in online storage. Use `,
 
 ```sql
 set @@execute_mode='online';
-LOAD DATA INFILE 'data.csv' INTO TABLE t1 OPTIONS(delimiter = ',' );
+LOAD DATA INFILE 'data.csv' INTO TABLE t1 OPTIONS(delimiter = ',', mode = 'append');
 ```
 
 Read data from the `data.csv` file into the `t1` table. Use `,` as the column delimiter, and replace the string "NA" with NULL.
 
 ```sql
-LOAD DATA INFILE 'data.csv' INTO TABLE t1 OPTIONS(delimiter = ',', null_value='NA');
+LOAD DATA INFILE 'data.csv' INTO TABLE t1 OPTIONS(delimiter = ',', mode = 'append', null_value='NA');
 ```
 
 Copy the `data_path` into the `t1` table as offline data.

--- a/docs/zh/openmldb_sql/dml/LOAD_DATA_STATEMENT.md
+++ b/docs/zh/openmldb_sql/dml/LOAD_DATA_STATEMENT.md
@@ -91,13 +91,13 @@ OpenMLDB 支持从 Hive 导入数据，但需要额外的设置和功能限制�
 
 ```sql
 set @@execute_mode='online';
-LOAD DATA INFILE 'data.csv' INTO TABLE t1 OPTIONS(delimiter = ',' );
+LOAD DATA INFILE 'data.csv' INTO TABLE t1 OPTIONS(delimiter = ',', mode = 'append');
 ```
 
 从`data.csv`文件读取数据到表`t1`中。并使用`,`作为列分隔符， 字符串"NA"将被替换为NULL。
 
 ```sql
-LOAD DATA INFILE 'data.csv' INTO TABLE t1 OPTIONS(delimiter = ',', null_value='NA');
+LOAD DATA INFILE 'data.csv' INTO TABLE t1 OPTIONS(delimiter = ',', mode = 'append', null_value='NA');
 ```
 
 将`data_path`软拷贝到表`t1`中，作为离线数据。


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add parameter mode='append' for the examples of 'LOAD DATA INFILE' statement in online mode.


* **What is the current behavior?** (You can also link to an open issue here)
The SQL statement cannot be executed correctly in the examples because the default value of the 'mode' parameter is 'error_if_exists', but in online mode, only mode='append' is supported.



* **What is the new behavior (if this is a feature change)?**

