### PR TITLE
fix: handle repeated sort keys and sort as int

### DIFF
--- a/hybridse/src/codegen/udf_ir_builder_test.cc
+++ b/hybridse/src/codegen/udf_ir_builder_test.cc
@@ -1199,6 +1199,27 @@ TEST_F(UdfIRBuilderTest, CustUdfs) {
                                                                       false);
 }
 
+TEST_F(UdfIRBuilderTest, JsonArraySortAsInt) {
+    openmldb::base::StringRef json = R"([{"a": "6", "b": "2"}, {"a": "11", "b": "9"}])";
+    CheckUdf<StringRef, StringRef, StringRef, StringRef, int32_t, bool>("json_array_sort", "9,2", json, "a", "b", 10,
+                                                                        true);
+    CheckUdf<StringRef, StringRef, StringRef, StringRef, int32_t, bool>("json_array_sort", "2,9", json, "a", "b", 10,
+                                                                        false);
+}
+
+TEST_F(UdfIRBuilderTest, JsonArraySortRepeatedKey) {
+    openmldb::base::StringRef json = R"([{"a": "6", "b": "a"}, {"a": "11", "b": "aaa"}, {"a": "6", "b": "aa"}])";
+    CheckUdf<StringRef, StringRef, StringRef, StringRef, int32_t, bool>("json_array_sort", "aaa,aa,a", json, "a", "b",
+                                                                        10, true);
+    CheckUdf<StringRef, StringRef, StringRef, StringRef, int32_t, bool>("json_array_sort", "a,aa,aaa", json, "a", "b",
+                                                                        10, false);
+}
+
+TEST_F(UdfIRBuilderTest, JsonArraySortInvalidKey) {
+    openmldb::base::StringRef json = R"([{"a": "a", "b": "2"}, {"a": "11", "b": "9"}])";
+    CheckUdf<StringRef, StringRef, StringRef, StringRef, int32_t, bool>("json_array_sort", "", json, "a", "b", 10,
+                                                                        true);
+}
 }
 }  // namespace codegen
 

--- a/hybridse/src/codegen/udf_ir_builder_test.cc
+++ b/hybridse/src/codegen/udf_ir_builder_test.cc
@@ -1216,9 +1216,11 @@ TEST_F(UdfIRBuilderTest, JsonArraySortRepeatedKey) {
 }
 
 TEST_F(UdfIRBuilderTest, JsonArraySortInvalidKey) {
-    openmldb::base::StringRef json = R"([{"a": "a", "b": "2"}, {"a": "11", "b": "9"}])";
-    CheckUdf<StringRef, StringRef, StringRef, StringRef, int32_t, bool>("json_array_sort", "", json, "a", "b", 10,
+    openmldb::base::StringRef json = R"([{"a": "-1", "b": "1"}, {"a": "a", "b": "2"}, {"a": "11", "b": "9"}])";
+    CheckUdf<StringRef, StringRef, StringRef, StringRef, int32_t, bool>("json_array_sort", "9,2,1", json, "a", "b", 10,
                                                                         true);
+    CheckUdf<StringRef, StringRef, StringRef, StringRef, int32_t, bool>("json_array_sort", "1,2,9", json, "a", "b", 10,
+                                                                        false);
 }
 }
 }  // namespace codegen

--- a/hybridse/src/udf/default_defs/feature_zero_def.cc
+++ b/hybridse/src/udf/default_defs/feature_zero_def.cc
@@ -15,6 +15,8 @@
  */
 
 #include <algorithm>
+#include <charconv>
+#include <iostream>
 #include <queue>
 #include <string>
 #include <tuple>
@@ -25,15 +27,14 @@
 #include "boost/algorithm/string.hpp"
 #include "boost/algorithm/string/join.hpp"
 #include "boost/algorithm/string/regex.hpp"
-
 #include "codec/list_iterator_codec.h"
 #include "codec/type_codec.h"
+#include "simdjson.h"
 #include "udf/containers.h"
 #include "udf/default_udf_library.h"
 #include "udf/udf.h"
 #include "udf/udf_registry.h"
 #include "vm/jit_runtime.h"
-#include "simdjson.h"
 
 using openmldb::base::Date;
 using hybridse::codec::ListRef;
@@ -615,7 +616,7 @@ void json_array_sort(::openmldb::base::StringRef *json_array,
 
   std::string_view order_ref(order->data_, order->size_);
   std::string_view column_ref(column->data_, column->size_);
-  std::map<std::string, std::string> container;
+  std::vector<std::pair<int, std::string>> container;
 
   for (auto ele : arr) {
     simdjson::ondemand::object obj;
@@ -635,27 +636,30 @@ void json_array_sort(::openmldb::base::StringRef *json_array,
       continue;
     }
 
-    container.emplace(order_val, column_val);
+    int order_int;
+    auto [ptr_order, ec_order] = std::from_chars(order_val.data(), order_val.data() + order_val.size(), order_int);
+    if (ec_order != std::errc()) {
+        return;
+    }
+    container.emplace_back(order_int, column_val);
   }
+
+  std::sort(container.begin(), container.end(), [desc](const auto& a, const auto& b) {
+      if (a.first == b.first) {
+          return desc ? a.second > b.second : a.second < b.second;
+      }
+      return desc ? a.first > b.first : a.first < b.first;
+  });
 
   std::stringstream ss;
   uint32_t topn = static_cast<uint32_t>(n);
   auto sz = container.size();
 
   for (uint32_t i = 0; i < topn && i < sz; ++i) {
-    if (desc) {
-      auto it = std::next(container.crbegin(), i);
-      ss << it->second;
-      if (std::next(it, 1) != container.crend() && i + 1 < topn) {
-        ss << ",";
+      ss << container[i].second;
+      if (i + 1 < topn && i + 1 < sz) {
+          ss << ",";
       }
-    } else {
-      auto it = std::next(container.cbegin(), i);
-      ss << it->second;
-      if (std::next(it, 1) != container.cend() && i + 1 < topn) {
-        ss << ",";
-      }
-    }
   }
 
   auto str = ss.str();

--- a/hybridse/src/udf/default_defs/feature_zero_def.cc
+++ b/hybridse/src/udf/default_defs/feature_zero_def.cc
@@ -639,7 +639,7 @@ void json_array_sort(::openmldb::base::StringRef *json_array,
     int order_int;
     auto [ptr_order, ec_order] = std::from_chars(order_val.data(), order_val.data() + order_val.size(), order_int);
     if (ec_order != std::errc()) {
-        return;
+        order_int = 0;
     }
     container.emplace_back(order_int, column_val);
   }

--- a/hybridse/src/udf/default_defs/feature_zero_def.cc
+++ b/hybridse/src/udf/default_defs/feature_zero_def.cc
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <charconv>
+#include <cstdint>
 #include <iostream>
 #include <queue>
 #include <string>
@@ -616,7 +617,7 @@ void json_array_sort(::openmldb::base::StringRef *json_array,
 
   std::string_view order_ref(order->data_, order->size_);
   std::string_view column_ref(column->data_, column->size_);
-  std::vector<std::pair<int, std::string>> container;
+  std::vector<std::pair<std::intmax_t, std::string>> container;
 
   for (auto ele : arr) {
     simdjson::ondemand::object obj;
@@ -636,7 +637,7 @@ void json_array_sort(::openmldb::base::StringRef *json_array,
       continue;
     }
 
-    int order_int;
+    std::intmax_t order_int;
     auto [ptr_order, ec_order] = std::from_chars(order_val.data(), order_val.data() + order_val.size(), order_int);
     if (ec_order != std::errc()) {
         order_int = 0;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
1. `json_array_sort` drops duplicate sort keys
2. `json_array_sort` sorts by string instead of int


* **What is the new behavior (if this is a feature change)?**
1. `json_array_sort` does not drop duplicate sort keys 
2. `json_array_sort` sorts by int instead of string, and breaks ties using output column
