### PR TITLE
feat(udf): array_combine & array_join

### DIFF
--- a/cases/query/udf_query.yaml
+++ b/cases/query/udf_query.yaml
@@ -562,14 +562,16 @@ cases:
         array_join(["1", "2"], "") c2,
         array_join(["1", "2"], cast(null as string)) c3,
         array_join(["1", NULL, "4", "5", NULL], "-") c4,
+        array_join(array<string>[], ",") as c5
     expect:
       columns:
         - c1 string
         - c2 string
         - c3 string
         - c4 string
+        - c5 string
       rows:
-        - ["1,2", "12", "12", "1-4-5"]
+        - ["1,2", "12", "12", "1-4-5", ""]
   - id: array_combine
     mode: request-unsupport
     sql: |
@@ -587,11 +589,50 @@ cases:
     sql: |
       select
         array_join(array_combine("-", [1, 2], [3, 4]), ",") c0,
+        array_join(array_combine("-", [1, 2], array<int64>[3], ["5", "6"]), ",") c1,
+        array_join(array_combine("|", ["1"], [timestamp(1717171200000), timestamp("2024-06-02 12:00:00")]), ",") c2,
     expect:
       columns:
         - c0 string
+        - c1 string
+        - c2 string
       rows:
-        - ["1-3,1-4,2-3,2-4"]
+        - ["1-3,1-4,2-3,2-4", "1-3-5,1-3-6,2-3-5,2-3-6", "1|2024-06-01 00:00:00,1|2024-06-02 12:00:00"]
+  - id: array_combine_3
+    desc: null values skipped
+    mode: request-unsupport
+    sql: |
+      select
+        array_join(array_combine("-", [1, NULL], [3, 4]), ",") c0,
+        array_join(array_combine("-", ARRAY<INT>[NULL], ["9", "8"]), ",") c1,
+    expect:
+      columns:
+        - c0 string
+        - c1 string
+      rows:
+        - ["1-3,1-4", ""]
+  - id: array_combine_4
+    desc: construct array from table
+    mode: request-unsupport
+    inputs:
+      - name: t1
+        columns: ["col1:int32", "std_ts:timestamp", "col2:string"]
+        indexs: ["index1:col1:std_ts"]
+        rows:
+          - [1, 1590115420001, "foo"]
+          - [2, 1590115420001, "bar"]
+    sql: |
+      select
+        col1,
+        array_join(array_combine("-", [col1, 10], [col2, "c2"]), ",") c0,
+      from t1
+    expect:
+      columns:
+        - col1 int32
+        - c0 string
+      rows:
+        - [1, "1-foo,1-c2,10-foo,10-c2"]
+        - [2, "2-bar,2-c2,10-bar,10-c2"]
 
   # ================================================================
   # Map data type

--- a/cases/query/udf_query.yaml
+++ b/cases/query/udf_query.yaml
@@ -581,6 +581,18 @@ cases:
       rows:
         - ["1-3,1-4,2-3,2-4"]
 
+  # - id: array_combine_2
+  #   desc: array_combine casting array to array<string> first
+  #   mode: request-unsupport
+  #   sql: |
+  #     select
+  #       array_join(array_combine("-", [1, 2], [3, 4]), ",") c0,
+  #   expect:
+  #     columns:
+  #       - c0 string
+  #     rows:
+  #       - ["1-3,1-4,2-3,2-4"]
+
   # ================================================================
   # Map data type
   # FIXME: request mode tests disabled, because TestRequestEngineForLastRow cause SEG FAULT

--- a/cases/query/udf_query.yaml
+++ b/cases/query/udf_query.yaml
@@ -591,13 +591,15 @@ cases:
         array_join(array_combine("-", [1, 2], [3, 4]), ",") c0,
         array_join(array_combine("-", [1, 2], array<int64>[3], ["5", "6"]), ",") c1,
         array_join(array_combine("|", ["1"], [timestamp(1717171200000), timestamp("2024-06-02 12:00:00")]), ",") c2,
+        array_join(array_combine("|", ["1"]), ",") c3,
     expect:
       columns:
         - c0 string
         - c1 string
         - c2 string
+        - c3 string
       rows:
-        - ["1-3,1-4,2-3,2-4", "1-3-5,1-3-6,2-3-5,2-3-6", "1|2024-06-01 00:00:00,1|2024-06-02 12:00:00"]
+        - ["1-3,1-4,2-3,2-4", "1-3-5,1-3-6,2-3-5,2-3-6", "1|2024-06-01 00:00:00,1|2024-06-02 12:00:00", "1"]
   - id: array_combine_3
     desc: null values skipped
     mode: request-unsupport
@@ -605,12 +607,14 @@ cases:
       select
         array_join(array_combine("-", [1, NULL], [3, 4]), ",") c0,
         array_join(array_combine("-", ARRAY<INT>[NULL], ["9", "8"]), ",") c1,
+        array_join(array_combine(string(NULL), ARRAY<INT>[1], ["9", "8"]), ",") c2,
     expect:
       columns:
         - c0 string
         - c1 string
+        - c2 string
       rows:
-        - ["1-3,1-4", ""]
+        - ["1-3,1-4", "", "19,18"]
   - id: array_combine_4
     desc: construct array from table
     mode: request-unsupport
@@ -633,6 +637,15 @@ cases:
       rows:
         - [1, "1-foo,1-c2,10-foo,10-c2"]
         - [2, "2-bar,2-c2,10-bar,10-c2"]
+  - id: array_combine_err1
+    mode: request-unsupport
+    sql: |
+      select
+        array_join(array_combine("-"), ",") c0,
+    expect:
+      success: false
+      msg: |
+        Fail to resolve expression: array_join(array_combine(-), ,)
 
   # ================================================================
   # Map data type

--- a/cases/query/udf_query.yaml
+++ b/cases/query/udf_query.yaml
@@ -554,6 +554,32 @@ cases:
         - c1 bool
       data: |
         true, false
+  - id: array_join
+    mode: request-unsupport
+    sql: |
+      select
+        array_join(["1", "2"], ",") c1,
+        array_join(["1", "2"], "") c2,
+        array_join(["1", "2"], cast(null as string)) c3,
+        array_join(["1", NULL, "4", "5", NULL], "-") c4,
+    expect:
+      columns:
+        - c1 string
+        - c2 string
+        - c3 string
+        - c4 string
+      rows:
+        - ["1,2", "12", "12", "1-4-5"]
+  - id: array_combine
+    mode: request-unsupport
+    sql: |
+      select
+        array_join(array_combine("-", ["1", "2"], ["3", "4"]), ",") c0,
+    expect:
+      columns:
+        - c0 string
+      rows:
+        - ["1-3,1-4,2-3,2-4"]
 
   # ================================================================
   # Map data type

--- a/cases/query/udf_query.yaml
+++ b/cases/query/udf_query.yaml
@@ -581,17 +581,17 @@ cases:
       rows:
         - ["1-3,1-4,2-3,2-4"]
 
-  # - id: array_combine_2
-  #   desc: array_combine casting array to array<string> first
-  #   mode: request-unsupport
-  #   sql: |
-  #     select
-  #       array_join(array_combine("-", [1, 2], [3, 4]), ",") c0,
-  #   expect:
-  #     columns:
-  #       - c0 string
-  #     rows:
-  #       - ["1-3,1-4,2-3,2-4"]
+  - id: array_combine_2
+    desc: array_combine casting array to array<string> first
+    mode: request-unsupport
+    sql: |
+      select
+        array_join(array_combine("-", [1, 2], [3, 4]), ",") c0,
+    expect:
+      columns:
+        - c0 string
+      rows:
+        - ["1-3,1-4,2-3,2-4"]
 
   # ================================================================
   # Map data type

--- a/hybridse/src/base/cartesian_product.cc
+++ b/hybridse/src/base/cartesian_product.cc
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2024 OpenMLDB authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "base/cartesian_product.h"
+
+#include <algorithm>
+
+#include "absl/types/span.h"
+
+namespace hybridse {
+namespace base {
+
+int32_t CartesianProductIterSize() { return sizeof(CartesianProductViewIterator); }
+
+static auto cartesian_product(const std::vector<std::vector<int>>& lists) {
+    std::vector<std::vector<int>> result;
+    if (std::find_if(std::begin(lists), std::end(lists), [](auto e) -> bool { return e.size() == 0; }) !=
+        std::end(lists)) {
+        return result;
+    }
+    for (auto& e : lists[0]) {
+        result.push_back({e});
+    }
+    for (size_t i = 1; i < lists.size(); ++i) {
+        std::vector<std::vector<int>> temp;
+        for (auto& e : result) {
+            for (auto f : lists[i]) {
+                auto e_tmp = e;
+                e_tmp.push_back(f);
+                temp.push_back(e_tmp);
+            }
+        }
+        result = temp;
+    }
+    return result;
+}
+
+std::vector<std::vector<int>> cartesian_product(absl::Span<int const> vec) {
+    std::vector<std::vector<int>> input;
+    for (auto& v : vec) {
+        std::vector<int> seq(v, 0);
+        for (int i = 0; i < v; ++i) {
+            seq[i] = i;
+        }
+        input.push_back(seq);
+    }
+    return cartesian_product(input);
+}
+
+auto cartesian_product_iterator(absl::Span<int const> vec) { auto products = cartesian_product(vec); }
+
+void CartesianProductIterNew(int32_t* vec, int32_t sz, int8_t* output) {
+    auto d = cartesian_product(absl::MakeSpan(vec, sz));
+    new (output) CartesianProductViewIterator(d);
+}
+
+void CartesianProductIterNext(int8_t* ptr) {
+    auto* it = reinterpret_cast<CartesianProductViewIterator*>(ptr);
+    if (it != nullptr) {
+        it->Next();
+    }
+}
+
+bool CartesianProductIterValid(int8_t* ptr) {
+    auto* it = reinterpret_cast<CartesianProductViewIterator*>(ptr);
+    if (it != nullptr) {
+        return it->Valid();
+    }
+    return false;
+}
+
+int32_t CartesianProductCount(int8_t* ptr) {
+    auto* it = reinterpret_cast<CartesianProductViewIterator*>(ptr);
+    if (it != nullptr) {
+        return it->data.size();
+    }
+    return 0;
+}
+
+int32_t CartesianProductIterGet(int8_t* ptr, int32_t idx) {
+    auto* it = reinterpret_cast<CartesianProductViewIterator*>(ptr);
+    if (it != nullptr) {
+        return it->GetProduct(idx);
+    }
+    return 0;
+}
+
+void CartesianProductIterDel(int8_t* output) {
+    if (output != nullptr) {
+        auto* it = reinterpret_cast<CartesianProductViewIterator*>(output);
+        if (it != nullptr) {
+            it->~CartesianProductViewIterator();
+        }
+    }
+}
+
+}  // namespace base
+}  // namespace hybridse

--- a/hybridse/src/base/cartesian_product.cc
+++ b/hybridse/src/base/cartesian_product.cc
@@ -23,8 +23,6 @@
 namespace hybridse {
 namespace base {
 
-int32_t CartesianProductIterSize() { return sizeof(CartesianProductViewIterator); }
-
 static auto cartesian_product(const std::vector<std::vector<int>>& lists) {
     std::vector<std::vector<int>> result;
     if (std::find_if(std::begin(lists), std::end(lists), [](auto e) -> bool { return e.size() == 0; }) !=
@@ -58,53 +56,6 @@ std::vector<std::vector<int>> cartesian_product(absl::Span<int const> vec) {
         input.push_back(seq);
     }
     return cartesian_product(input);
-}
-
-auto cartesian_product_iterator(absl::Span<int const> vec) { auto products = cartesian_product(vec); }
-
-void CartesianProductIterNew(int32_t* vec, int32_t sz, int8_t* output) {
-    auto d = cartesian_product(absl::MakeSpan(vec, sz));
-    new (output) CartesianProductViewIterator(d);
-}
-
-void CartesianProductIterNext(int8_t* ptr) {
-    auto* it = reinterpret_cast<CartesianProductViewIterator*>(ptr);
-    if (it != nullptr) {
-        it->Next();
-    }
-}
-
-bool CartesianProductIterValid(int8_t* ptr) {
-    auto* it = reinterpret_cast<CartesianProductViewIterator*>(ptr);
-    if (it != nullptr) {
-        return it->Valid();
-    }
-    return false;
-}
-
-int32_t CartesianProductCount(int8_t* ptr) {
-    auto* it = reinterpret_cast<CartesianProductViewIterator*>(ptr);
-    if (it != nullptr) {
-        return it->data.size();
-    }
-    return 0;
-}
-
-int32_t CartesianProductIterGet(int8_t* ptr, int32_t idx) {
-    auto* it = reinterpret_cast<CartesianProductViewIterator*>(ptr);
-    if (it != nullptr) {
-        return it->GetProduct(idx);
-    }
-    return 0;
-}
-
-void CartesianProductIterDel(int8_t* output) {
-    if (output != nullptr) {
-        auto* it = reinterpret_cast<CartesianProductViewIterator*>(output);
-        if (it != nullptr) {
-            it->~CartesianProductViewIterator();
-        }
-    }
 }
 
 }  // namespace base

--- a/hybridse/src/base/cartesian_product.h
+++ b/hybridse/src/base/cartesian_product.h
@@ -17,7 +17,6 @@
 #ifndef HYBRIDSE_SRC_BASE_CARTESIAN_PRODUCT_H_
 #define HYBRIDSE_SRC_BASE_CARTESIAN_PRODUCT_H_
 
-#include <cstdint>
 #include <vector>
 
 #include "absl/types/span.h"
@@ -25,29 +24,7 @@
 namespace hybridse {
 namespace base {
 
-using CartesianProductViewForIndex = std::vector<std::vector<int>>;
-
-struct CartesianProductViewIterator {
-    explicit CartesianProductViewIterator(const CartesianProductViewForIndex& d) : data(d) { it = data.cbegin(); }
-
-    CartesianProductViewForIndex ::const_iterator Next() { return std::next(it); }
-    bool Valid() const { return it != data.cend(); }
-
-    int GetProduct(int i) const { return it->at(i); }
-
-    CartesianProductViewForIndex data;
-    CartesianProductViewForIndex ::const_iterator it;
-};
-
 std::vector<std::vector<int>> cartesian_product(absl::Span<int const> vec);
-
-int32_t CartesianProductIterSize();
-void CartesianProductIterNew(int32_t* vec, int32_t sz, int8_t* ptr);
-int32_t CartesianProductCount(int8_t* ptr);
-int32_t CartesianProductIterGet(int8_t* ptr, int32_t idx);
-void CartesianProductIterNext(int8_t* ptr);
-bool CartesianProductIterValid(int8_t* ptr);
-void CartesianProductIterDel(int8_t* ptr);
 
 }  // namespace base
 }  // namespace hybridse

--- a/hybridse/src/base/cartesian_product.h
+++ b/hybridse/src/base/cartesian_product.h
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2024 OpenMLDB authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef HYBRIDSE_SRC_BASE_CARTESIAN_PRODUCT_H_
+#define HYBRIDSE_SRC_BASE_CARTESIAN_PRODUCT_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "absl/types/span.h"
+
+namespace hybridse {
+namespace base {
+
+using CartesianProductViewForIndex = std::vector<std::vector<int>>;
+
+struct CartesianProductViewIterator {
+    explicit CartesianProductViewIterator(const CartesianProductViewForIndex& d) : data(d) { it = data.cbegin(); }
+
+    CartesianProductViewForIndex ::const_iterator Next() { return std::next(it); }
+    bool Valid() const { return it != data.cend(); }
+
+    int GetProduct(int i) const { return it->at(i); }
+
+    CartesianProductViewForIndex data;
+    CartesianProductViewForIndex ::const_iterator it;
+};
+
+std::vector<std::vector<int>> cartesian_product(absl::Span<int const> vec);
+
+int32_t CartesianProductIterSize();
+void CartesianProductIterNew(int32_t* vec, int32_t sz, int8_t* ptr);
+int32_t CartesianProductCount(int8_t* ptr);
+int32_t CartesianProductIterGet(int8_t* ptr, int32_t idx);
+void CartesianProductIterNext(int8_t* ptr);
+bool CartesianProductIterValid(int8_t* ptr);
+void CartesianProductIterDel(int8_t* ptr);
+
+}  // namespace base
+}  // namespace hybridse
+
+#endif  // HYBRIDSE_SRC_BASE_CARTESIAN_PRODUCT_H_

--- a/hybridse/src/codegen/array_ir_builder.cc
+++ b/hybridse/src/codegen/array_ir_builder.cc
@@ -150,6 +150,11 @@ absl::StatusOr<llvm::Value*> ArrayIRBuilder::CastToArrayString(CodeGenContextBas
     }
 
     llvm::Type* src_ele_type = src_builder->element_type_;
+    if (IsStringPtr(src_ele_type)) {
+        // already array<string>
+        return src;
+    }
+
     auto fields = src_builder->Load(ctx, src);
     CHECK_ABSL_STATUSOR(fields);
     llvm::Value* src_raws = fields.value().at(RAW_IDX);

--- a/hybridse/src/codegen/array_ir_builder.cc
+++ b/hybridse/src/codegen/array_ir_builder.cc
@@ -122,5 +122,19 @@ bool ArrayIRBuilder::CreateDefault(::llvm::BasicBlock* block, ::llvm::Value** ou
     return true;
 }
 
+absl::StatusOr<NativeValue> ArrayIRBuilder::ExtractElement(CodeGenContextBase* ctx, const NativeValue& arr,
+                                                           const NativeValue& key) const {
+    return absl::UnimplementedError("array extract element");
+}
+
+absl::StatusOr<llvm::Value*> ArrayIRBuilder::NumElements(CodeGenContextBase* ctx, llvm::Value* arr) const {
+    llvm::Value* out = nullptr;
+    if (!Load(ctx->GetCurrentBlock(), arr, SZ_IDX, &out)) {
+        return absl::InternalError("codegen: fail to extract array size");
+    }
+
+    return out;
+}
+
 }  // namespace codegen
 }  // namespace hybridse

--- a/hybridse/src/codegen/array_ir_builder.cc
+++ b/hybridse/src/codegen/array_ir_builder.cc
@@ -18,9 +18,12 @@
 
 #include <string>
 
+#include "absl/strings/substitute.h"
+#include "base/fe_status.h"
 #include "codegen/cast_expr_ir_builder.h"
 #include "codegen/context.h"
 #include "codegen/ir_base_builder.h"
+#include "codegen/string_ir_builder.h"
 
 namespace hybridse {
 namespace codegen {
@@ -137,7 +140,7 @@ absl::StatusOr<llvm::Value*> ArrayIRBuilder::NumElements(CodeGenContextBase* ctx
     return out;
 }
 
-absl::StatusOr<llvm::Value*> ArrayIRBuilder::CastFrom(CodeGenContextBase* ctx, llvm::Value* src) {
+absl::StatusOr<llvm::Value*> ArrayIRBuilder::CastToArrayString(CodeGenContextBase* ctx, llvm::Value* src) {
     auto sb = StructTypeIRBuilder::CreateStructTypeIRBuilder(ctx->GetModule(), src->getType());
     CHECK_ABSL_STATUSOR(sb);
 
@@ -150,17 +153,21 @@ absl::StatusOr<llvm::Value*> ArrayIRBuilder::CastFrom(CodeGenContextBase* ctx, l
     auto fields = src_builder->Load(ctx, src);
     CHECK_ABSL_STATUSOR(fields);
     llvm::Value* src_raws = fields.value().at(RAW_IDX);
+    llvm::Value* src_nulls = fields.value().at(NULL_IDX);
     llvm::Value* num_elements = fields.value().at(SZ_IDX);
-
 
     llvm::Value* casted = nullptr;
     if (!CreateDefault(ctx->GetCurrentBlock(), &casted)) {
         return absl::InternalError("codegen error: fail to construct default array");
     }
+    // initialize each element
+    CHECK_ABSL_STATUS(Initialize(ctx, casted, {num_elements}));
 
     auto builder = ctx->GetBuilder();
-    auto* raw_array_ptr = builder->CreateAlloca(element_type_, num_elements);
-    auto* nullables_ptr = builder->CreateAlloca(builder->getInt1Ty(), num_elements);
+    auto dst_fields = Load(ctx, casted);
+    CHECK_ABSL_STATUSOR(fields);
+    auto* raw_array_ptr = dst_fields.value().at(RAW_IDX);
+    auto* nullables_ptr = dst_fields.value().at(NULL_IDX);
 
     llvm::Type* idx_type = builder->getInt64Ty();
     llvm::Value* idx = builder->CreateAlloca(idx_type);
@@ -176,13 +183,16 @@ absl::StatusOr<llvm::Value*> ArrayIRBuilder::CastFrom(CodeGenContextBase* ctx, l
 
             llvm::Value* src_ele_value =
                 builder->CreateLoad(src_ele_type, builder->CreateGEP(src_ele_type, src_raws, idx_val));
+            llvm::Value* dst_ele =
+                builder->CreateLoad(element_type_, builder->CreateGEP(element_type_, raw_array_ptr, idx_val));
 
-            NativeValue out;
-            CHECK_STATUS(cast_builder.Cast(NativeValue::Create(src_ele_value), element_type_, &out));
+            codegen::StringIRBuilder str_builder(ctx->GetModule());
+            auto s = str_builder.CastFrom(ctx->GetCurrentBlock(), src_ele_value, dst_ele);
+            CHECK_TRUE(s.ok(), common::kCodegenError, s.ToString());
 
-            builder->CreateStore(out.GetRaw(), builder->CreateGEP(element_type_, raw_array_ptr, idx_val));
-            builder->CreateStore(out.GetIsNull(builder),
-                                 builder->CreateGEP(builder->getInt1Ty(), nullables_ptr, idx_val));
+            builder->CreateStore(
+                builder->CreateLoad(builder->getInt1Ty(), builder->CreateGEP(builder->getInt1Ty(), src_nulls, idx_val)),
+                builder->CreateGEP(builder->getInt1Ty(), nullables_ptr, idx_val));
 
             builder->CreateStore(builder->CreateAdd(idx_val, builder->getInt64(1)), idx);
             return {};
@@ -192,5 +202,35 @@ absl::StatusOr<llvm::Value*> ArrayIRBuilder::CastFrom(CodeGenContextBase* ctx, l
     return casted;
 }
 
+absl::Status ArrayIRBuilder::Initialize(CodeGenContextBase* ctx, ::llvm::Value* alloca,
+                                        absl::Span<llvm::Value* const> args) const {
+    auto* builder = ctx->GetBuilder();
+    StringIRBuilder str_builder(ctx->GetModule());
+    auto ele_type = str_builder.GetType();
+    if (!alloca->getType()->isPointerTy() || alloca->getType()->getPointerElementType() != struct_type_ ||
+        ele_type->getPointerTo() != element_type_) {
+        return absl::UnimplementedError(absl::Substitute(
+            "not able to Initialize array except array<string>, got type $0", GetLlvmObjectString(alloca->getType())));
+    }
+    if (args.size() != 1) {
+        // require one argument that is array size
+        return absl::InvalidArgumentError("initialize array requries one argument which is array size");
+    }
+    if (!args[0]->getType()->isIntegerTy()) {
+        return absl::InvalidArgumentError("array size argument should be integer");
+    }
+    auto sz = args[0];
+    if (sz->getType() != builder->getInt64Ty()) {
+        CastExprIRBuilder cast_builder(ctx->GetCurrentBlock());
+        base::Status s;
+        cast_builder.SafeCastNumber(sz, builder->getInt64Ty(), &sz, s);
+        CHECK_STATUS_TO_ABSL(s);
+    }
+    auto fn = ctx->GetModule()->getOrInsertFunction("hybridse_alloc_array_string", builder->getVoidTy(),
+                                                    struct_type_->getPointerTo(), builder->getInt64Ty());
+
+    builder->CreateCall(fn, {alloca, sz});
+    return absl::OkStatus();
+}
 }  // namespace codegen
 }  // namespace hybridse

--- a/hybridse/src/codegen/array_ir_builder.h
+++ b/hybridse/src/codegen/array_ir_builder.h
@@ -42,10 +42,15 @@ class ArrayIRBuilder : public StructTypeIRBuilder {
         CHECK_TRUE(false, common::kCodegenError, "casting to array un-implemented");
     };
 
- private:
-    void InitStructType() override;
+    absl::StatusOr<NativeValue> ExtractElement(CodeGenContextBase* ctx, const NativeValue& arr,
+                                               const NativeValue& key) const override;
+
+    absl::StatusOr<llvm::Value*> NumElements(CodeGenContextBase* ctx, llvm::Value* arr) const override;
 
     bool CreateDefault(::llvm::BasicBlock* block, ::llvm::Value** output) override;
+
+ private:
+    void InitStructType() override;
 
  private:
     ::llvm::Type* element_type_ = nullptr;

--- a/hybridse/src/codegen/array_ir_builder.h
+++ b/hybridse/src/codegen/array_ir_builder.h
@@ -42,7 +42,7 @@ class ArrayIRBuilder : public StructTypeIRBuilder {
         CHECK_TRUE(false, common::kCodegenError, "casting to array un-implemented");
     };
 
-    absl::StatusOr<llvm::Value*> CastFrom(CodeGenContextBase* ctx, llvm::Value* src);
+    absl::StatusOr<llvm::Value*> CastToArrayString(CodeGenContextBase* ctx, llvm::Value* src);
 
     absl::StatusOr<NativeValue> ExtractElement(CodeGenContextBase* ctx, const NativeValue& arr,
                                                const NativeValue& key) const override;
@@ -50,6 +50,9 @@ class ArrayIRBuilder : public StructTypeIRBuilder {
     absl::StatusOr<llvm::Value*> NumElements(CodeGenContextBase* ctx, llvm::Value* arr) const override;
 
     bool CreateDefault(::llvm::BasicBlock* block, ::llvm::Value** output) override;
+
+    absl::Status Initialize(CodeGenContextBase* ctx, ::llvm::Value* alloca,
+                            absl::Span<llvm::Value* const> args) const override;
 
  private:
     void InitStructType() override;

--- a/hybridse/src/codegen/array_ir_builder.h
+++ b/hybridse/src/codegen/array_ir_builder.h
@@ -42,6 +42,8 @@ class ArrayIRBuilder : public StructTypeIRBuilder {
         CHECK_TRUE(false, common::kCodegenError, "casting to array un-implemented");
     };
 
+    absl::StatusOr<llvm::Value*> CastFrom(CodeGenContextBase* ctx, llvm::Value* src);
+
     absl::StatusOr<NativeValue> ExtractElement(CodeGenContextBase* ctx, const NativeValue& arr,
                                                const NativeValue& key) const override;
 

--- a/hybridse/src/codegen/ir_base_builder.cc
+++ b/hybridse/src/codegen/ir_base_builder.cc
@@ -575,16 +575,32 @@ bool GetFullType(node::NodeManager* nm, ::llvm::Type* type,
                 if (type_pointee->isStructTy()) {
                     auto* key_type = type_pointee->getStructElementType(1);
                     const node::TypeNode* key = nullptr;
-                    if (key_type->isPointerTy() && !GetFullType(nm, key_type->getPointerElementType(), &key)) {
+                    if (!key_type->isPointerTy() || !GetFullType(nm, key_type->getPointerElementType(), &key)) {
                         return false;
                     }
                     const node::TypeNode* value = nullptr;
                     auto* value_type = type_pointee->getStructElementType(2);
-                    if (value_type->isPointerTy() && !GetFullType(nm, value_type->getPointerElementType(), &value)) {
+                    if (!value_type->isPointerTy() || !GetFullType(nm, value_type->getPointerElementType(), &value)) {
                         return false;
                     }
 
                     *type_node = nm->MakeNode<node::MapType>(key, value);
+                    return true;
+                }
+            }
+            return false;
+        }
+        case hybridse::node::kArray: {
+            if (type->isPointerTy()) {
+                auto type_pointee = type->getPointerElementType();
+                if (type_pointee->isStructTy()) {
+                    auto* key_type = type_pointee->getStructElementType(0);
+                    const node::TypeNode* key = nullptr;
+                    if (!key_type->isPointerTy() || !GetFullType(nm, key_type->getPointerElementType(), &key)) {
+                        return false;
+                    }
+
+                    *type_node = nm->MakeNode<node::TypeNode>(node::DataType::kArray, key);
                     return true;
                 }
             }

--- a/hybridse/src/codegen/string_ir_builder.cc
+++ b/hybridse/src/codegen/string_ir_builder.cc
@@ -403,5 +403,17 @@ base::Status StringIRBuilder::ConcatWS(::llvm::BasicBlock* block,
     *output = NativeValue::CreateWithFlag(concat_str, ret_null);
     return base::Status();
 }
+absl::Status StringIRBuilder::CastFrom(llvm::BasicBlock* block, llvm::Value* src, llvm::Value* alloca) {
+    if (IsStringPtr(src->getType())) {
+        return absl::UnimplementedError("not necessary to cast string to string");
+    }
+    ::llvm::IRBuilder<> builder(block);
+    ::std::string fn_name = "string." + TypeName(src->getType());
+
+    auto cast_func = m_->getOrInsertFunction(
+        fn_name, ::llvm::FunctionType::get(builder.getVoidTy(), {src->getType(), alloca->getType()}, false));
+    builder.CreateCall(cast_func, {src, alloca});
+    return absl::OkStatus();
+}
 }  // namespace codegen
 }  // namespace hybridse

--- a/hybridse/src/codegen/string_ir_builder.h
+++ b/hybridse/src/codegen/string_ir_builder.h
@@ -36,6 +36,7 @@ class StringIRBuilder : public StructTypeIRBuilder {
     bool CopyFrom(::llvm::BasicBlock* block, ::llvm::Value* src, ::llvm::Value* dist) override;
     base::Status CastFrom(::llvm::BasicBlock* block, const NativeValue& src, NativeValue* output) override;
     base::Status CastFrom(::llvm::BasicBlock* block, ::llvm::Value* src, ::llvm::Value** output);
+    absl::Status CastFrom(llvm::BasicBlock* block, llvm::Value* in, llvm::Value* alloca);
 
     bool NewString(::llvm::BasicBlock* block, ::llvm::Value** output);
     bool NewString(::llvm::BasicBlock* block, const std::string& str,

--- a/hybridse/src/codegen/string_ir_builder.h
+++ b/hybridse/src/codegen/string_ir_builder.h
@@ -36,6 +36,9 @@ class StringIRBuilder : public StructTypeIRBuilder {
     bool CopyFrom(::llvm::BasicBlock* block, ::llvm::Value* src, ::llvm::Value* dist) override;
     base::Status CastFrom(::llvm::BasicBlock* block, const NativeValue& src, NativeValue* output) override;
     base::Status CastFrom(::llvm::BasicBlock* block, ::llvm::Value* src, ::llvm::Value** output);
+
+    // casting from {in} to string ptr alloca, alloca has allocated already.
+    // if {in} is string ptr already, it returns error status since generally it's not necessary to call this function
     absl::Status CastFrom(llvm::BasicBlock* block, llvm::Value* in, llvm::Value* alloca);
 
     bool NewString(::llvm::BasicBlock* block, ::llvm::Value** output);

--- a/hybridse/src/codegen/struct_ir_builder.cc
+++ b/hybridse/src/codegen/struct_ir_builder.cc
@@ -311,7 +311,7 @@ absl::StatusOr<NativeValue> Combine(CodeGenContextBase* ctx, const NativeValue d
             return absl::InternalError("codegen error: arguments to array_combine is not ARRAY");
         }
         if (!tp->GetGenericType(0)->IsString()) {
-            auto s = arr_builder.CastFrom(ctx, args.at(i).GetRaw());
+            auto s = arr_builder.CastToArrayString(ctx, args.at(i).GetRaw());
             CHECK_ABSL_STATUSOR(s);
             casted_args.at(i) = NativeValue::Create(s.value());
         } else {
@@ -339,5 +339,9 @@ absl::StatusOr<NativeValue> Combine(CodeGenContextBase* ctx, const NativeValue d
     return NativeValue::Create(out);
 }
 
+absl::Status StructTypeIRBuilder::Initialize(CodeGenContextBase* ctx, ::llvm::Value* alloca,
+                                             absl::Span<llvm::Value* const> args) const {
+    return absl::UnimplementedError(absl::StrCat("Initialize for type ", GetLlvmObjectString(struct_type_)));
+}
 }  // namespace codegen
 }  // namespace hybridse

--- a/hybridse/src/codegen/struct_ir_builder.cc
+++ b/hybridse/src/codegen/struct_ir_builder.cc
@@ -280,7 +280,6 @@ absl::StatusOr<NativeValue> CreateSafeNull(::llvm::BasicBlock* block, ::llvm::Ty
     return NativeValue(nullptr, nullptr, type);
 }
 
-// args should be array of string
 absl::StatusOr<NativeValue> Combine(CodeGenContextBase* ctx, const NativeValue delimiter,
                                     absl::Span<const NativeValue> args) {
     auto builder = ctx->GetBuilder();

--- a/hybridse/src/codegen/struct_ir_builder.h
+++ b/hybridse/src/codegen/struct_ir_builder.h
@@ -65,6 +65,12 @@ class StructTypeIRBuilder : public TypeIRBuilder {
     virtual absl::StatusOr<NativeValue> ExtractElement(CodeGenContextBase* ctx, const NativeValue& arr,
                                                        const NativeValue& key) const;
 
+    // Get size of the elements inside value {arr}
+    // - if {arr} is array/map, return size of array/map
+    // - if {arr} is struct, return number of struct fields
+    // - otherwise report error
+    virtual absl::StatusOr<llvm::Value*> NumElements(CodeGenContextBase* ctx, llvm::Value* arr) const;
+
     ::llvm::Type* GetType() const;
 
     std::string GetTypeDebugString() const;
@@ -100,6 +106,10 @@ class StructTypeIRBuilder : public TypeIRBuilder {
 // returns NativeValue{raw, is_null=true} on success, raw is ensured to be not nullptr
 absl::StatusOr<NativeValue> CreateSafeNull(::llvm::BasicBlock* block, ::llvm::Type* type);
 
+// Do the cartesian product for a list of arrry
+// output a array of string, each value is a pair (A1, B2, C3...), as "A1-B2-C3-...", "-" is the delimiter
+absl::StatusOr<NativeValue> Combine(CodeGenContextBase* ctx, const NativeValue delimiter,
+                                    absl::Span<const NativeValue> args);
 }  // namespace codegen
 }  // namespace hybridse
 #endif  // HYBRIDSE_SRC_CODEGEN_STRUCT_IR_BUILDER_H_

--- a/hybridse/src/codegen/struct_ir_builder.h
+++ b/hybridse/src/codegen/struct_ir_builder.h
@@ -58,6 +58,9 @@ class StructTypeIRBuilder : public TypeIRBuilder {
     virtual absl::StatusOr<::llvm::Value*> ConstructFromRaw(CodeGenContextBase* ctx,
                                                             absl::Span<::llvm::Value* const> args) const;
 
+    virtual absl::Status Initialize(CodeGenContextBase* ctx, ::llvm::Value* alloca,
+                                    absl::Span<llvm::Value* const> args) const;
+
     // Extract element value from composite data type
     // 1. extract from array type by index
     // 2. extract from struct type by field name

--- a/hybridse/src/udf/default_defs/array_def.cc
+++ b/hybridse/src/udf/default_defs/array_def.cc
@@ -145,7 +145,7 @@ void DefaultUdfLibrary::InitArrayUdfs() {
     RegisterExternal("array_join")
         .args<ArrayRef<StringRef>, Nullable<StringRef>>(array_join)
         .doc(R"(
-             @brief array_join(array, delimiter) - Concatenates the elements of the given array using the delimiter and an optional string to replace nulls. Any null value is filtered.
+             @brief array_join(array, delimiter) - Concatenates the elements of the given array using the delimiter. Any null value is filtered.
 
              Example:
 
@@ -156,10 +156,10 @@ void DefaultUdfLibrary::InitArrayUdfs() {
              @since 0.9.2)");
 
     RegisterCodeGenUdf("array_combine")
-        .variadic_args<AnyArg>(
+        .variadic_args<Nullable<StringRef>>(
             [](UdfResolveContext* ctx, const ExprAttrNode& delimit, const std::vector<ExprAttrNode>& arg_attrs,
                ExprAttrNode* out) -> base::Status {
-                CHECK_TRUE(delimit.type()->IsString(), common::kCodegenError, "delimiter must be string");
+                CHECK_TRUE(!arg_attrs.empty(), common::kCodegenError, "at least one array required by array_combine");
                 for (auto & val : arg_attrs) {
                     CHECK_TRUE(val.type()->IsArray(), common::kCodegenError, "argument to array_combine must be array");
                 }
@@ -179,7 +179,7 @@ void DefaultUdfLibrary::InitArrayUdfs() {
                 @brief array_combine(delimiter, array1, array2, ...)
 
                 return array of strings for input array1, array2, ... doing cartesian product. Each product is joined with
-                {delimiter} as a string
+                {delimiter} as a string. Empty string used if {delimiter} is null.
 
                 Example:
 

--- a/hybridse/src/udf/default_defs/array_def.cc
+++ b/hybridse/src/udf/default_defs/array_def.cc
@@ -162,8 +162,6 @@ void DefaultUdfLibrary::InitArrayUdfs() {
                 CHECK_TRUE(delimit.type()->IsString(), common::kCodegenError, "delimiter must be string");
                 for (auto & val : arg_attrs) {
                     CHECK_TRUE(val.type()->IsArray(), common::kCodegenError, "argument to array_combine must be array");
-                    CHECK_TRUE(val.type()->GetGenericType(0)->IsString(), common::kCodegenError,
-                               "argument to array_combine must be array of string");
                 }
                 auto nm = ctx->node_manager();
                 out->SetType(nm->MakeNode<node::TypeNode>(node::kArray, nm->MakeNode<node::TypeNode>(node::kVarchar)));

--- a/hybridse/src/udf/udf.cc
+++ b/hybridse/src/udf/udf.cc
@@ -1427,9 +1427,9 @@ void array_combine(codec::StringRef *del, int32_t cnt, ArrayRef<codec::StringRef
     // cal cartesian products
     auto products = hybridse::base::cartesian_product(arr_szs);
 
+    auto real_sz = products.size();
     v1::AllocManagedArray(out, products.size());
 
-    // TODO(xxx): what if array values contains null
     for (int prod_idx = 0; prod_idx < products.size(); ++prod_idx) {
         auto &prod = products.at(prod_idx);
         int32_t sz = 0;
@@ -1440,6 +1440,11 @@ void array_combine(codec::StringRef *del, int32_t cnt, ArrayRef<codec::StringRef
                     sz += del->size_;
                 }
                 sz += data[i]->raw[prod.at(i)]->size_;
+            } else {
+                // null exists in current product
+                // the only option now is to skip
+                real_sz--;
+                continue;
             }
         }
         auto buf = v1::AllocManagedStringBuf(sz);
@@ -1460,7 +1465,7 @@ void array_combine(codec::StringRef *del, int32_t cnt, ArrayRef<codec::StringRef
         out->raw[prod_idx]->size_ = sz;
     }
 
-    out->size = products.size();
+    out->size = real_sz;
 }
 
 }  // namespace v1

--- a/hybridse/src/udf/udf.h
+++ b/hybridse/src/udf/udf.h
@@ -520,7 +520,8 @@ void hex(StringRef *str, StringRef *output);
 void unhex(StringRef *str, StringRef *output, bool* is_null);
 
 void printLog(const char* fmt);
-
+void array_combine(codec::StringRef *del, int32_t cnt, ArrayRef<codec::StringRef> **data,
+                   ArrayRef<codec::StringRef> *out);
 }  // namespace v1
 
 /// \brief register native udf related methods into given UdfLibrary `lib`

--- a/hybridse/src/vm/jit_wrapper.cc
+++ b/hybridse/src/vm/jit_wrapper.cc
@@ -17,6 +17,8 @@
 
 #include <string>
 #include <utility>
+
+#include "base/cartesian_product.h"
 #include "glog/logging.h"
 #include "llvm/ExecutionEngine/JITSymbol.h"
 #include "llvm/ExecutionEngine/Orc/CompileUtils.h"
@@ -251,6 +253,9 @@ void InitBuiltinJitSymbols(HybridSeJitWrapper* jit) {
         "fmod", reinterpret_cast<void*>(
                     static_cast<double (*)(double, double)>(&fmod)));
     jit->AddExternalFunction("fmodf", reinterpret_cast<void*>(&fmodf));
+
+    // cartesian product
+    jit->AddExternalFunction("hybridse_array_combine", reinterpret_cast<void*>(&hybridse::udf::v1::array_combine));
 }
 
 }  // namespace vm

--- a/hybridse/src/vm/jit_wrapper.cc
+++ b/hybridse/src/vm/jit_wrapper.cc
@@ -256,6 +256,8 @@ void InitBuiltinJitSymbols(HybridSeJitWrapper* jit) {
 
     // cartesian product
     jit->AddExternalFunction("hybridse_array_combine", reinterpret_cast<void*>(&hybridse::udf::v1::array_combine));
+    jit->AddExternalFunction("hybridse_alloc_array_string",
+                             reinterpret_cast<void*>(&hybridse::udf::v1::AllocManagedArray<codec::StringRef>));
 }
 
 }  // namespace vm


### PR DESCRIPTION
Two UDFs added

## array_combine

```
array_combine (delimiter, array1, ...)
```

- param **delimiter**: string delimiter for each product
- param **array1**: variadic list of arrays, requires at least one. You may provide array of any primitive type as input arrays, like `intXX, string, date, timestamp`, but not array of composited types. For example, `ARRAY<MAP<int, int>>` is invalid
- return: array of string, each element is a product

**return array of strings for input array1, array2, ... doing cartesian product. Each product is joined with {delimiter} as a string. Empty string used if {delimiter} is null.**

```sql
select array_combine("-", ["1", "2"], ["3", "4"]);  -- ["1-3", "1-4", "2-3", "2-4"]
```

## array_join
```
array_join(arr, delimiter)
```

**Concatenates the elements of the given array using the delimiter. Any null value is filtered.**

```sql
select array_join(["1", "2"], "-");  -- "1-2"
```