### PR TITLE
refactor: replace boost::ends_with with absl::EndsWith

### DIFF
--- a/src/datacollector/data_collector.cc
+++ b/src/datacollector/data_collector.cc
@@ -22,8 +22,8 @@
 #include <utility>
 #include <vector>
 
+#include "absl/strings/match.h"
 #include "absl/strings/str_join.h"
-#include "boost/algorithm/string/predicate.hpp"
 #include "gflags/gflags.h"
 #include "google/protobuf/util/message_differencer.h"
 
@@ -415,7 +415,7 @@ bool DataCollectorImpl::FetchBinlogUnlocked(const std::string& name, const std::
     for (auto& p : fs::directory_iterator(binlog_dir)) {
         if (fs::is_regular_file(p)) {
             auto file_name = p.path().filename().string();
-            if (!boost::ends_with(file_name, ".log")) {
+            if (!absl::EndsWith(file_name, ".log")) {
                 continue;
             }
             auto src = binlog_path + file_name;

--- a/src/tablet/file_sender.cc
+++ b/src/tablet/file_sender.cc
@@ -19,9 +19,9 @@
 #include <thread>  // NOLINT
 #include <vector>
 
+#include "absl/strings/match.h"
 #include "base/file_util.h"
 #include "base/glog_wrapper.h"
-#include "boost/algorithm/string/predicate.hpp"
 #include "common/timer.h"
 #include "gflags/gflags.h"
 #include "nameserver/system_table.h"
@@ -124,7 +124,7 @@ int FileSender::SendFile(const std::string& file_name, const std::string& full_p
 }
 
 int FileSender::SendFile(const std::string& file_name, const std::string& dir_name, const std::string& full_path) {
-    if (!boost::ends_with(full_path, file_name)) {
+    if (!absl::EndsWith(full_path, file_name)) {
         PDLOG(WARNING, "invalid file[%s] path[%s]", file_name.c_str(), full_path.c_str());
         return -1;
     }


### PR DESCRIPTION
## Summary

Continues the boost-removal effort (see #4099, #4097, #4095). Replaces `boost::ends_with` with `absl::EndsWith` in two files and drops the now-unused `boost/algorithm/string/predicate.hpp` include from each.

- `src/datacollector/data_collector.cc`
- `src/tablet/file_sender.cc`

`absl::EndsWith` is already the established convention in this codebase (e.g. `src/storage/disk_table_snapshot.cc:53`, `src/storage/aggregator.cc:1306`, `src/sdk/sql_cluster_router.cc:4506`).

No behavior change — both APIs take `string_view` and return `bool`.

## Test plan

- [ ] CI build / existing unit tests pass.
- [ ] No remaining `boost::ends_with` references in the two touched files.