### PR TITLE
fix: disable javadoc auto link detection

### DIFF
--- a/java/openmldb-batchjob/pom.xml
+++ b/java/openmldb-batchjob/pom.xml
@@ -142,6 +142,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <detectJavaApiLink>false</detectJavaApiLink>
+          <detectOfflineLinks>false</detectOfflineLinks>
+        </configuration>
       </plugin>
 
     </plugins>

--- a/java/openmldb-spark-connector/pom.xml
+++ b/java/openmldb-spark-connector/pom.xml
@@ -119,6 +119,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <detectJavaApiLink>false</detectJavaApiLink>
+                    <detectOfflineLinks>false</detectOfflineLinks>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/java/openmldb-taskmanager/pom.xml
+++ b/java/openmldb-taskmanager/pom.xml
@@ -332,6 +332,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                  <detectJavaApiLink>false</detectJavaApiLink>
+                  <detectOfflineLinks>false</detectOfflineLinks>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

Javadoc generation fails because the Maven Javadoc plugin automatically tries to detect offline links and fetch `package-list` files from generated module documentation that may not exist.

This results in errors like:

`Error fetching link: .../target/apidocs/package-list`

It also triggers unnecessary Java API link detection warnings.

### What is the new behavior (if this is a feature change)?

This PR disables automatic Java API link detection and offline link detection in:

* `openmldb-batchjob`
* `openmldb-spark-connector`
* `openmldb-taskmanager`

After this change, the previous `package-list` error no longer appears during Javadoc generation.
fixes:#3848