### PR TITLE
ci(coverage): upload coverage with token

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -102,9 +102,10 @@ jobs:
           path: build
 
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: build/coverage.info
+          token: ${{ secrets.CODECOV_TOKEN }}
           name: coverage-cpp
           fail_ci_if_error: true
           verbose: true

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -452,9 +452,10 @@ jobs:
           path: go
 
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: go/coverage.out,python/openmldb_sdk/tests/coverage.xml,python/openmldb_tool/tests/coverage.xml,java/**/target/site/jacoco/jacoco.xml,java/**/target/scoverage.xml
           name: coverage-sdk
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
tokenless upload seems break for codecov-action v3, no fix upstream. Upgrading to v4 with a upload token. Ref https://github.com/codecov/codecov-action/issues/1359


