### PR TITLE
refactor: replace boost predicates with absl

### DIFF
--- a/src/nameserver/name_server_impl.cc
+++ b/src/nameserver/name_server_impl.cc
@@ -23,6 +23,7 @@
 #include <set>
 #include <vector>
 
+#include "absl/strings/match.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
@@ -1098,7 +1099,7 @@ void NameServerImpl::UpdateTablets(const std::vector<std::string>& endpoints) {
     std::string nearline_tablet_endpoint;
     for (const auto& endpoint : endpoints) {
         std::string cur_endpoint = endpoint;
-        if (boost::starts_with(cur_endpoint, ::openmldb::base::NEARLINE_PREFIX)) {
+        if (absl::StartsWith(cur_endpoint, ::openmldb::base::NEARLINE_PREFIX)) {
             nearline_tablet_endpoint = endpoint.substr(::openmldb::base::NEARLINE_PREFIX.size());
             cur_endpoint = nearline_tablet_endpoint;
         } else {
@@ -1263,7 +1264,7 @@ void NameServerImpl::OnTabletOnline(const std::string& endpoint) {
             offline_endpoint_map_.erase(iter);
             return;
         }
-        if (!boost::starts_with(value, "startup_")) {
+        if (!absl::StartsWith(value, "startup_")) {
             uint64_t cur_time = ::baidu::common::timer::get_micros() / 1000;
             if (cur_time < iter->second + FLAGS_tablet_heartbeat_timeout) {
                 PDLOG(INFO,
@@ -1275,7 +1276,7 @@ void NameServerImpl::OnTabletOnline(const std::string& endpoint) {
             }
         }
     }
-    if (boost::starts_with(value, "startup_")) {
+    if (absl::StartsWith(value, "startup_")) {
         PDLOG(INFO, "endpoint %s is startup, exe tablet offline", endpoint.c_str());
         OnTabletOffline(endpoint, true);
     }

--- a/src/tablet/tablet_impl.cc
+++ b/src/tablet/tablet_impl.cc
@@ -34,6 +34,7 @@
 #include <vector>
 
 #include "absl/cleanup/cleanup.h"
+#include "absl/strings/match.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "base/file_util.h"
@@ -4185,7 +4186,7 @@ int TabletImpl::CreateTableInternal(const ::openmldb::api::TableMeta* table_meta
         engine_->ClearCacheLocked("");
 
         // we always refresh the aggr catalog in case zk notification arrives later than the `deploy` sql
-        if (boost::iequals(table_meta->db(), openmldb::nameserver::PRE_AGG_DB)) {
+        if (absl::EqualsIgnoreCase(table_meta->db(), openmldb::nameserver::PRE_AGG_DB)) {
             RefreshAggrCatalog();
         }
     }


### PR DESCRIPTION
## Summary
- Replace `boost::starts_with` with `absl::StartsWith` in `src/nameserver/name_server_impl.cc` (3 sites).
- Replace `boost::iequals` with `absl::EqualsIgnoreCase` in `src/tablet/tablet_impl.cc` (1 site).
- Matches the convention used after the `boost::ends_with` removal in #4107. No behavior change.

## Test plan
- [ ] Existing unit/integration tests pass in CI.