### PR TITLE
fix: fix macos cmake version

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -174,6 +174,8 @@ jobs:
         with:
           java-version: '8'
           distribution: 'temurin'
+      - name: Install CMake 3.22
+        run: brew install cmake@3.22 && brew link cmake@3.22 --force
       - name: prepare release
         run: |
           VERSION="snapshot"

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -174,8 +174,10 @@ jobs:
         with:
           java-version: '8'
           distribution: 'temurin'
-      - name: Install CMake 3.22
-        run: brew install cmake@3.22 && brew link cmake@3.22 --force
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@v1
+          with:
+              cmake-version: '3.22.0'
       - name: prepare release
         run: |
           VERSION="snapshot"

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -176,8 +176,8 @@ jobs:
           distribution: 'temurin'
       - name: Setup CMake
         uses: jwlawson/actions-setup-cmake@v1
-          with:
-              cmake-version: '3.22.0'
+        with:
+          cmake-version: '3.22.0'
       - name: prepare release
         run: |
           VERSION="snapshot"

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -173,6 +173,10 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '14.1.0'
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@v1
+        with:
+          cmake-version: '3.22.0'
 
       - name: Cache local Maven repository
         uses: actions/cache@v3
@@ -341,6 +345,10 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '14.1.0'
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@v1
+        with:
+          cmake-version: '3.22.0'
 
       - name: prepare release
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}


### PR DESCRIPTION
```
-- Found Protobuf: /Users/runner/work/OpenMLDB/OpenMLDB/.deps/usr/lib/libprotobuf.a (found suitable exact version "3.6.1")
CMake Error at contrib/rapidjson/CMakeLists.txt:1 (CMAKE_MINIMUM_REQUIRED):
-- Found Protobuf Libraries: /Users/runner/work/OpenMLDB/OpenMLDB/.deps/usr/lib/libprotobuf.a
  Compatibility with CMake < 3.5 has been removed from CMake.
-- Found Threads: TRUE

-- Adding contrib module simdjson (configuring with simdjson)
  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.


make: *** [configure] Error 1
-- Adding contrib module rapidjson (configuring with rapidjson)
```