### PR TITLE
fix: fix typos in hybridse udf docstrings

### DIFF
--- a/hybridse/src/udf/default_udf_library.cc
+++ b/hybridse/src/udf/default_udf_library.cc
@@ -874,9 +874,9 @@ void DefaultUdfLibrary::InitStringUdf() {
             @endcode
 
             @param str
-            @param pos define the begining of the substring.
+            @param pos define the beginning of the substring.
 
-            - If `pos` is positive, the begining of the substring is `pos` charactors from the start of string.
+            - If `pos` is positive, the beginning of the substring is `pos` characters from the start of string.
             - If `pos` is negative, the beginning of the substring is `pos` characters from the end of the string, rather than the beginning.
 
             @since 0.1.0)");
@@ -900,9 +900,9 @@ void DefaultUdfLibrary::InitStringUdf() {
             @endcode
 
             @param str
-            @param pos: define the begining of the substring.
+            @param pos: define the beginning of the substring.
 
-             - If `pos` is positive, the begining of the substring is `pos` charactors from the start of string.
+             - If `pos` is positive, the beginning of the substring is `pos` characters from the start of string.
              - If `pos` is negative, the beginning of the substring is `pos` characters from the end of the string, rather than the beginning.
 
             @param len length of substring. If len is less than 1, the result is the empty string.
@@ -947,8 +947,8 @@ void DefaultUdfLibrary::InitStringUdf() {
 
             @param substr
             @param str
-            @param pos: define the begining search position of the str.
-             - Negetive value is illegal and will return 0 directly;
+            @param pos: define the beginning search position of the str.
+             - Negative value is illegal and will return 0 directly;
              - If substr is "" and pos less equal len(str) + 1, return pos, other case return 0;
         )");
 

--- a/hybridse/src/udf/udf.h
+++ b/hybridse/src/udf/udf.h
@@ -397,7 +397,7 @@ void bool_to_string(bool v, StringRef *output);
 
 // transform string into integral
 // base is default to 10, 16 if string starts with '0x' or '0X', other base is not considered.
-// for hex string, it's parsed unsigned, add minus('-') to the very begining for negative hex
+// for hex string, it's parsed unsigned, add minus('-') to the very beginning for negative hex
 // returns (status, int64)
 struct StrToIntegral {
     std::pair<absl::Status, int64_t> operator()(absl::string_view in) {


### PR DESCRIPTION
## Summary

Small docstring typo fixes in `hybridse/src/udf/`, in the spirit of #4085 / #4086:

- `begining` → `beginning` (×6)
- `charactors` → `characters` (×2)
- `Negetive` → `Negative` (×1)

These appear in the doxygen-style `@param` / `@brief` doc comments for `substring`, `substr`, and `locate` UDFs, plus a comment on the `StrToIntegral` helper. No behavior change.

## Test plan

- [ ] Comment-only changes; no build or runtime impact expected.