### PR TITLE
ci: update create-pull-request action to v6 in udf-doc-gen workflow & rm deprecated file sync

### DIFF
--- a/.github/workflows/udf-doc.yml
+++ b/.github/workflows/udf-doc.yml
@@ -54,7 +54,6 @@ jobs:
         if: github.event_name != 'pull_request'
         with:
           add-paths: |
-            docs/en/reference/sql/udfs_8h.md
             docs/zh/openmldb_sql/udfs_8h.md
           labels: |
             udf

--- a/.github/workflows/udf-doc.yml
+++ b/.github/workflows/udf-doc.yml
@@ -50,7 +50,7 @@ jobs:
           make -C hybridse/tools/documentation/udf_doxygen sync
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v6
         if: github.event_name != 'pull_request'
         with:
           add-paths: |

--- a/hybridse/tools/documentation/udf_doxygen/Makefile
+++ b/hybridse/tools/documentation/udf_doxygen/Makefile
@@ -27,7 +27,6 @@ doxygen2md: doxygen
 
 sync: doxygen2md
 	@if [ -n "$(SYNC_DIR)" ]; then \
-	    cp -v "$(UDF_GEN_DIR)/Files/udfs_8h.md" "$(SYNC_DIR)/docs/en/reference/sql/udfs_8h.md"; \
 	    cp -v "$(UDF_GEN_DIR)/Files/udfs_8h.md" "$(SYNC_DIR)/docs/zh/openmldb_sql/udfs_8h.md"; \
 	else \
 	    echo "SKIP SYNC: DEFAULT Sync DIR not found"; \


### PR DESCRIPTION
udf doc gen fail issue#3903 (bug).
Updated the create-pull-request (.github/worflows/udf-doc.yml) to v6 which is currently using v4 causing deprecated issues.

