### PR TITLE
fix: make clients use always send auth info

### DIFF
--- a/src/auth/brpc_authenticator.cc
+++ b/src/auth/brpc_authenticator.cc
@@ -18,6 +18,7 @@
 
 #include "auth_utils.h"
 #include "butil/endpoint.h"
+#include "nameserver/system_table.h"
 
 namespace openmldb::authn {
 
@@ -37,6 +38,9 @@ int BRPCAuthenticator::GenerateCredential(std::string* auth_str) const {
 
 int BRPCAuthenticator::VerifyCredential(const std::string& auth_str, const butil::EndPoint& client_addr,
                                         brpc::AuthContext* out_ctx) const {
+    if (FLAGS_skip_grant_tables) {
+        return 0;
+    }
     if (auth_str.length() < 2) {
         return -1;
     }

--- a/src/cmd/openmldb.cc
+++ b/src/cmd/openmldb.cc
@@ -149,15 +149,12 @@ void StartNameServer() {
     brpc::ServerOptions options;
     std::unique_ptr<openmldb::auth::UserAccessManager> user_access_manager;
     std::unique_ptr<openmldb::authn::BRPCAuthenticator> server_authenticator;
-    if (!FLAGS_skip_grant_tables) {
-        user_access_manager =
-            std::make_unique<openmldb::auth::UserAccessManager>(name_server->GetSystemTableIterator());
-        server_authenticator = std::make_unique<openmldb::authn::BRPCAuthenticator>(
-            [&user_access_manager](const std::string& host, const std::string& username, const std::string& password) {
-                return user_access_manager->IsAuthenticated(host, username, password);
-            });
-        options.auth = server_authenticator.get();
-    }
+    user_access_manager = std::make_unique<openmldb::auth::UserAccessManager>(name_server->GetSystemTableIterator());
+    server_authenticator = std::make_unique<openmldb::authn::BRPCAuthenticator>(
+        [&user_access_manager](const std::string& host, const std::string& username, const std::string& password) {
+            return user_access_manager->IsAuthenticated(host, username, password);
+        });
+    options.auth = server_authenticator.get();
 
     options.num_threads = FLAGS_thread_pool_size;
     brpc::Server server;
@@ -259,14 +256,12 @@ void StartTablet() {
     std::unique_ptr<openmldb::auth::UserAccessManager> user_access_manager;
     std::unique_ptr<openmldb::authn::BRPCAuthenticator> server_authenticator;
 
-    if (!FLAGS_skip_grant_tables) {
-        user_access_manager = std::make_unique<openmldb::auth::UserAccessManager>(tablet->GetSystemTableIterator());
-        server_authenticator = std::make_unique<openmldb::authn::BRPCAuthenticator>(
-            [&user_access_manager](const std::string& host, const std::string& username, const std::string& password) {
-                return user_access_manager->IsAuthenticated(host, username, password);
-            });
-        options.auth = server_authenticator.get();
-    }
+    user_access_manager = std::make_unique<openmldb::auth::UserAccessManager>(tablet->GetSystemTableIterator());
+    server_authenticator = std::make_unique<openmldb::authn::BRPCAuthenticator>(
+        [&user_access_manager](const std::string& host, const std::string& username, const std::string& password) {
+            return user_access_manager->IsAuthenticated(host, username, password);
+        });
+    options.auth = server_authenticator.get();
     options.num_threads = FLAGS_thread_pool_size;
     brpc::Server server;
     if (server.AddService(tablet, brpc::SERVER_DOESNT_OWN_SERVICE) != 0) {

--- a/src/nameserver/name_server_impl.cc
+++ b/src/nameserver/name_server_impl.cc
@@ -1520,12 +1520,10 @@ bool NameServerImpl::Init(const std::string& zk_cluster, const std::string& zk_p
     task_vec_.resize(FLAGS_name_server_task_max_concurrency + FLAGS_name_server_task_concurrency_for_replica_cluster);
     task_thread_pool_.DelayTask(FLAGS_make_snapshot_check_interval,
                                 boost::bind(&NameServerImpl::SchedMakeSnapshot, this));
-    if (!FLAGS_skip_grant_tables) {
-        std::shared_ptr<::openmldb::nameserver::TableInfo> table_info;
-        while (
-            !GetTableInfo(::openmldb::nameserver::USER_INFO_NAME, ::openmldb::nameserver::INTERNAL_DB, &table_info)) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
-        }
+    std::shared_ptr<::openmldb::nameserver::TableInfo> table_info;
+    while (
+        !GetTableInfo(::openmldb::nameserver::USER_INFO_NAME, ::openmldb::nameserver::INTERNAL_DB, &table_info)) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
     return true;
 }
@@ -5593,7 +5591,7 @@ void NameServerImpl::OnLocked() {
         PDLOG(WARNING, "recover failed");
     }
     CreateDatabaseOrExit(INTERNAL_DB);
-    if (!FLAGS_skip_grant_tables && db_table_info_[INTERNAL_DB].count(USER_INFO_NAME) == 0) {
+    if (db_table_info_[INTERNAL_DB].count(USER_INFO_NAME) == 0) {
         auto temp = FLAGS_system_table_replica_num;
         FLAGS_system_table_replica_num = tablets_.size();
         CreateSystemTableOrExit(SystemTableType::kUser);

--- a/src/rpc/rpc_client.h
+++ b/src/rpc/rpc_client.h
@@ -104,9 +104,7 @@ class RpcClient {
         if (use_sleep_policy_) {
             options.retry_policy = &sleep_retry_policy;
         }
-        if (!FLAGS_skip_grant_tables) {
-            options.auth = &client_authenticator_;
-        }
+        options.auth = &client_authenticator_;
 
         if (channel_->Init(endpoint_.c_str(), "", &options) != 0) {
             return -1;

--- a/src/sdk/mini_cluster.h
+++ b/src/sdk/mini_cluster.h
@@ -365,7 +365,6 @@ class StandaloneEnv {
             });
         brpc::ServerOptions options;
         options.auth = ns_authenticator_;
-        options.auth = ns_authenticator_;
         if (ns_.AddService(nameserver, brpc::SERVER_OWNS_SERVICE) != 0) {
             LOG(WARNING) << "fail to add ns";
             return false;

--- a/src/tablet/file_sender.cc
+++ b/src/tablet/file_sender.cc
@@ -64,9 +64,7 @@ bool FileSender::Init() {
     }
     channel_ = new brpc::Channel();
     brpc::ChannelOptions options;
-    if (!FLAGS_skip_grant_tables) {
-        options.auth = &client_authenticator_;
-    }
+    options.auth = &client_authenticator_;
     options.timeout_ms = FLAGS_request_timeout_ms;
     options.connect_timeout_ms = FLAGS_request_timeout_ms;
     options.max_retry = FLAGS_request_max_retry;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Clients need a flag to enable BRPC authentication and send tokens. This causes a problem for the java sdk which cannot set GFLAGS to enable auth


* **What is the new behavior (if this is a feature change)?**
Clients always send brpc auth tokens. Servers validate tokens or not based on the skip grant tables flag
