### PR TITLE
fix: handle repeated sort keys and sort as int

### DIFF
--- a/hybridse/src/codegen/udf_ir_builder_test.cc
+++ b/hybridse/src/codegen/udf_ir_builder_test.cc
@@ -1484,6 +1484,28 @@ TEST_F(UdfIRBuilderTest, CustUdfs) {
                                                                       false);
 }
 
+TEST_F(UdfIRBuilderTest, JsonArraySortAsInt) {
+    openmldb::base::StringRef json = R"([{"a": "6", "b": "2"}, {"a": "11", "b": "9"}])";
+    CheckUdf<StringRef, StringRef, StringRef, StringRef, int32_t, bool>("json_array_sort", "9,2", json, "a", "b", 10,
+                                                                        true);
+    CheckUdf<StringRef, StringRef, StringRef, StringRef, int32_t, bool>("json_array_sort", "2,9", json, "a", "b", 10,
+                                                                        false);
+}
+
+TEST_F(UdfIRBuilderTest, JsonArraySortRepeatedKey) {
+    openmldb::base::StringRef json = R"([{"a": "6", "b": "2"}, {"a": "11", "b": "9"}, {"a": "6", "b": "10"}])";
+    CheckUdf<StringRef, StringRef, StringRef, StringRef, int32_t, bool>("json_array_sort", "9,10,2", json, "a", "b", 10,
+                                                                        true);
+    CheckUdf<StringRef, StringRef, StringRef, StringRef, int32_t, bool>("json_array_sort", "2,10,9", json, "a", "b", 10,
+                                                                        false);
+}
+
+TEST_F(UdfIRBuilderTest, JsonArraySortInvalidKey) {
+    openmldb::base::StringRef json = R"([{"a": "a", "b": "2"}, {"a": "11", "b": "9"}])";
+    CheckUdf<StringRef, StringRef, StringRef, StringRef, int32_t, bool>("json_array_sort", "", json, "a", "b", 10,
+                                                                        true);
+}
+
 }  // namespace codegen
 }  // namespace hybridse
 

--- a/hybridse/src/codegen/udf_ir_builder_test.cc
+++ b/hybridse/src/codegen/udf_ir_builder_test.cc
@@ -1493,11 +1493,11 @@ TEST_F(UdfIRBuilderTest, JsonArraySortAsInt) {
 }
 
 TEST_F(UdfIRBuilderTest, JsonArraySortRepeatedKey) {
-    openmldb::base::StringRef json = R"([{"a": "6", "b": "2"}, {"a": "11", "b": "9"}, {"a": "6", "b": "10"}])";
-    CheckUdf<StringRef, StringRef, StringRef, StringRef, int32_t, bool>("json_array_sort", "9,10,2", json, "a", "b", 10,
-                                                                        true);
-    CheckUdf<StringRef, StringRef, StringRef, StringRef, int32_t, bool>("json_array_sort", "2,10,9", json, "a", "b", 10,
-                                                                        false);
+    openmldb::base::StringRef json = R"([{"a": "6", "b": "a"}, {"a": "11", "b": "aaa"}, {"a": "6", "b": "aa"}])";
+    CheckUdf<StringRef, StringRef, StringRef, StringRef, int32_t, bool>("json_array_sort", "aaa,aa,a", json, "a", "b",
+                                                                        10, true);
+    CheckUdf<StringRef, StringRef, StringRef, StringRef, int32_t, bool>("json_array_sort", "a,aa,aaa", json, "a", "b",
+                                                                        10, false);
 }
 
 TEST_F(UdfIRBuilderTest, JsonArraySortInvalidKey) {

--- a/hybridse/src/udf/default_defs/feature_zero_def.cc
+++ b/hybridse/src/udf/default_defs/feature_zero_def.cc
@@ -652,7 +652,7 @@ void json_array_sort(::openmldb::base::StringRef *json_array,
 
   std::string_view order_ref(order->data_, order->size_);
   std::string_view column_ref(column->data_, column->size_);
-  std::vector<std::pair<int, int>> container;
+  std::vector<std::pair<int, std::string>> container;
 
   for (auto ele : arr) {
     simdjson::ondemand::object obj;
@@ -677,14 +677,7 @@ void json_array_sort(::openmldb::base::StringRef *json_array,
     if (ec_order != std::errc()) {
         return;
     }
-
-    int column_val_int;
-    auto [ptr_column, ec_column] =
-        std::from_chars(column_val.data(), column_val.data() + column_val.size(), column_val_int);
-    if (ec_column != std::errc()) {
-        return;
-    }
-    container.emplace_back(static_cast<int>(order_int), static_cast<int>(column_val_int));
+    container.emplace_back(static_cast<int>(order_int), std::string(column_val));
   }
 
   std::sort(container.begin(), container.end(), [desc](const auto& a, const auto& b) {

--- a/hybridse/src/udf/default_defs/feature_zero_def.cc
+++ b/hybridse/src/udf/default_defs/feature_zero_def.cc
@@ -677,7 +677,7 @@ void json_array_sort(::openmldb::base::StringRef *json_array,
     if (ec_order != std::errc()) {
         return;
     }
-    container.emplace_back(static_cast<int>(order_int), std::string(column_val));
+    container.emplace_back(order_int, column_val);
   }
 
   std::sort(container.begin(), container.end(), [desc](const auto& a, const auto& b) {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
1. `json_array_sort` drops duplicate sort keys
2. `json_array_sort` sorts by string instead of int


* **What is the new behavior (if this is a feature change)?**
1. `json_array_sort` does not drop duplicate sort keys 
2. `json_array_sort` sorts by int instead of string, and breaks ties using output column
