### PR TITLE
refactor: fix compile for mcjit and improve to tests

### DIFF
--- a/hybridse/.gitignore
+++ b/hybridse/.gitignore
@@ -14,6 +14,7 @@ thirdsrc
 
 src/fe_version.h
 src/hyhridse_version.h
+src/case/test_cfg.h
 
 # ignore docgen
 style.xml

--- a/hybridse/CMakeLists.txt
+++ b/hybridse/CMakeLists.txt
@@ -125,6 +125,12 @@ configure_file(
         "${PROJECT_SOURCE_DIR}/src/version.h.in"
         "${PROJECT_SOURCE_DIR}/src/hybridse_version.h"
 )
+
+configure_file(
+        "${PROJECT_SOURCE_DIR}/src/case/test_cfg.h.in"
+        "${PROJECT_SOURCE_DIR}/src/case/test_cfg.h"
+)
+
 if (DEFINED ENV{CI})
   # suppress useless maven log (e.g download log) on CI environment
   set(MAVEN_FLAGS --batch-mode)

--- a/hybridse/include/case/sql_case.h
+++ b/hybridse/include/case/sql_case.h
@@ -221,6 +221,9 @@ class SqlCase {
     }
     static std::set<std::string> HYBRIDSE_LEVEL();
 
+    // Get the base directory searching for yaml test cases.
+    // It is by default directory to current git repository, or you can override
+    // the base directory with 'SQL_CASE_BASE_DIR' environment variable
     static std::string SqlCaseBaseDir();
 
     static bool IsDebug() {

--- a/hybridse/src/case/sql_case.cc
+++ b/hybridse/src/case/sql_case.cc
@@ -35,6 +35,7 @@
 #include "glog/logging.h"
 #include "node/sql_node.h"
 #include "plan/plan_api.h"
+#include "case/test_cfg.h"
 #include "vm/engine.h"
 #include "zetasql/parser/parser.h"
 #include "planv2/ast_node_converter.h"
@@ -1758,15 +1759,7 @@ std::set<std::string> SqlCase::HYBRIDSE_LEVEL() {
 }
 
 std::string SqlCase::SqlCaseBaseDir() {
-    char* value = getenv("SQL_CASE_BASE_DIR");
-    if (value != nullptr) {
-        return std::string(value);
-    }
-    value = getenv("YAML_CASE_BASE_DIR");
-    if (value != nullptr) {
-        return std::string(value);
-    }
-    return "";
+    return SQL_CASE_BASE_DIR;
 }
 
 absl::StatusOr<std::vector<codec::Row>> ExtractInsertRow(vm::HybridSeJitWrapper* jit, absl::string_view insert,

--- a/hybridse/src/case/sql_case.cc
+++ b/hybridse/src/case/sql_case.cc
@@ -1759,6 +1759,10 @@ std::set<std::string> SqlCase::HYBRIDSE_LEVEL() {
 }
 
 std::string SqlCase::SqlCaseBaseDir() {
+    char* value = getenv("SQL_CASE_BASE_DIR");
+    if (value != nullptr) {
+        return std::string(value);
+    }
     return SQL_CASE_BASE_DIR;
 }
 

--- a/hybridse/src/case/test_cfg.h.in
+++ b/hybridse/src/case/test_cfg.h.in
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2024 OpenMLDB Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef HYBRIDSE_SRC_CASE_TEST_CFG_H_
+#define HYBRIDSE_SRC_CASE_TEST_CFG_H_
+
+#define SQL_CASE_BASE_DIR "${CMAKE_SOURCE_DIR}"
+
+#endif  // HYBRIDSE_SRC_CASE_TEST_CFG_H_

--- a/hybridse/src/vm/jit.cc
+++ b/hybridse/src/vm/jit.cc
@@ -29,6 +29,7 @@ extern "C" {
 #include "llvm/ExecutionEngine/JITSymbol.h"
 #include "llvm/ExecutionEngine/Orc/CompileUtils.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
+#include "llvm/ExecutionEngine/JITEventListener.h"
 #include "llvm/ExecutionEngine/Orc/ExecutionUtils.h"
 #include "llvm/ExecutionEngine/Orc/IRCompileLayer.h"
 #include "llvm/ExecutionEngine/Orc/IRTransformLayer.h"
@@ -314,7 +315,7 @@ bool HybridSeMcJitWrapper::AddModule(
     } else {
         execution_engine_->addModule(std::move(module));
     }
-    if (jit_options_.IsEnableVTune()) {
+    if (jit_options_.IsEnableVtune()) {
         auto listener = ::llvm::JITEventListener::createIntelJITEventListener();
         if (listener == nullptr) {
             LOG(WARNING) << "Intel jit events is not enabled";
@@ -322,7 +323,7 @@ bool HybridSeMcJitWrapper::AddModule(
             execution_engine_->RegisterJITEventListener(listener);
         }
     }
-    if (jit_options_.IsEnableGDB()) {
+    if (jit_options_.IsEnableGdb()) {
         auto listener =
             ::llvm::JITEventListener::createGDBRegistrationListener();
         if (listener == nullptr) {


### PR DESCRIPTION
- fix compile with `-DLLVM_EXT_ENABLE=ON`
- setup sql case base dir on compile, no need to specify `SQL_CASE_BASE_DIR` environment every time
