### PR TITLE
feat(codegen): map data type patches

### DIFF
--- a/cases/query/udf_query.yaml
+++ b/cases/query/udf_query.yaml
@@ -572,12 +572,11 @@ cases:
         map('1', 2, '3', 4, '5', 6, '7', 8, '9', 10, '11', 12)['10'] as e8,
         # first match on duplicate keys
         map('1', 2, '1', 4, '1', 6, '7', 8, '9', 10, '11', 12)['1'] as e9,
-        # map("c", 99, "d", NULL)["d"] as e10,
+        map("c", 99, "d", NULL)["d"] as e10,
     expect:
-      # FIXME(someone): add e10 result core dump occasionally on centOS
-      columns: ["e1 string", "e2 int", "e3 string", "e4 int", "e5 string", "e6 timestamp", "e7 int", "e8 int", "e9 int"]
+      columns: ["e1 string", "e2 int", "e3 string", "e4 int", "e5 string", "e6 timestamp", "e7 int", "e8 int", "e9 int", "e10 int"]
       data: |
-        2, 100, NULL, 101, f, 2000, 10, NULL, 2
+        2, 100, NULL, 101, f, 2000, 10, NULL, 2, NULL
   - id: 14
     mode: request-unsupport
     sql: |

--- a/hybridse/include/codec/fe_row_codec.h
+++ b/hybridse/include/codec/fe_row_codec.h
@@ -68,6 +68,9 @@ const std::unordered_map<::hybridse::type::Type, uint8_t>& GetTypeSizeMap();
 bool IsCodecBaseType(const type::ColumnSchema& sc);
 bool IsCodecStrLikeType(const type::ColumnSchema& sc);
 
+// returns the corresponding SQL string representation for input ColumnSchema
+absl::StatusOr<std::string> ColumnSchemaStr(const type::ColumnSchema&);
+
 inline uint8_t GetAddrLength(uint32_t size) {
     if (size <= UINT8_MAX) {
         return 1;

--- a/hybridse/src/codegen/ir_base_builder.cc
+++ b/hybridse/src/codegen/ir_base_builder.cc
@@ -29,6 +29,8 @@
 #include "codegen/string_ir_builder.h"
 #include "codegen/timestamp_ir_builder.h"
 #include "glog/logging.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/IR/GlobalVariable.h"
 #include "node/node_manager.h"
 #include "proto/fe_type.pb.h"
 
@@ -1076,5 +1078,30 @@ std::string GetIRTypeName(llvm::Type* type)  {
     type->print(ss, false, true);
     return ss.str();
 }
+
+void PrintLog(llvm::LLVMContext* context, llvm::Module* module, llvm::IRBuilder<>* builder, absl::string_view toPrint,
+              bool useGlobal) {
+    llvm::FunctionCallee printFunct =
+        module->getOrInsertFunction("printLog", builder->getVoidTy(), builder->getInt8PtrTy());
+
+    llvm::Value* stringVar;
+    llvm::Constant* stringConstant =
+        llvm::ConstantDataArray::getString(*context, llvm::StringRef(toPrint.data(), toPrint.size()));
+
+    // array[i8] type
+    if (useGlobal) {
+        stringVar = builder->CreateGlobalString(llvm::StringRef(toPrint.data(), toPrint.size()));
+        // Note: Does not work without allocation
+        // stringVar = new llvm::GlobalVariable(*module, stringConstant->getType(), true,
+        //                                      llvm::GlobalValue::PrivateLinkage, stringConstant, "");
+    } else {
+        stringVar = builder->CreateAlloca(stringConstant->getType());
+        builder->CreateStore(stringConstant, stringVar);
+    }
+
+    llvm::Value* cast = builder->CreatePointerCast(stringVar, builder->getInt8PtrTy());
+    builder->CreateCall(printFunct, cast);
+}
+
 }  // namespace codegen
 }  // namespace hybridse

--- a/hybridse/src/codegen/ir_base_builder.h
+++ b/hybridse/src/codegen/ir_base_builder.h
@@ -117,6 +117,9 @@ llvm::Value* CreateAllocaAtHead(llvm::IRBuilder<>* builder, llvm::Type* dtype,
 
 llvm::Value* CodecSizeForPrimitive(llvm::IRBuilder<>* builder, llvm::Type* type);
 
+void PrintLog(llvm::LLVMContext* context, llvm::Module* module, llvm::IRBuilder<>* builder, absl::string_view toPrint,
+              bool useGlobal = true);
+
 }  // namespace codegen
 }  // namespace hybridse
 #endif  // HYBRIDSE_SRC_CODEGEN_IR_BASE_BUILDER_H_

--- a/hybridse/src/codegen/map_ir_builder.cc
+++ b/hybridse/src/codegen/map_ir_builder.cc
@@ -198,7 +198,7 @@ absl::StatusOr<NativeValue> MapIRBuilder::ExtractElement(CodeGenContextBase* ctx
                                     {
                                         struct_type_->getPointerTo(),                   // arr ptr
                                         ctx->GetBuilder()->getInt1Ty(),                 // arr is null
-                                        key_type_,                                      // key type
+                                        key_type_,                                      // key value
                                         ctx->GetBuilder()->getInt1Ty(),                 // key is null
                                         value_type_->getPointerTo(),                    // output value ptr
                                         ctx->GetBuilder()->getInt1Ty()->getPointerTo()  // output is null ptr
@@ -217,13 +217,23 @@ absl::StatusOr<NativeValue> MapIRBuilder::ExtractElement(CodeGenContextBase* ctx
 
         auto builder = ctx->GetBuilder();
 
+        PrintLog(&ctx->GetLLVMContext(), ctx->GetModule(), ctx->GetBuilder(), "enter extract map element");
+
         builder->CreateStore(builder->getInt1(true), out_null_alloca_param);
+        ::llvm::Value* idx_alloc = builder->CreateAlloca(builder->getInt32Ty());
+        builder->CreateStore(builder->getInt32(0), idx_alloc);
+        ::llvm::Value* found_idx_alloc = builder->CreateAlloca(builder->getInt32Ty());
+        builder->CreateStore(builder->getInt32(-1), found_idx_alloc);
+
+        llvm::Value* sz_alloca = builder->CreateAlloca(builder->getInt32Ty());
+        llvm::Value* keys_alloca = builder->CreateAlloca(key_type_->getPointerTo());
 
         auto s = ctx->CreateBranchNot(
             builder->CreateOr(arr_is_null_param, key_is_null_param),
             [&]() -> base::Status {
                 ::llvm::Value* sz = nullptr;
                 CHECK_TRUE(Load(ctx->GetCurrentBlock(), map_ptr_param, SZ_IDX, &sz), common::kCodegenError);
+                ctx->GetBuilder()->CreateStore(sz, sz_alloca);
 
                 CHECK_STATUS(ctx->CreateBranch(builder->CreateICmpSLE(sz, builder->getInt32(0)), [&]() -> base::Status {
                     builder->CreateRetVoid();
@@ -232,25 +242,21 @@ absl::StatusOr<NativeValue> MapIRBuilder::ExtractElement(CodeGenContextBase* ctx
 
                 ::llvm::Value* keys = nullptr;
                 CHECK_TRUE(Load(ctx->GetCurrentBlock(), map_ptr_param, KEY_VEC_IDX, &keys), common::kCodegenError);
-
-                ::llvm::Value* idx_alloc = builder->CreateAlloca(builder->getInt32Ty());
-                builder->CreateStore(builder->getInt32(0), idx_alloc);
-                ::llvm::Value* found_idx_alloc = builder->CreateAlloca(builder->getInt32Ty());
-                builder->CreateStore(builder->getInt32(-1), found_idx_alloc);
+                ctx->GetBuilder()->CreateStore(keys, keys_alloca);
 
                 CHECK_STATUS(
                     ctx->CreateWhile(
                         [&](::llvm::Value** cond) -> base::Status {
                             ::llvm::Value* idx = builder->CreateLoad(idx_alloc);
                             ::llvm::Value* found = builder->CreateLoad(found_idx_alloc);
-                            *cond = builder->CreateAnd(builder->CreateICmpSLT(idx, sz),
+                            *cond = builder->CreateAnd(builder->CreateICmpSLT(idx, builder->CreateLoad(sz_alloca)),
                                                        builder->CreateICmpSLT(found, builder->getInt32(0)));
                             return {};
                         },
                         [&]() -> base::Status {
                             ::llvm::Value* idx = builder->CreateLoad(idx_alloc);
                             // key never null
-                            auto* ele = builder->CreateLoad(builder->CreateGEP(keys, idx));
+                            auto* ele = builder->CreateLoad(builder->CreateGEP(builder->CreateLoad(keys_alloca), idx));
                             ::llvm::Value* eq = nullptr;
                             base::Status s;
                             PredicateIRBuilder::BuildEqExpr(ctx->GetCurrentBlock(), ele, key_val_param, &eq, s);
@@ -267,7 +273,7 @@ absl::StatusOr<NativeValue> MapIRBuilder::ExtractElement(CodeGenContextBase* ctx
                 auto* found_idx = builder->CreateLoad(found_idx_alloc);
 
                 CHECK_STATUS(ctx->CreateBranch(
-                    builder->CreateAnd(builder->CreateICmpSLT(found_idx, sz),
+                    builder->CreateAnd(builder->CreateICmpSLT(found_idx, builder->CreateLoad(sz_alloca)),
                                        builder->CreateICmpSGE(found_idx, builder->getInt32(0))),
                     [&]() -> base::Status {
                         ::llvm::Value* values = nullptr;

--- a/hybridse/src/udf/udf.cc
+++ b/hybridse/src/udf/udf.cc
@@ -1407,6 +1407,12 @@ int64_t FarmFingerprint(absl::string_view input) {
     return absl::bit_cast<int64_t>(farmhash::Fingerprint64(input));
 }
 
+void printLog(const char* fmt) {
+    if (fmt) {
+        fprintf(stderr, "%s\n", fmt);
+    }
+}
+
 }  // namespace v1
 
 bool RegisterMethod(UdfLibrary *lib, const std::string &fn_name, hybridse::node::TypeNode *ret,

--- a/hybridse/src/udf/udf.h
+++ b/hybridse/src/udf/udf.h
@@ -519,6 +519,8 @@ void hex(StringRef *str, StringRef *output);
 
 void unhex(StringRef *str, StringRef *output, bool* is_null);
 
+void printLog(const char* fmt);
+
 }  // namespace v1
 
 /// \brief register native udf related methods into given UdfLibrary `lib`

--- a/hybridse/src/vm/jit.h
+++ b/hybridse/src/vm/jit.h
@@ -85,8 +85,8 @@ std::string LlvmToString(const T& value) {
 
 class HybridSeLlvmJitWrapper : public HybridSeJitWrapper {
  public:
-    HybridSeLlvmJitWrapper() {}
-    ~HybridSeLlvmJitWrapper() {}
+    explicit HybridSeLlvmJitWrapper(const JitOptions& options = {});
+    ~HybridSeLlvmJitWrapper() override {}
 
     bool Init() override;
 
@@ -99,6 +99,7 @@ class HybridSeLlvmJitWrapper : public HybridSeJitWrapper {
     hybridse::vm::RawPtrHandle FindFunction(const std::string& funcname) override;
 
  private:
+    const JitOptions jit_options_;
     std::unique_ptr<HybridSeJit> jit_;
     std::unique_ptr<::llvm::orc::MangleAndInterner> mi_;
 };

--- a/hybridse/src/vm/jit_wrapper.cc
+++ b/hybridse/src/vm/jit_wrapper.cc
@@ -113,11 +113,10 @@ HybridSeJitWrapper* HybridSeJitWrapper::Create(const JitOptions& jit_options) {
         return new HybridSeLlvmJitWrapper();
 #endif
     } else {
-        if (jit_options.IsEnableVtune() || jit_options.IsEnablePerf() ||
-            jit_options.IsEnableGdb()) {
+        if (jit_options.IsEnableVtune() || jit_options.IsEnablePerf()) {
             LOG(WARNING) << "LLJIT do not support jit events";
         }
-        return new HybridSeLlvmJitWrapper();
+        return new HybridSeLlvmJitWrapper(jit_options);
     }
 }
 
@@ -132,6 +131,7 @@ void InitBuiltinJitSymbols(HybridSeJitWrapper* jit) {
     jit->AddExternalFunction("memset", (reinterpret_cast<void*>(&memset)));
     jit->AddExternalFunction("memcpy", (reinterpret_cast<void*>(&memcpy)));
     jit->AddExternalFunction("__bzero", (reinterpret_cast<void*>(&bzero)));
+    jit->AddExternalFunction("printLog", (reinterpret_cast<void*>(&udf::v1::printLog)));
 
     jit->AddExternalFunction(
         "hybridse_storage_get_bool_field",

--- a/hybridse/src/vm/jit_wrapper.h
+++ b/hybridse/src/vm/jit_wrapper.h
@@ -37,6 +37,7 @@ class HybridSeJitWrapper {
  public:
     HybridSeJitWrapper();
     HybridSeJitWrapper(const HybridSeJitWrapper&) = delete;
+    HybridSeJitWrapper& operator=(const HybridSeJitWrapper&) = delete;
 
     virtual ~HybridSeJitWrapper() {}
 

--- a/src/sdk/sql_sdk_base_test.cc
+++ b/src/sdk/sql_sdk_base_test.cc
@@ -70,7 +70,6 @@ void SQLSDKTest::CreateTables(hybridse::sqlcase::SqlCase& sql_case,  // NOLINT
         if (sql_case.BuildCreateSqlFromInput(i, &create, partition_num) && !create.empty()) {
             std::string placeholder = "{" + std::to_string(i) + "}";
             absl::StrReplaceAll({{placeholder, sql_case.inputs()[i].name_}}, &create);
-            LOG(INFO) << create;
             router->ExecuteDDL(input_db_name, create, &status);
             ASSERT_TRUE(router->RefreshCatalog());
             ASSERT_TRUE(status.code == 0) << status.msg;


### PR DESCRIPTION
1. feat: add simple debug facility `printLog` in codegen so JITed code is able to print simple logs runtime
2. fix: **extract map value** when value is NULL, current codegen still inspect the NULL value (especially value is a struct ptr like string), so a safe null struct should always constructed, instead of a `UndefValue`
3. feat(draft): make LLJIT accept `JItOptions` as well, it does not have real difference now, but should expected to support later.
4. fix: gen create table sql in sql_sdk_test
