### PR TITLE
refactor!: relocate go sdk

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -368,49 +368,8 @@ jobs:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
 
-  go-sdk:
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/4paradigm/hybridsql:latest
-    env:
-      OPENMLDB_BUILD_TARGET: "openmldb"
-      OPENMLDB_MODE: standalone
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/setup-go@v3
-        with:
-          go-version: 1.18
-
-      - name: build openmldb
-        run: make build install
-
-      - name: start server
-        run: ./openmldb/sbin/start-all.sh
-
-      - name: init test database
-        env:
-          OPENMLDB_NS_HOST: 127.0.0.1
-          OPENMLDB_NS_PORT: 6527
-        run: |
-          echo "CREATE DATABASE test_db;" | ./openmldb/bin/openmldb --host=$OPENMLDB_NS_HOST --port=$OPENMLDB_NS_PORT
-
-      - name: go test
-        env:
-          OPENMLDB_APISERVER_HOST: 127.0.0.1
-          OPENMLDB_APISERVER_PORT: 8080
-        working-directory: go
-        run: go test ./... -race -covermode=atomic -coverprofile=coverage.out
-
-      - name: upload coverage
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage-go-report-${{ github.sha }}
-          path: go/coverage.out
-          retention-days: 3
-
   publish-test-results:
-    needs: ["java-sdk", "python-sdk", "go-sdk"]
+    needs: ["java-sdk", "python-sdk"]
     # the action will only run on 4paradigm/OpenMLDB's context, not for fork repo or dependabot
     if: >
       always() && github.event_name == 'push' || (
@@ -426,7 +385,7 @@ jobs:
       comment_title: SDK Test Report
 
   publish-coverage-results:
-    needs: ["java-sdk", "python-sdk", "go-sdk"]
+    needs: ["java-sdk", "python-sdk"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -454,7 +413,7 @@ jobs:
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v4
         with:
-          files: go/coverage.out,python/openmldb_sdk/tests/coverage.xml,python/openmldb_tool/tests/coverage.xml,java/**/target/site/jacoco/jacoco.xml,java/**/target/scoverage.xml
+          files: python/openmldb_sdk/tests/coverage.xml,python/openmldb_tool/tests/coverage.xml,java/**/target/site/jacoco/jacoco.xml,java/**/target/scoverage.xml
           name: coverage-sdk
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -404,12 +404,6 @@ jobs:
           name: coverage-python-report-${{ github.sha }}
           path: python
 
-      - name: Download Artifacts (go)
-        uses: actions/download-artifact@v3
-        with:
-          name: coverage-go-report-${{ github.sha }}
-          path: go
-
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v4
         with:

--- a/docs/en/quickstart/sdk/go_sdk.md
+++ b/docs/en/quickstart/sdk/go_sdk.md
@@ -11,7 +11,7 @@ The current functionality support of the Go SDK is not yet complete. It is curre
 ## Go SDK installation
 
 ```bash
-go get github.com/4paradigm/OpenMLDB/go
+go get github.com/4paradigm/openmldb-go-sdk
 ```
 
 ## Go SDK usage
@@ -79,7 +79,7 @@ import (
   "database/sql"
 
   // Load OpenMLDB SDK
-  _ "github.com/4paradigm/OpenMLDB/go"
+  _ "github.com/4paradigm/openmldb-go-sdk
 )
 
 func main() {

--- a/docs/zh/quickstart/sdk/go_sdk.md
+++ b/docs/zh/quickstart/sdk/go_sdk.md
@@ -12,7 +12,7 @@ Go SDK 目前功能支持上并不完善，目前仅用于开发测试或者特�
 ## Go SDK 包安装
 
 ```Bash
-go get github.com/4paradigm/OpenMLDB/go
+go get github.com/4paradigm/openmldb-go-sdk
 ```
 
 ## 使用 Go SDK
@@ -80,7 +80,7 @@ import (
   "database/sql"
 
   // 加载 OpenMLDB SDK
-  _ "github.com/4paradigm/OpenMLDB/go"
+  _ "github.com/4paradigm/openmldb-go-sdk"
 )
 
 func main() {

--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,5 @@
+**Moved to https://github.com/4paradigm/openmldb-go-sdk**
+
+Please note this directory only reserved for backwards compatibility use over `github.com/4paradigm/OpenMLDB/go`, and will removed anytime in later releases.
+
+Consider migrate to `github.com/4paradigm/openmldb-go-sdk`.


### PR DESCRIPTION
moving to https://github.com/4paradigm/openmldb-go-sdk
