### PR TITLE
refactor: replace boost::container::deque with std::deque

### DIFF
--- a/src/codec/codec_bench_test.cc
+++ b/src/codec/codec_bench_test.cc
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <deque>
 #include <iostream>
 
 #include "base/kv_iterator.h"
@@ -35,7 +36,7 @@ class CodecBenchmarkTest : public ::testing::Test {
 };
 
 void RunHasTs(::openmldb::storage::DataBlock* db) {
-    boost::container::deque<std::pair<uint64_t, ::openmldb::base::Slice>> data;
+    std::deque<std::pair<uint64_t, ::openmldb::base::Slice>> data;
     uint32_t total_block_size = 0;
     for (uint32_t i = 0; i < 1000; i++) {
         data.emplace_back(1000, std::move(::openmldb::base::Slice(db->data, db->size)));

--- a/src/codec/codec_test.cc
+++ b/src/codec/codec_test.cc
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+#include <deque>
 #include <memory>
 #include <string>
 #include <vector>
 
-#include "boost/container/deque.hpp"
 #include "codec/encrypt.h"
 #include "codec/row_codec.h"
 #include "gtest/gtest.h"
@@ -36,7 +36,7 @@ class CodecTest : public ::testing::Test {
 };
 
 TEST_F(CodecTest, EncodeRows) {
-    boost::container::deque<std::pair<uint64_t, ::openmldb::base::Slice>> data;
+    std::deque<std::pair<uint64_t, ::openmldb::base::Slice>> data;
     std::string test1 = "value1";
     std::string test2 = "value2";
     std::string empty;

--- a/src/codec/row_codec.cc
+++ b/src/codec/row_codec.cc
@@ -21,7 +21,6 @@
 #include <vector>
 
 #include "base/glog_wrapper.h"
-#include "boost/container/deque.hpp"
 #include "codec/schema_codec.h"
 #include "codec/row_codec.h"
 #include "storage/segment.h"

--- a/src/codec/row_codec.h
+++ b/src/codec/row_codec.h
@@ -23,7 +23,6 @@
 #include <vector>
 
 #include "base/status.h"
-#include "boost/container/deque.hpp"
 #include "butil/iobuf.h"
 #include "codec/codec.h"
 #include "storage/segment.h"

--- a/src/tablet/tablet_impl.cc
+++ b/src/tablet/tablet_impl.cc
@@ -45,7 +45,6 @@
 #include "base/strings.h"
 #include "base/sys_info.h"
 #include "boost/bind.hpp"
-#include "boost/container/deque.hpp"
 #include "brpc/controller.h"
 #include "butil/iobuf.h"
 #include "codec/codec.h"


### PR DESCRIPTION
## Summary
- Use `std::deque` in `src/codec/codec_test.cc` and `src/codec/codec_bench_test.cc` — `boost::container::deque` adds nothing over the standard one here.
- Drop the `boost/container/deque.hpp` include from `src/codec/row_codec.{h,cc}` and `src/tablet/tablet_impl.cc`, where it was already unused. No behavior change.

## Test plan
- [ ] `codec_test` and `codec_bench_test` build and pass in CI.
- [ ] `tablet_impl` still builds.