### PR TITLE
feat: request mode in raw SQL

### DIFF
--- a/cases/plan/cmd.yaml
+++ b/cases/plan/cmd.yaml
@@ -754,3 +754,11 @@ cases:
         +-node[CMD]
           +-cmd_type: show create table
           +-args: [db1, t1]
+
+  - id: callstmt
+    sql: call sp(1, cast("ab" as string))
+    expect:
+      plan_tree_str: |
+        +-[kPlanTypeCallStmt]
+          +-procedure_name: [sp]
+          +-arguments: 1, string(ab)

--- a/cases/query/fail_query.yaml
+++ b/cases/query/fail_query.yaml
@@ -70,3 +70,53 @@ cases:
     expect:
       success: false
       msg: unsupport join type RightJoin
+  - id: 4
+    mode: batch-unsupport
+    inputs:
+      - name: t1
+        columns: ["c1 string","c2 int","c4 timestamp"]
+        indexs: ["index1:c1:c4"]
+        rows:
+          - ["aa",20,1000]
+          - ["bb",30,1000]
+    sql: |
+      SELECT * from t1
+      CONFIG (execute_mode = 'request', values = [])
+    expect:
+      success: false
+      msg: |
+        FAILED_PRECONDITION: element number of the request values must not empty
+  - id: 5
+    mode: batch-unsupport
+    inputs:
+      - name: t1
+        columns: ["c1 string","c2 int","c4 timestamp"]
+        indexs: ["index1:c1:c4"]
+        rows:
+          - ["aa",20,1000]
+          - ["bb",30,1000]
+    sql: |
+      SELECT * from t1
+      CONFIG (execute_mode = 'request', values = ("c1"))
+    expect:
+      success: false
+      msg: |
+        INTERNAL: pass in expr number do not match, expect 3 but got 1: (c1)
+
+  # TODO: open this case after #3847
+  # - id: 6
+  #   mode: batch-unsupport
+  #   inputs:
+  #     - name: t1
+  #       columns: ["c1 string","c2 int","c4 date"]
+  #       indexs: ["index1:c1"]
+  #       rows:
+  #         - ["aa",20,1000]
+  #         - ["bb",30,1000]
+  #   sql: |
+  #     SELECT * from t1
+  #     CONFIG (execute_mode = 'request', values = ("c1", 19, 12) )
+  #   expect:
+  #     success: false
+  #     msg: |
+  #       xx

--- a/cases/query/simple_query.yaml
+++ b/cases/query/simple_query.yaml
@@ -985,3 +985,29 @@ cases:
       data: |
         1, 10, 1000
         2, 30, 2000
+
+  - id: 108
+    mode: request-unsupport
+    inputs:
+      # t1 as request table, only one request row concerned
+      # from SQL config options
+      - name: t1
+        columns: ["id int32", "b int32", "ts int64"]
+        indexs: ["idx2:b:ts"]
+        data: |
+          1, 10, 1000
+      - name: t2
+        columns: ["id int32", "b int32", "ts int64"]
+        indexs: ["idx2:b:ts"]
+        data: |
+          3, 10, 1000
+          4, 30, 2000
+    sql: |
+      select t1.*, t2.id as ix from t1
+      last join t2 on t1.b = t2.b
+      config (execute_mode = 'request', values = (5, 10, timestamp(4000)))
+    expect:
+      columns: ["id int32", "b int32", "ts int64", "ix int32"]
+      order: id
+      data: |
+        5, 10, 4000, 3

--- a/hybridse/examples/toydb/src/cmd/toydb_run_engine.cc
+++ b/hybridse/examples/toydb/src/cmd/toydb_run_engine.cc
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-#include "absl/strings/match.h"
 #include "testing/toydb_engine_test_base.h"
+
+#include "gflags/gflags.h"
 
 DEFINE_string(yaml_path, "", "Yaml filepath to load cases from");
 DEFINE_string(runner_mode, "batch",
@@ -82,14 +83,15 @@ int RunSingle(const std::string& yaml_path) {
         if (!FLAGS_case_id.empty() && FLAGS_case_id != sql_case.id()) {
             continue;
         }
-        EngineMode mode;
+        EngineMode default_mode;
         if (absl::EqualsIgnoreCase(FLAGS_runner_mode, "batch")) {
-            mode = kBatchMode;
+            default_mode = kBatchMode;
         } else if (absl::EqualsIgnoreCase(FLAGS_runner_mode, "request")) {
-            mode = kRequestMode;
+            default_mode = kRequestMode;
         } else {
-            mode = kBatchRequestMode;
+            default_mode = kBatchRequestMode;
         }
+        auto mode = Engine::TryDetermineMode(sql_case.sql_str_, default_mode);
         int ret = DoRunEngine(sql_case, options, mode);
         if (ret != ENGINE_TEST_RET_SUCCESS) {
             return ret;

--- a/hybridse/examples/toydb/src/cmd/toydb_run_engine.cc
+++ b/hybridse/examples/toydb/src/cmd/toydb_run_engine.cc
@@ -91,7 +91,7 @@ int RunSingle(const std::string& yaml_path) {
         } else {
             default_mode = kBatchRequestMode;
         }
-        auto mode = Engine::TryDetermineMode(sql_case.sql_str_, default_mode);
+        auto mode = Engine::TryDetermineEngineMode(sql_case.sql_str_, default_mode);
         int ret = DoRunEngine(sql_case, options, mode);
         if (ret != ENGINE_TEST_RET_SUCCESS) {
             return ret;

--- a/hybridse/examples/toydb/src/testing/toydb_engine_test_base.cc
+++ b/hybridse/examples/toydb/src/testing/toydb_engine_test_base.cc
@@ -194,6 +194,7 @@ void BatchRequestEngineCheck(const SqlCase& sql_case,
 
 void EngineCheck(const SqlCase& sql_case, const EngineOptions& options,
                  EngineMode engine_mode) {
+    engine_mode = hybridse::vm::Engine::TryDetermineMode(sql_case.sql_str(), engine_mode);
     if (engine_mode == kBatchMode) {
         ToydbBatchEngineTestRunner engine_test(sql_case, options);
         engine_test.RunCheck();

--- a/hybridse/examples/toydb/src/testing/toydb_engine_test_base.cc
+++ b/hybridse/examples/toydb/src/testing/toydb_engine_test_base.cc
@@ -194,7 +194,7 @@ void BatchRequestEngineCheck(const SqlCase& sql_case,
 
 void EngineCheck(const SqlCase& sql_case, const EngineOptions& options,
                  EngineMode engine_mode) {
-    engine_mode = hybridse::vm::Engine::TryDetermineMode(sql_case.sql_str(), engine_mode);
+    engine_mode = hybridse::vm::Engine::TryDetermineEngineMode(sql_case.sql_str(), engine_mode);
     if (engine_mode == kBatchMode) {
         ToydbBatchEngineTestRunner engine_test(sql_case, options);
         engine_test.RunCheck();

--- a/hybridse/include/node/node_enum.h
+++ b/hybridse/include/node/node_enum.h
@@ -98,6 +98,7 @@ enum SqlNodeType {
     kColumnSchema,
     kCreateUserStmt,
     kAlterUserStmt,
+    kCallStmt,
     kSqlNodeTypeLast,  // debug type
 };
 
@@ -143,8 +144,9 @@ enum ExprType {
     kExprIn,
     kExprEscaped,
     kExprArray,
-    kExprArrayElement,  // extract value from a array or map, with `[]` operator
-    kExprFake,          // not a real one
+    kExprArrayElement,      // extract value from a array or map, with `[]` operator
+    kExprStructCtorParens,  // (expr1, expr2, ...)
+    kExprFake,              // not a real one
     kExprLast = kExprFake,
 };
 
@@ -344,6 +346,7 @@ enum PlanType {
     kPlanTypeShow,
     kPlanTypeCreateUser,
     kPlanTypeAlterUser,
+    kPlanTypeCallStmt,
     kUnknowPlan = -1,
 };
 

--- a/hybridse/include/node/plan_node.h
+++ b/hybridse/include/node/plan_node.h
@@ -809,6 +809,22 @@ class AlterTableStmtPlanNode : public LeafPlanNode {
     std::vector<const AlterActionBase *> actions_;
 };
 
+class CallStmtPlan : public LeafPlanNode {
+ public:
+    CallStmtPlan(const std::vector<std::string> names, const std::vector<ExprNode *> args)
+        : LeafPlanNode(kPlanTypeCallStmt), procedure_name_(names), arguments_(args) {}
+    ~CallStmtPlan() override {}
+
+    const std::vector<std::string> &procedure_name() const { return procedure_name_; }
+    const std::vector<ExprNode *> &arguments() const { return arguments_; }
+
+    void Print(std::ostream &output, const std::string &org_tab) const override;
+
+ private:
+    const std::vector<std::string> procedure_name_;
+    const std::vector<ExprNode*> arguments_;
+};
+
 bool PlanEquals(const PlanNode *left, const PlanNode *right);
 bool PlanListEquals(const std::vector<PlanNode *> &list1, const std::vector<PlanNode *> &list2);
 void PrintPlanVector(std::ostream &output, const std::string &tab, PlanNodeList vec, const std::string vector_name,

--- a/hybridse/include/node/sql_node.h
+++ b/hybridse/include/node/sql_node.h
@@ -2597,19 +2597,20 @@ class StructExpr : public ExprNode {
 class StructCtorWithParens : public ExprNode {
  public:
     explicit StructCtorWithParens(absl::Span<ExprNode *const> fields)
-        : ExprNode(kExprStructCtorParens), fields_(fields.begin(), fields.end()) {}
+        : ExprNode(kExprStructCtorParens) {
+        for (auto e : fields) {
+            AddChild(e);
+        }
+    }
     ~StructCtorWithParens() override {}
 
-    absl::Span<ExprNode *const> fields() const { return fields_; }
+    absl::Span<ExprNode *const> fields() const { return children_; }
 
     // LOW priority
     // void Print(std::ostream &output, const std::string &org_tab) const override;
     const std::string GetExprString() const override;
     StructCtorWithParens *ShadowCopy(NodeManager *nm) const override;
     Status InferAttr(ExprAnalysisContext *ctx) override;
-
- private:
-    const std::vector<ExprNode *> fields_;
 };
 
 class ExternalFnDefNode : public FnDefNode {

--- a/hybridse/include/plan/plan_api.h
+++ b/hybridse/include/plan/plan_api.h
@@ -16,6 +16,7 @@
 #ifndef HYBRIDSE_INCLUDE_PLAN_PLAN_API_H_
 #define HYBRIDSE_INCLUDE_PLAN_PLAN_API_H_
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 
@@ -48,6 +49,8 @@ class PlanAPI {
     static const int GetPlanLimitCount(node::PlanNode* plan_trees);
     static const std::string GenerateName(const std::string prefix, int id);
 };
+
+absl::Status ParseStatement(absl::string_view, std::unique_ptr<zetasql::ParserOutput>*);
 
 // Parse the input str and SQL type and convert to TypeNode representation
 //

--- a/hybridse/include/vm/engine.h
+++ b/hybridse/include/vm/engine.h
@@ -20,9 +20,10 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
-#include <unordered_map>
+
 #include "base/spin_lock.h"
 #include "codec/fe_row_codec.h"
 #include "vm/catalog.h"
@@ -36,6 +37,7 @@ using ::hybridse::codec::Row;
 
 inline constexpr const char* LONG_WINDOWS = "long_windows";
 
+class SqlContext;
 class Engine;
 /// \brief An options class for controlling engine behaviour.
 class EngineOptions {
@@ -177,13 +179,6 @@ class RunSession {
     }
 
     void SetIndexHintsHandler(std::shared_ptr<IndexHintHandler> handler) { index_hints_ = handler; }
-
-    /// extract request rows info in SQL.
-    /// A SQL e.g 'SELECT ... FROM t1 options (execute_mode = "request", values = ...)'
-    /// request row info exists in 'values' option, as a format of:
-    /// 1. [(col1_expr, col2_expr, ... ), (...), ...]
-    /// 2. (col1_expr, col2_expr, ... )
-    absl::Status ExtractRequestRowsInSQL(std::vector<Row> * rows) const;
 
  protected:
     std::shared_ptr<hybridse::vm::CompileInfo> compile_info_;
@@ -370,8 +365,8 @@ class Engine {
     static void InitializeUnsafeRowOptFlag(bool isUnsafeRowOpt);
 
     /// determine engine mode for `sql`, `sql` may contains option defining
-    /// execute_mode, `default_mode` used if not.
-    static EngineMode TryDetermineMode(absl::string_view sql, EngineMode default_mode);
+    /// execute_mode, `default_mode` used if not or error.
+    static EngineMode TryDetermineEngineMode(absl::string_view sql, EngineMode default_mode);
 
     /// \brief Compile sql in db and stored the results in the session
     bool Get(const std::string& sql, const std::string& db,
@@ -429,6 +424,13 @@ class Engine {
     EngineOptions GetEngineOptions();
 
  private:
+    /// extract request rows info in SQL.
+    /// A SQL e.g 'SELECT ... FROM t1 options (execute_mode = "request", values = ...)'
+    /// request row info exists in 'values' option, as a format of:
+    /// 1. [(col1_expr, col2_expr, ... ), (...), ...]
+    /// 2. (col1_expr, col2_expr, ... )
+    static absl::Status ExtractRequestRowsInSQL(SqlContext* ctx);
+
     std::shared_ptr<CompileInfo> GetCacheLocked(const std::string& db,
                                                 const std::string& sql,
                                                 EngineMode engine_mode);

--- a/hybridse/include/vm/engine_context.h
+++ b/hybridse/include/vm/engine_context.h
@@ -24,8 +24,9 @@
 namespace hybridse {
 namespace vm {
 
-enum EngineMode { kBatchMode, kRequestMode, kMockRequestMode, kBatchRequestMode };
+enum EngineMode { kBatchMode, kRequestMode, kMockRequestMode, kBatchRequestMode, kOffline };
 std::string EngineModeName(EngineMode mode);
+absl::StatusOr<EngineMode> UnparseEngineMode(absl::string_view);
 
 struct BatchRequestInfo {
     // common column indices in batch request mode

--- a/hybridse/include/vm/physical_op.h
+++ b/hybridse/include/vm/physical_op.h
@@ -1835,14 +1835,14 @@ class PhysicalSelectIntoNode : public PhysicalUnaryNode {
             return nullptr;
         }
         auto it = options_->find(option);
-        return it == options_->end() ? nullptr : it->second;
+        return it == options_->end() ? nullptr : it->second->GetAsOrNull<hybridse::node::ConstNode>();
     }
     const hybridse::node::ConstNode *GetConfigOption(const std::string &option) const {
         if (!config_options_) {
             return nullptr;
         }
         auto it = config_options_->find(option);
-        return it == config_options_->end() ? nullptr : it->second;
+        return it == config_options_->end() ? nullptr : it->second->GetAsOrNull<hybridse::node::ConstNode>();
     }
 
     std::string query_str_, out_file_;
@@ -1878,7 +1878,7 @@ class PhysicalLoadDataNode : public PhysicalOpNode {
             return nullptr;
         }
         auto it = options_->find(option);
-        return it == options_->end() ? nullptr : it->second;
+        return it == options_->end() ? nullptr : it->second->GetAsOrNull<hybridse::node::ConstNode>();
     }
 
     std::string file_;

--- a/hybridse/include/vm/sql_ctx.h
+++ b/hybridse/include/vm/sql_ctx.h
@@ -36,7 +36,7 @@ class ClusterJob;
 
 struct SqlContext {
     // mode: batch|request|batch request
-    ::hybridse::vm::EngineMode engine_mode;
+    ::hybridse::vm::EngineMode engine_mode = EngineMode::kBatchMode;
     bool is_cluster_optimized = false;
     bool is_batch_request_optimized = false;
     bool enable_expr_optimize = false;
@@ -72,6 +72,13 @@ struct SqlContext {
     std::string encoded_request_schema;
     ::hybridse::node::NodeManager nm;
     ::hybridse::udf::UdfLibrary* udf_library = nullptr;
+
+    // ref to request row expressions defined in SQL `options (execute_mode = 'request', values = ... )`.
+    // those expressions are used to construct request row in needed.
+    // can be:
+    // 1. Array [ StructCtorWithParens ]
+    // 2. StructCtorWithParens
+    const node::ExprNode* request_expressions = nullptr;
 
     ::hybridse::vm::BatchRequestInfo batch_request_info;
 

--- a/hybridse/include/vm/sql_ctx.h
+++ b/hybridse/include/vm/sql_ctx.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "node/node_manager.h"
 #include "vm/engine_context.h"
@@ -79,6 +80,9 @@ struct SqlContext {
     // 1. Array [ StructCtorWithParens ]
     // 2. StructCtorWithParens
     const node::ExprNode* request_expressions = nullptr;
+    // compiled request rows from SQL CONFIG clause, `values` option
+    // request_rows get fullfilled if engine mode is kRequestMode or kBatchRequestMode
+    std::vector<codec::Row> request_rows;
 
     ::hybridse::vm::BatchRequestInfo batch_request_info;
 

--- a/hybridse/src/codegen/insert_row_builder.cc
+++ b/hybridse/src/codegen/insert_row_builder.cc
@@ -24,6 +24,7 @@
 #include "absl/cleanup/cleanup.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_join.h"
+#include "absl/strings/substitute.h"
 #include "base/fe_status.h"
 #include "codegen/buf_ir_builder.h"
 #include "codegen/context.h"
@@ -52,6 +53,10 @@ absl::StatusOr<std::shared_ptr<int8_t>> InsertRowBuilder::ComputeRow(absl::Span<
 }
 
 absl::StatusOr<int8_t*> InsertRowBuilder::ComputeRowUnsafe(absl::Span<node::ExprNode* const> values) {
+    if (schema_->size() != values.size()) {
+        return absl::FailedPreconditionError(
+            absl::Substitute("invalid expression number, expect $0, but got $1", schema_->size(), values.size()));
+    }
     absl::Cleanup clean = [&]() { fn_counter_++; };
 
     DLOG(INFO) << absl::StrJoin(values, ", ", [](std::string* str, const node::ExprNode* const expr) {

--- a/hybridse/src/node/expr_node.cc
+++ b/hybridse/src/node/expr_node.cc
@@ -1205,12 +1205,12 @@ ExprNode *ArrayElementExpr::array() const { return GetChild(0); }
 ExprNode *ArrayElementExpr::position() const { return GetChild(1); }
 
 StructCtorWithParens* StructCtorWithParens::ShadowCopy(NodeManager* nm) const {
-    return nm->MakeNode<StructCtorWithParens>(fields_);
+    return nm->MakeNode<StructCtorWithParens>(fields());
 }
 const std::string StructCtorWithParens::GetExprString() const {
     return absl::StrCat(
         "(",
-        absl::StrJoin(fields_, ", ",
+        absl::StrJoin(fields(), ", ",
                       [](std::string* out, const ExprNode* e) { absl::StrAppend(out, e->GetExprString()); }),
         ")");
 }

--- a/hybridse/src/node/expr_node.cc
+++ b/hybridse/src/node/expr_node.cc
@@ -1203,5 +1203,21 @@ Status ArrayElementExpr::InferAttr(ExprAnalysisContext* ctx) {
 }
 ExprNode *ArrayElementExpr::array() const { return GetChild(0); }
 ExprNode *ArrayElementExpr::position() const { return GetChild(1); }
+
+StructCtorWithParens* StructCtorWithParens::ShadowCopy(NodeManager* nm) const {
+    return nm->MakeNode<StructCtorWithParens>(fields_);
+}
+const std::string StructCtorWithParens::GetExprString() const {
+    return absl::StrCat(
+        "(",
+        absl::StrJoin(fields_, ", ",
+                      [](std::string* out, const ExprNode* e) { absl::StrAppend(out, e->GetExprString()); }),
+        ")");
+}
+
+Status StructCtorWithParens::InferAttr(ExprAnalysisContext* ctx) {
+    // TODO
+    return {};
+}
 }  // namespace node
 }  // namespace hybridse

--- a/hybridse/src/node/plan_node.cc
+++ b/hybridse/src/node/plan_node.cc
@@ -19,6 +19,7 @@
 #include <string>
 
 #include "absl/algorithm/container.h"
+#include "absl/strings/str_join.h"
 namespace hybridse {
 namespace node {
 
@@ -228,6 +229,8 @@ std::string NameOfPlanNodeType(const PlanType &type) {
             return "kPlanTypeCreateUser";
         case kPlanTypeAlterUser:
             return "kPlanTypeAlterUser";
+        case kPlanTypeCallStmt:
+            return "kPlanTypeCallStmt";
         case kUnknowPlan:
             return std::string("kUnknow");
     }
@@ -867,5 +870,16 @@ void AlterTableStmtPlanNode::Print(std::ostream &output, const std::string &org_
     }
 }
 
+void CallStmtPlan::Print(std::ostream &output, const std::string &org_tab) const {
+    LeafPlanNode::Print(output, org_tab);
+    output << "\n";
+    auto tab = org_tab + INDENT;
+    PrintValue(output, tab, procedure_name_, "procedure_name", false);
+    output << "\n";
+    PrintValue(output, tab,
+               absl::StrJoin(arguments_, ", ",
+                             [](std::string *out, const ExprNode *n) { absl::StrAppend(out, n->GetExprString()); }),
+               "arguments", true);
+}
 }  // namespace node
 }  // namespace hybridse

--- a/hybridse/src/node/sql_node.cc
+++ b/hybridse/src/node/sql_node.cc
@@ -2765,7 +2765,7 @@ std::string SetOptionsAction::DebugString() const {
         }
         absl::StrAppend(&output, kv.first);
         absl::StrAppend(&output, "=");
-        absl::StrAppend(&output, kv.second->GetAsString());
+        absl::StrAppend(&output, kv.second->GetExprString());
     }
     return absl::Substitute("SetOptionsAction ($0)", output);
 }

--- a/hybridse/src/node/sql_node.cc
+++ b/hybridse/src/node/sql_node.cc
@@ -145,9 +145,10 @@ static absl::flat_hash_map<ExprType, absl::string_view> CreateExprTypeNamesMap()
       {kExprEscaped, "escape"},
       {kExprArray, "array"},
       {kExprArrayElement, "array element"},
+      {kExprStructCtorParens, "struct with parens"},
   };
   for (auto kind = 0; kind < ExprType::kExprLast; ++kind) {
-        DCHECK(map.find(static_cast<ExprType>(kind)) != map.end());
+      DCHECK(map.find(static_cast<ExprType>(kind)) != map.end());
   }
   return map;
 }
@@ -1191,6 +1192,7 @@ static absl::flat_hash_map<SqlNodeType, absl::string_view> CreateSqlNodeTypeToNa
         {kWithClauseEntry, "kWithClauseEntry"},
         {kAlterTableStmt, "kAlterTableStmt"},
         {kColumnSchema, "kColumnSchema"},
+        {kCallStmt, "kCallStmt"},
     };
     for (auto kind = 0; kind < SqlNodeType::kSqlNodeTypeLast; ++kind) {
         DCHECK(map.find(static_cast<SqlNodeType>(kind)) != map.end())

--- a/hybridse/src/plan/planner.cc
+++ b/hybridse/src/plan/planner.cc
@@ -776,8 +776,6 @@ base::Status SimplePlanner::CreatePlanTree(const NodePointVector &parser_trees, 
                 break;
             }
             case ::hybridse::node::kSetStmt: {
-                CHECK_TRUE(is_batch_mode_, common::kPlanError,
-                           "Non-support SET Op in online serving");
                 node::PlanNode *set_plan_node = nullptr;
                 CHECK_STATUS(CreateSetPlanNode(dynamic_cast<node::SetNode *>(parser_tree), &set_plan_node));
                 plan_trees.push_back(set_plan_node);

--- a/hybridse/src/plan/planner.cc
+++ b/hybridse/src/plan/planner.cc
@@ -39,6 +39,8 @@ inline bool IsCurRowRelativeWinFun(absl::string_view fn_name) {
            absl::EqualsIgnoreCase("lead", fn_name);
 }
 
+base::Status ConvertCall(const node::CallStmt* call, node::NodeManager* nm, node::CallStmtPlan** out);
+
 Planner::Planner(node::NodeManager *manager, const bool is_batch_mode, const bool is_cluster_optimized,
         const bool enable_batch_window_parallelization,
         const std::unordered_map<std::string, std::string>* extra_options)
@@ -805,9 +807,19 @@ base::Status SimplePlanner::CreatePlanTree(const NodePointVector &parser_trees, 
             case ::hybridse::node::kAlterTableStmt: {
                 node::AlterTableStmtPlanNode* out = nullptr;
                 CHECK_STATUS(ConvertGuard<node::AlterTableStmt>(
-                    parser_tree, &out, [this](const node::AlterTableStmt *from, node::AlterTableStmtPlanNode **out) {
-                        *out = node_manager_->MakeNode<node::AlterTableStmtPlanNode>(from->db_, from->table_,
-                                                                                     from->actions_);
+                    parser_tree, &out,
+                    [](const node::AlterTableStmt *from, node::NodeManager *nm, node::AlterTableStmtPlanNode **out) {
+                        *out = nm->MakeNode<node::AlterTableStmtPlanNode>(from->db_, from->table_, from->actions_);
+                        return base::Status::OK();
+                    }));
+                plan_trees.push_back(out);
+                break;
+            }
+            case ::hybridse::node::kCallStmt: {
+                node::CallStmtPlan *out = nullptr;
+                CHECK_STATUS(ConvertGuard<node::CallStmt>(
+                    parser_tree, &out, [](const node::CallStmt *from, node::NodeManager *nm, node::CallStmtPlan **out) {
+                        *out = nm->MakeNode<node::CallStmtPlan>(from->procedure_name(), from->arguments());
                         return base::Status::OK();
                     }));
                 plan_trees.push_back(out);

--- a/hybridse/src/plan/planner.h
+++ b/hybridse/src/plan/planner.h
@@ -68,7 +68,7 @@ class Planner {
     ABSL_MUST_USE_RESULT base::Status ConvertGuard(const node::SqlNode *node, OutputType **output, ConvertFn &&func) {
         auto specific_node = dynamic_cast<std::add_pointer_t<std::add_const_t<NodeType>>>(node);
         CHECK_TRUE(specific_node != nullptr, common::kUnsupportSql, "unable to cast");
-        return func(specific_node, output);
+        return func(specific_node, node_manager_, output);
     }
 
     static absl::StatusOr<node::TablePlanNode *> IsTable(node::PlanNode *node);

--- a/hybridse/src/plan/planner.h
+++ b/hybridse/src/plan/planner.h
@@ -25,8 +25,6 @@
 
 #include "absl/status/statusor.h"
 #include "base/fe_status.h"
-#include "gflags/gflags.h"
-#include "glog/logging.h"
 #include "node/node_manager.h"
 #include "node/plan_node.h"
 #include "node/sql_node.h"

--- a/hybridse/src/planv2/ast_node_converter_test.cc
+++ b/hybridse/src/planv2/ast_node_converter_test.cc
@@ -742,7 +742,7 @@ TEST_F(ASTNodeConverterTest, ConvertCreateFunctionOKTest) {
     auto option = create_fun_stmt->Options();
     ASSERT_EQ(option->size(), 1);
     ASSERT_EQ(option->begin()->first, "PATH");
-    ASSERT_EQ(option->begin()->second->GetAsString(), "/tmp/libmyfun.so");
+    ASSERT_EQ(option->begin()->second->GetExprString(), "/tmp/libmyfun.so");
 
     std::string sql2 = "CREATE AGGREGATE FUNCTION fun1 (x BIGINT) RETURNS STRING OPTIONS (PATH='/tmp/libmyfun.so');";
     create_fun_stmt = nullptr;

--- a/hybridse/src/planv2/plan_api.cc
+++ b/hybridse/src/planv2/plan_api.cc
@@ -15,6 +15,7 @@
  */
 #include "plan/plan_api.h"
 
+#include "absl/status/status.h"
 #include "absl/strings/substitute.h"
 #include "planv2/ast_node_converter.h"
 #include "planv2/planner_v2.h"
@@ -46,7 +47,19 @@ base::Status PlanAPI::CreatePlanTreeFromScript(vm::SqlContext *ctx) {
     auto planner_ptr =
         std::make_unique<SimplePlannerV2>(&ctx->nm, ctx->engine_mode == vm::kBatchMode, ctx->is_cluster_optimized,
                                           ctx->enable_batch_window_parallelization, ctx->options.get());
-    return planner_ptr->CreateASTScriptPlan(script, ctx->logical_plan);
+    CHECK_STATUS(planner_ptr->CreateASTScriptPlan(script, ctx->logical_plan));
+
+    for (auto plan : ctx->logical_plan) {
+        if (plan->GetType() == node::kPlanTypeQuery) {
+            auto query = dynamic_cast<node::QueryPlanNode *>(plan);
+            if (query && query->config_options_ && query->config_options_->count("values") != 0) {
+                ctx->request_expressions = query->config_options_->at("values");
+                break;
+            }
+        }
+    }
+
+    return {};
 }
 
 bool PlanAPI::CreatePlanTreeFromScript(const std::string &sql, PlanNodeList &plan_trees, NodeManager *node_manager,
@@ -87,6 +100,22 @@ const std::string PlanAPI::GenerateName(const std::string prefix, int id) {
     time(&t);
     std::string name = prefix + "_" + std::to_string(id) + "_" + std::to_string(t);
     return name;
+}
+
+absl::Status ParseStatement(absl::string_view sql, std::unique_ptr<zetasql::ParserOutput>* out) {
+    zetasql::ParserOptions parser_opts;
+    zetasql::LanguageOptions language_opts;
+    language_opts.EnableLanguageFeature(zetasql::FEATURE_V_1_3_COLUMN_DEFAULT_VALUE);
+    parser_opts.set_language_options(&language_opts);
+    auto zetasql_status = zetasql::ParseStatement(sql, parser_opts, out);
+    zetasql::ErrorLocation location;
+    if (!zetasql_status.ok()) {
+        zetasql::ErrorLocation location;
+        GetErrorLocation(zetasql_status, &location);
+        return absl::InvalidArgumentError(zetasql::FormatError(zetasql_status));
+    }
+
+    return absl::OkStatus();
 }
 
 absl::StatusOr<codec::Schema> ParseTableColumSchema(absl::string_view str) {

--- a/hybridse/src/planv2/planner_v2.h
+++ b/hybridse/src/planv2/planner_v2.h
@@ -22,16 +22,11 @@
 
 #include "base/fe_status.h"
 #include "node/node_manager.h"
-#include "node/plan_node.h"
 #include "plan/planner.h"
 #include "zetasql/parser/parser.h"
 
 namespace hybridse {
 namespace plan {
-
-using base::Status;
-using node::NodePointVector;
-using node::PlanNodeList;
 
 class SimplePlannerV2 : public SimplePlanner {
  public:

--- a/hybridse/src/testing/engine_test_base.cc
+++ b/hybridse/src/testing/engine_test_base.cc
@@ -18,6 +18,7 @@
 #include <utility>
 
 #include "absl/cleanup/cleanup.h"
+#include "absl/strings/ascii.h"
 #include "absl/time/clock.h"
 #include "base/texttable.h"
 #include "google/protobuf/util/message_differencer.h"
@@ -419,7 +420,7 @@ Status EngineTestRunner::Compile() {
     if (!ok || !status.isOK()) {
         DLOG(INFO) << status;
         if (!sql_case_.expect().msg_.empty()) {
-            EXPECT_EQ(sql_case_.expect().msg_, status.msg);
+            EXPECT_EQ(absl::StripAsciiWhitespace(sql_case_.expect().msg_), status.msg);
         }
         return_code_ = ENGINE_TEST_RET_COMPILE_ERROR;
     } else {

--- a/hybridse/src/vm/engine.cc
+++ b/hybridse/src/vm/engine.cc
@@ -36,6 +36,7 @@
 
 DECLARE_bool(enable_spark_unsaferow_format);
 #define EXECUTE_MODE_OPT "execute_mode"
+#define VALUES_OPT "values"
 
 namespace hybridse {
 namespace vm {
@@ -51,6 +52,9 @@ EngineOptions::EngineOptions()
       enable_window_column_pruning_(false),
       max_sql_cache_size_(50) {
 }
+
+static absl::Status ExtractRows(const node::ExprNode* expr, const codec::Schema* sc, std::vector<codec::Row>* out)
+    ABSL_ATTRIBUTE_NONNULL();
 
 Engine::Engine(const std::shared_ptr<Catalog>& catalog) : cl_(catalog), options_(), mu_(), lru_cache_() {}
 Engine::Engine(const std::shared_ptr<Catalog>& catalog, const EngineOptions& options)
@@ -186,6 +190,15 @@ bool Engine::Get(const std::string& sql, const std::string& db, RunSession& sess
         ok = compiler.BuildClusterJob(info->get_sql_context(), status);
         if (!ok || 0 != status.code) {
             LOG(WARNING) << "fail to build cluster job: " << status.msg;
+            return false;
+        }
+    }
+
+    {
+        auto s = ExtractRequestRowsInSQL(&sql_context);
+        if (!s.ok()) {
+            status.code = common::kCodegenError;
+            status.msg = s.ToString();
             return false;
         }
     }
@@ -383,7 +396,7 @@ bool RunSession::SetCompileInfo(const std::shared_ptr<CompileInfo>& compile_info
     return true;
 }
 
-static absl::Status ExtractRows(const node::ExprNode* expr, const codec::Schema sc, std::vector<codec::Row>* out) {
+absl::Status ExtractRows(const node::ExprNode* expr, const codec::Schema* sc, std::vector<codec::Row>* out) {
     switch (expr->GetExprType()) {
         case node::kExprStructCtorParens: {
             auto struct_expr = expr->GetAsOrNull<node::StructCtorWithParens>();
@@ -391,35 +404,48 @@ static absl::Status ExtractRows(const node::ExprNode* expr, const codec::Schema 
             auto jit =
                 std::shared_ptr<hybridse::vm::HybridSeJitWrapper>(vm::HybridSeJitWrapper::CreateWithDefaultSymbols(&s));
             CHECK_STATUS_TO_ABSL(s);
-            codec::RowBuilder2 builder(jit.get(), {sc});
+            codec::RowBuilder2 builder(jit.get(), {*sc});
             CHECK_STATUS_TO_ABSL(builder.Init());
             codec::Row r;
             CHECK_STATUS_TO_ABSL(builder.Build(struct_expr->children_, &r));
             out->push_back(r);
-
             break;
         }
         case node::kExprArray: {
             auto arr = expr->GetAsOrNull<node::ArrayExpr>();
+            if (arr->GetChildNum() == 0) {
+                return absl::FailedPreconditionError("element number of the request values must not empty");
+            }
             for (auto e : arr->children_) {
                 CHECK_ABSL_STATUS(ExtractRows(e, sc, out));
             }
             break;
         }
         default: {
-            return absl::InvalidArgumentError(absl::StrCat("invalid expression: ", expr->GetExprString()));
+            // try build as request schema size = 1, necessary since AST parser simplify '(expr1)' to 'expr1'.
+            // this also allows syntax like 'values = [12, 12]', where request table schema is '[int]',
+            // it is a special rule to go with AST parser, not recommanded to users generally.
+            base::Status s;
+            auto jit =
+                std::shared_ptr<hybridse::vm::HybridSeJitWrapper>(vm::HybridSeJitWrapper::CreateWithDefaultSymbols(&s));
+            CHECK_STATUS_TO_ABSL(s);
+            codec::RowBuilder2 builder(jit.get(), {*sc});
+            CHECK_STATUS_TO_ABSL(builder.Init());
+            codec::Row r;
+            CHECK_STATUS_TO_ABSL(builder.Build({const_cast<node::ExprNode*>(expr)}, &r));
+            out->push_back(r);
         }
     }
 
     return absl::OkStatus();
 }
 
-absl::Status RunSession::ExtractRequestRowsInSQL(std::vector<Row>* rows) const {
-    assert(GetCompileInfo() != nullptr && "session not compiled yet");
-    auto& sql_ctx = std::dynamic_pointer_cast<vm::SqlCompileInfo>(GetCompileInfo())->get_sql_context();
-    if (sql_ctx.request_expressions != nullptr) {
+absl::Status Engine::ExtractRequestRowsInSQL(SqlContext* sql_ctx) {
+    if ((sql_ctx->engine_mode == kRequestMode || sql_ctx->engine_mode == kBatchRequestMode) &&
+        !sql_ctx->request_schema.empty() && sql_ctx->request_expressions != nullptr) {
+        // extract rows if request table and request values expression both exists
         vm::Engine::InitializeGlobalLLVM();
-        CHECK_ABSL_STATUS(ExtractRows(sql_ctx.request_expressions, sql_ctx.request_schema, rows));
+        CHECK_ABSL_STATUS(ExtractRows(sql_ctx->request_expressions, &sql_ctx->request_schema, &sql_ctx->request_rows));
     }
     return absl::OkStatus();
 }
@@ -431,13 +457,8 @@ int32_t RequestRunSession::Run(const Row& in_row, Row* out_row) {
 }
 int32_t RequestRunSession::Run(const uint32_t task_id, const Row& in_row, Row* out_row) {
     ::hybridse::codec::Row row = in_row;
-    std::vector<::hybridse::codec::Row> sql_request_rows;
-    // extract request values in SQL itself,
-    auto s = ExtractRequestRowsInSQL(&sql_request_rows);
-    if (!s.ok()) {
-        LOG(WARNING) << "extract request error: " << s;
-        return -1;
-    }
+    std::vector<::hybridse::codec::Row>& sql_request_rows =
+        std::dynamic_pointer_cast<SqlCompileInfo>(GetCompileInfo())->get_sql_context().request_rows;
     if (!sql_request_rows.empty()) {
         row = sql_request_rows.at(0);
     }
@@ -470,13 +491,8 @@ int32_t BatchRequestRunSession::Run(const std::vector<Row>& request_batch, std::
 }
 int32_t BatchRequestRunSession::Run(const uint32_t id, const std::vector<Row>& request_batch,
                                     std::vector<Row>& output) {
-    std::vector<::hybridse::codec::Row> sql_request_rows;
-    // extract request values in SQL itself,
-    auto s = ExtractRequestRowsInSQL(&sql_request_rows);
-    if (!s.ok()) {
-        LOG(WARNING) << "extract request error: " << s;
-        return -1;
-    }
+    std::vector<::hybridse::codec::Row>& sql_request_rows =
+        std::dynamic_pointer_cast<SqlCompileInfo>(GetCompileInfo())->get_sql_context().request_rows;
 
     RunnerContext ctx(std::dynamic_pointer_cast<SqlCompileInfo>(compile_info_)->get_sql_context().cluster_job,
                       sql_request_rows.empty() ? request_batch : sql_request_rows, sp_name_, is_debug_);
@@ -609,7 +625,7 @@ std::shared_ptr<TableHandler> LocalTablet::SubQuery(uint32_t task_id, const std:
     return std::make_shared<LocalTabletTableHandler>(task_id, session, in_rows, request_is_common);
 }
 
-EngineMode Engine::TryDetermineMode(absl::string_view sql, EngineMode default_mode) {
+EngineMode Engine::TryDetermineEngineMode(absl::string_view sql, EngineMode default_mode) {
     // DESIGN ISSUE as compiler need EngineMode before compilation,
     // give this method as a distinct function to SQL Compile function.
     std::unique_ptr<zetasql::ParserOutput> ast;
@@ -618,25 +634,38 @@ EngineMode Engine::TryDetermineMode(absl::string_view sql, EngineMode default_mo
         return default_mode;
     }
 
+    EngineMode mode = default_mode;
     if (ast->statement() &&
         ast->statement()->node_kind() == zetasql::AST_QUERY_STATEMENT ) {
         auto query = ast->statement()->GetAsOrNull<zetasql::ASTQueryStatement>();
         if (query && query->config_clause()) {
             auto options = query->config_clause()->options_list()->options_entries();
+            bool values_arr_size_gt_1 = false;
             for (auto kv : options) {
                 auto name = kv->name()->GetAsStringView();
                 if (absl::EqualsIgnoreCase(name, EXECUTE_MODE_OPT)) {
                     auto val = kv->value()->GetAsOrNull<zetasql::ASTStringLiteral>();
                     if (val) {
                         auto m = UnparseEngineMode(val->string_value());
-                        return m.value_or(default_mode);
+                        mode = m.value_or(default_mode);
                     }
                 }
+
+                if (absl::EqualsIgnoreCase(name, VALUES_OPT)) {
+                    auto arr_expr = kv->value()->GetAsOrNull<zetasql::ASTArrayConstructor>();
+                    if (arr_expr) {
+                        values_arr_size_gt_1 = arr_expr->elements().size() > 1;
+                    }
+                }
+            }
+
+            if (mode == vm::kRequestMode && values_arr_size_gt_1) {
+                mode = kBatchRequestMode;
             }
         }
     }
 
-    return default_mode;
+    return mode;
 }
 }  // namespace vm
 }  // namespace hybridse

--- a/hybridse/src/vm/engine.cc
+++ b/hybridse/src/vm/engine.cc
@@ -25,19 +25,20 @@
 #include "codec/fe_row_codec.h"
 #include "gflags/gflags.h"
 #include "llvm-c/Target.h"
+#include "plan/plan_api.h"
 #include "udf/default_udf_library.h"
 #include "vm/internal/node_helper.h"
 #include "vm/local_tablet_handler.h"
 #include "vm/mem_catalog.h"
 #include "vm/runner_ctx.h"
 #include "vm/sql_compiler.h"
+#include "zetasql/parser/parser.h"
 
 DECLARE_bool(enable_spark_unsaferow_format);
+#define EXECUTE_MODE_OPT "execute_mode"
 
 namespace hybridse {
 namespace vm {
-
-static bool LLVM_IS_INITIALIZED = false;
 
 EngineOptions::EngineOptions()
     : keep_ir_(false),
@@ -56,16 +57,15 @@ Engine::Engine(const std::shared_ptr<Catalog>& catalog, const EngineOptions& opt
     : cl_(catalog), options_(options), mu_(), lru_cache_() {}
 Engine::~Engine() {}
 
-void Engine::InitializeGlobalLLVM() {
-    // not thread safe, but is generally fine to call multiple times
-    if (LLVM_IS_INITIALIZED) return;
-
+static bool InitializeLLVM() {
     absl::Time begin = absl::Now();
     LLVMInitializeNativeTarget();
     LLVMInitializeNativeAsmPrinter();
     LOG(INFO) << "initialize llvm native target and asm printer, takes " << absl::Now() - begin;
-    LLVM_IS_INITIALIZED = true;
+    return true;
 }
+
+void Engine::InitializeGlobalLLVM() { [[maybe_unused]] static bool LLVM_IS_INITIALIZED = InitializeLLVM(); }
 
 void Engine::InitializeUnsafeRowOptFlag(bool isUnsafeRowOpt) {
     FLAGS_enable_spark_unsaferow_format = isUnsafeRowOpt;
@@ -383,12 +383,64 @@ bool RunSession::SetCompileInfo(const std::shared_ptr<CompileInfo>& compile_info
     return true;
 }
 
+static absl::Status ExtractRows(const node::ExprNode* expr, const codec::Schema sc, std::vector<codec::Row>* out) {
+    switch (expr->GetExprType()) {
+        case node::kExprStructCtorParens: {
+            auto struct_expr = expr->GetAsOrNull<node::StructCtorWithParens>();
+            base::Status s;
+            auto jit =
+                std::shared_ptr<hybridse::vm::HybridSeJitWrapper>(vm::HybridSeJitWrapper::CreateWithDefaultSymbols(&s));
+            CHECK_STATUS_TO_ABSL(s);
+            codec::RowBuilder2 builder(jit.get(), {sc});
+            CHECK_STATUS_TO_ABSL(builder.Init());
+            codec::Row r;
+            CHECK_STATUS_TO_ABSL(builder.Build(struct_expr->children_, &r));
+            out->push_back(r);
+
+            break;
+        }
+        case node::kExprArray: {
+            auto arr = expr->GetAsOrNull<node::ArrayExpr>();
+            for (auto e : arr->children_) {
+                CHECK_ABSL_STATUS(ExtractRows(e, sc, out));
+            }
+            break;
+        }
+        default: {
+            return absl::InvalidArgumentError(absl::StrCat("invalid expression: ", expr->GetExprString()));
+        }
+    }
+
+    return absl::OkStatus();
+}
+
+absl::Status RunSession::ExtractRequestRowsInSQL(std::vector<Row>* rows) const {
+    assert(GetCompileInfo() != nullptr && "session not compiled yet");
+    auto& sql_ctx = std::dynamic_pointer_cast<vm::SqlCompileInfo>(GetCompileInfo())->get_sql_context();
+    if (sql_ctx.request_expressions != nullptr) {
+        vm::Engine::InitializeGlobalLLVM();
+        CHECK_ABSL_STATUS(ExtractRows(sql_ctx.request_expressions, sql_ctx.request_schema, rows));
+    }
+    return absl::OkStatus();
+}
+
 int32_t RequestRunSession::Run(const Row& in_row, Row* out_row) {
     DLOG(INFO) << "Request Row Run with main task";
     return Run(std::dynamic_pointer_cast<SqlCompileInfo>(compile_info_)->get_sql_context().cluster_job->main_task_id(),
                in_row, out_row);
 }
 int32_t RequestRunSession::Run(const uint32_t task_id, const Row& in_row, Row* out_row) {
+    ::hybridse::codec::Row row = in_row;
+    std::vector<::hybridse::codec::Row> sql_request_rows;
+    // extract request values in SQL itself,
+    auto s = ExtractRequestRowsInSQL(&sql_request_rows);
+    if (!s.ok()) {
+        LOG(WARNING) << "extract request error: " << s;
+        return -1;
+    }
+    if (!sql_request_rows.empty()) {
+        row = sql_request_rows.at(0);
+    }
     auto task = std::dynamic_pointer_cast<SqlCompileInfo>(compile_info_)
                     ->get_sql_context()
                     .cluster_job->GetTask(task_id)
@@ -398,7 +450,7 @@ int32_t RequestRunSession::Run(const uint32_t task_id, const Row& in_row, Row* o
         return -2;
     }
     DLOG(INFO) << "Request Row Run with task_id " << task_id;
-    RunnerContext ctx(std::dynamic_pointer_cast<SqlCompileInfo>(compile_info_)->get_sql_context().cluster_job, in_row,
+    RunnerContext ctx(std::dynamic_pointer_cast<SqlCompileInfo>(compile_info_)->get_sql_context().cluster_job, row,
                       sp_name_, is_debug_);
     auto output = task->RunWithCache(ctx);
     if (!output) {
@@ -418,8 +470,16 @@ int32_t BatchRequestRunSession::Run(const std::vector<Row>& request_batch, std::
 }
 int32_t BatchRequestRunSession::Run(const uint32_t id, const std::vector<Row>& request_batch,
                                     std::vector<Row>& output) {
+    std::vector<::hybridse::codec::Row> sql_request_rows;
+    // extract request values in SQL itself,
+    auto s = ExtractRequestRowsInSQL(&sql_request_rows);
+    if (!s.ok()) {
+        LOG(WARNING) << "extract request error: " << s;
+        return -1;
+    }
+
     RunnerContext ctx(std::dynamic_pointer_cast<SqlCompileInfo>(compile_info_)->get_sql_context().cluster_job,
-                      request_batch, sp_name_, is_debug_);
+                      sql_request_rows.empty() ? request_batch : sql_request_rows, sp_name_, is_debug_);
     auto task =
         std::dynamic_pointer_cast<SqlCompileInfo>(compile_info_)->get_sql_context().cluster_job->GetTask(id).GetRoot();
     if (nullptr == task) {
@@ -547,6 +607,37 @@ std::shared_ptr<TableHandler> LocalTablet::SubQuery(uint32_t task_id, const std:
         }
     }
     return std::make_shared<LocalTabletTableHandler>(task_id, session, in_rows, request_is_common);
+}
+
+EngineMode Engine::TryDetermineMode(absl::string_view sql, EngineMode default_mode) {
+    // DESIGN ISSUE as compiler need EngineMode before compilation,
+    // give this method as a distinct function to SQL Compile function.
+    std::unique_ptr<zetasql::ParserOutput> ast;
+    auto s = hybridse::plan::ParseStatement(sql, &ast);
+    if (!s.ok()) {
+        LOG(WARNING) << s;
+        return default_mode;
+    }
+
+    if (ast->statement() &&
+        ast->statement()->node_kind() == zetasql::AST_QUERY_STATEMENT ) {
+        auto query = ast->statement()->GetAsOrNull<zetasql::ASTQueryStatement>();
+        if (query && query->config_clause()) {
+            auto options = query->config_clause()->options_list()->options_entries();
+            for (auto kv : options) {
+                auto name = kv->name()->GetAsStringView();
+                if (absl::EqualsIgnoreCase(name, EXECUTE_MODE_OPT)) {
+                    auto val = kv->value()->GetAsOrNull<zetasql::ASTStringLiteral>();
+                    if (val) {
+                        auto m = UnparseEngineMode(val->string_value());
+                        return m.value_or(default_mode);
+                    }
+                }
+            }
+        }
+    }
+
+    return default_mode;
 }
 }  // namespace vm
 }  // namespace hybridse

--- a/hybridse/src/vm/engine.cc
+++ b/hybridse/src/vm/engine.cc
@@ -615,7 +615,6 @@ EngineMode Engine::TryDetermineMode(absl::string_view sql, EngineMode default_mo
     std::unique_ptr<zetasql::ParserOutput> ast;
     auto s = hybridse::plan::ParseStatement(sql, &ast);
     if (!s.ok()) {
-        LOG(WARNING) << s;
         return default_mode;
     }
 

--- a/hybridse/src/vm/engine_compile_test.cc
+++ b/hybridse/src/vm/engine_compile_test.cc
@@ -709,6 +709,26 @@ TEST_F(EngineCompileTest, ExternalFunctionTest) {
     std::string sql2 = "select cut2(col0) from t1;";
     ASSERT_TRUE(engine.Get(sql2, "simple_db", session, get_status));
 }
+
+TEST_F(EngineCompileTest, DetermineEngineMode) {
+    EXPECT_EQ(vm::kRequestMode, Engine::TryDetermineEngineMode(R"(SELECT * from t1
+CONFIG (execute_mode = 'request', values = [12]))",
+                                    kBatchMode));
+
+    EXPECT_EQ(vm::kBatchRequestMode, Engine::TryDetermineEngineMode(R"(SELECT * from t1
+CONFIG (execute_mode = 'request', values = [(12), (12)]))",
+                                    kBatchMode));
+
+    EXPECT_EQ(vm::kBatchRequestMode, Engine::TryDetermineEngineMode(R"(SELECT * from t1
+CONFIG (execute_mode = 'batchrequest', values = [(12)]))",
+                                    kBatchMode));
+
+    // no option, default
+    EXPECT_EQ(vm::kRequestMode, Engine::TryDetermineEngineMode(R"(SELECT * FROM t1)", kRequestMode));
+    // on error, default
+    EXPECT_EQ(vm::kBatchMode, Engine::TryDetermineEngineMode(R"(SELECT)", kBatchMode));
+}
+
 }  // namespace vm
 }  // namespace hybridse
 

--- a/hybridse/src/vm/engine_context.cc
+++ b/hybridse/src/vm/engine_context.cc
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2024 OpenMLDB authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "vm/engine_context.h"
+
+#include "absl/container/flat_hash_map.h"
+
+namespace hybridse {
+namespace vm {
+
+static absl::flat_hash_map<absl::string_view, EngineMode> createModeMap() {
+    absl::flat_hash_map<absl::string_view, EngineMode> map = {
+        {"online", kBatchMode},  // 'online' default to batch
+        {"batch", kBatchMode},
+        {"online_preview", kBatchMode},
+        {"online_batch", kBatchMode},
+        {"request", kRequestMode},
+        {"online_request", kRequestMode},
+        {"batch_request", kBatchRequestMode},
+        {"batchrequest", kBatchRequestMode},
+        {"online_batchrequest", kBatchRequestMode},
+        {"offline", kOffline},
+    };
+    return map;
+}
+
+static const auto& getModeMap() {
+    static const absl::flat_hash_map<absl::string_view, EngineMode> mode_map = *new auto(createModeMap());
+    return mode_map;
+}
+
+std::string EngineModeName(EngineMode mode) {
+    switch (mode) {
+        case kBatchMode:
+            return "kBatchMode";
+        case kRequestMode:
+            return "kRequestMode";
+        case kBatchRequestMode:
+            return "kBatchRequestMode";
+        case kMockRequestMode:
+            return "kMockRequestMode";
+        case kOffline:
+            return "kOffline";
+        default:
+            return "unknown";
+    }
+}
+
+absl::StatusOr<EngineMode> UnparseEngineMode(absl::string_view str) {
+    auto& m = getModeMap();
+    auto it = m.find(str);
+    if (it != m.end()) {
+        return it->second;
+    }
+
+    return absl::NotFoundError(absl::StrCat("no matching mode for string '", str, "'"));
+}
+
+}  // namespace vm
+}  // namespace hybridse

--- a/hybridse/src/vm/sql_compiler.cc
+++ b/hybridse/src/vm/sql_compiler.cc
@@ -133,21 +133,6 @@ bool SqlCompiler::Compile(SqlContext& ctx, Status& status) {  // NOLINT
     return true;
 }
 
-std::string EngineModeName(EngineMode mode) {
-    switch (mode) {
-        case kBatchMode:
-            return "kBatchMode";
-        case kRequestMode:
-            return "kRequestMode";
-        case kBatchRequestMode:
-            return "kBatchRequestMode";
-        case kMockRequestMode:
-            return "kMockRequestMode";
-        default:
-            return "unknown";
-    }
-}
-
 Status SqlCompiler::BuildBatchModePhysicalPlan(SqlContext* ctx, const ::hybridse::node::PlanNodeList& plan_list,
                                                ::llvm::Module* llvm_module, udf::UdfLibrary* library,
                                                PhysicalOpNode** output) {

--- a/src/sdk/node_adapter.cc
+++ b/src/sdk/node_adapter.cc
@@ -793,10 +793,12 @@ absl::StatusOr<std::string> NodeAdapter::ExtractUserOption(const hybridse::node:
     if (!absl::EqualsIgnoreCase(map.begin()->first, "password")) {
         return absl::InvalidArgumentError("invalid option " + map.begin()->first);
     }
-    if (map.begin()->second->GetDataType() != hybridse::node::kVarchar) {
+    auto& kv = *map.begin();
+    auto cnode = kv.second->GetAsOrNull<::hybridse::node::ConstNode>();
+    if (cnode == nullptr || cnode->GetDataType() != hybridse::node::kVarchar) {
         return absl::InvalidArgumentError("the value of password should be string");
     }
-    return map.begin()->second->GetAsString();
+    return cnode->GetAsString();
 }
 
 }  // namespace openmldb::sdk

--- a/src/sdk/options_map_parser.h
+++ b/src/sdk/options_map_parser.h
@@ -47,7 +47,8 @@ class OptionsMapParser {
             if (options_map_.find(key) != options_map_.end()) {
                 LOG(WARNING) << "option " << key << " already exists, won't replace";
             } else {
-                options_map_.insert(std::pair<std::string, hybridse::node::ConstNode>(key, *(item.second)));  // copy
+                options_map_.insert(std::pair<std::string, hybridse::node::ConstNode>(
+                    key, *(item.second)->GetAsOrNull<hybridse::node ::ConstNode>()));  // copy
             }
         }
     }

--- a/src/sdk/sql_cluster_router.cc
+++ b/src/sdk/sql_cluster_router.cc
@@ -2668,14 +2668,15 @@ std::shared_ptr<hybridse::sdk::ResultSet> SQLClusterRouter::ExecuteSQL(
     // functions we called later may not change the status if it's succeed. So if we pass error status here, we'll get a
     // fake error
     status->SetOK();
-    hybridse::node::NodeManager node_manager;
-    hybridse::node::PlanNodeList plan_trees;
-    hybridse::base::Status sql_status;
-    hybridse::plan::PlanAPI::CreatePlanTreeFromScript(sql, plan_trees, &node_manager, sql_status);
+    hybridse::vm::SqlContext ctx;
+    ctx.sql = sql;
+    auto sql_status = hybridse::plan::PlanAPI::CreatePlanTreeFromScript(&ctx);
     if (!sql_status.isOK()) {
         COPY_PREPEND_AND_WARN(status, sql_status, "create logic plan tree failed");
         return {};
     }
+
+    auto& plan_trees = ctx.logical_plan;
     auto ns_ptr = cluster_sdk_->GetNsClient();
     if (!ns_ptr) {
         SET_STATUS_AND_WARN(status, StatusCode::kRuntimeError, "no ns client, retry or check ns process");
@@ -3677,16 +3678,18 @@ hybridse::sdk::Status SQLClusterRouter::HandleCreateFunction(const hybridse::nod
     }
     fun->set_file((*option)["FILE"]->GetExprString());
     if (auto iter = option->find("RETURN_NULLABLE"); iter != option->end()) {
-        if (iter->second->GetDataType() != hybridse::node::kBool) {
+        auto cnode = iter->second->GetAsOrNull<hybridse::node::ConstNode>();
+        if (cnode == nullptr || cnode->GetDataType() != hybridse::node::kBool) {
             return {StatusCode::kCmdError, "return_nullable should be bool"};
         }
-        fun->set_return_nullable(iter->second->GetBool());
+        fun->set_return_nullable(cnode->GetBool());
     }
     if (auto iter = option->find("ARG_NULLABLE"); iter != option->end()) {
-        if (iter->second->GetDataType() != hybridse::node::kBool) {
+        auto cnode = iter->second->GetAsOrNull<hybridse::node::ConstNode>();
+        if (cnode == nullptr || cnode->GetDataType() != hybridse::node::kBool) {
             return {StatusCode::kCmdError, "arg_nullable should be bool"};
         }
-        fun->set_arg_nullable(iter->second->GetBool());
+        fun->set_arg_nullable(cnode->GetBool());
     }
     hybridse::sdk::Status st;
     if (cluster_sdk_->IsClusterMode()) {
@@ -3814,13 +3817,13 @@ hybridse::sdk::Status SQLClusterRouter::HandleDeploy(const std::string& db,
     Bias bias;
     iter = deploy_node->Options()->find(RANGE_BIAS_OPTION);
     if (iter != deploy_node->Options()->end()) {
-        if (!bias.SetRange(iter->second)) {
+        if (!bias.SetRange(iter->second->GetAsOrNull<hybridse::node::ConstNode>())) {
             return {StatusCode::kCmdError, "range bias '" + iter->second->GetExprString() + "' is illegal"};
         }
     }
     iter = deploy_node->Options()->find(ROWS_BIAS_OPTION);
     if (iter != deploy_node->Options()->end()) {
-        if (!bias.SetRows(iter->second)) {
+        if (!bias.SetRows(iter->second->GetAsOrNull<hybridse::node::ConstNode>())) {
             return {StatusCode::kCmdError, "rows bias '" + iter->second->GetExprString() + "' is illegal"};
         }
     }

--- a/src/sdk/sql_sdk_test.cc
+++ b/src/sdk/sql_sdk_test.cc
@@ -23,17 +23,11 @@
 #include <string>
 #include <vector>
 
-#include "base/file_util.h"
 #include "base/glog_wrapper.h"
-#include "codec/fe_row_codec.h"
-#include "common/timer.h"
 #include "gflags/gflags.h"
 #include "sdk/mini_cluster.h"
 #include "sdk/sql_router.h"
-#include "sdk/sql_sdk_base_test.h"
-#include "test/base_test.h"
 #include "test/util.h"
-#include "vm/catalog.h"
 
 namespace openmldb {
 namespace sdk {
@@ -44,6 +38,7 @@ std::shared_ptr<SQLRouter> router_ = std::shared_ptr<SQLRouter>();
 static void SetOnlineMode(std::shared_ptr<SQLRouter> router) {
     ::hybridse::sdk::Status status;
     router->ExecuteSQL("SET @@execute_mode='online';", &status);
+    ASSERT_TRUE(status.IsOK()) << status.msg;
 }
 
 static std::shared_ptr<SQLRouter> GetNewSQLRouter() {

--- a/src/sdk/sql_sdk_test.h
+++ b/src/sdk/sql_sdk_test.h
@@ -18,7 +18,7 @@
 #define SRC_SDK_SQL_SDK_TEST_H_
 
 #include <string>
-#include "base/glog_wrapper.h"
+
 #include "sdk/sql_sdk_base_test.h"
 
 namespace openmldb {
@@ -58,6 +58,8 @@ INSTANTIATE_TEST_SUITE_P(SQLSDKLastJoinWhere, SQLSDKQueryTest,
                          testing::ValuesIn(SQLSDKQueryTest::InitCases("cases/query/last_join_where.yaml")));
 INSTANTIATE_TEST_SUITE_P(SQLSDKParameterizedQuery, SQLSDKQueryTest,
                          testing::ValuesIn(SQLSDKQueryTest::InitCases("cases/query/parameterized_query.yaml")));
+INSTANTIATE_TEST_SUITE_P(SQLSimpleQuery, SQLSDKQueryTest,
+                         testing::ValuesIn(SQLSDKQueryTest::InitCases("cases/query/simple_query.yaml")));
 
 // Test Cluster
 INSTANTIATE_TEST_SUITE_P(

--- a/src/tablet/tablet_impl.cc
+++ b/src/tablet/tablet_impl.cc
@@ -1686,7 +1686,7 @@ void TabletImpl::ProcessQuery(bool is_sub, RpcController* ctrl, const openmldb::
 
     hybridse::vm::EngineMode default_mode =
         request->is_batch() ? hybridse::vm::EngineMode::kBatchMode : hybridse::vm::EngineMode::kRequestMode;
-    auto mode = hybridse::vm::Engine::TryDetermineMode(request->sql(), default_mode);
+    auto mode = hybridse::vm::Engine::TryDetermineEngineMode(request->sql(), default_mode);
 
     ::hybridse::base::Status status;
     if (mode == hybridse::vm::EngineMode::kBatchMode) {

--- a/src/tablet/tablet_impl.cc
+++ b/src/tablet/tablet_impl.cc
@@ -1684,8 +1684,12 @@ void TabletImpl::ProcessQuery(bool is_sub, RpcController* ctrl, const openmldb::
         }
     };
 
+    hybridse::vm::EngineMode default_mode =
+        request->is_batch() ? hybridse::vm::EngineMode::kBatchMode : hybridse::vm::EngineMode::kRequestMode;
+    auto mode = hybridse::vm::Engine::TryDetermineMode(request->sql(), default_mode);
+
     ::hybridse::base::Status status;
-    if (request->is_batch()) {
+    if (mode == hybridse::vm::EngineMode::kBatchMode) {
         // convert repeated openmldb:type::DataType into hybridse::codec::Schema
         hybridse::codec::Schema parameter_schema;
         for (int i = 0; i < request->parameter_types().size(); i++) {


### PR DESCRIPTION
##  request mode in RAW SQL
```sql
SELECT ....
CONFIG ( execute_mode = 'request', values = (expr1, expr2 , ...) )

SELECT ....
CONFIG ( execute_mode = 'request', values = [(expr1, expr2 , ...), (....)] )
```

## call procedure 

```sql
call dp (expr1, expr2, ...)
```

## TODOs
- docs
- support `request` value in system variable `execute_mode`
- take care const query