### PR TITLE
fix: avoid zero division in table checker

### DIFF
--- a/python/openmldb_tool/diagnostic_tool/table_checker.py
+++ b/python/openmldb_tool/diagnostic_tool/table_checker.py
@@ -104,7 +104,7 @@ class TableChecker:
             self._byte2mb(t["dused_dist"])
             self._show_dist(
                 t["dused_dist"],
-                max_width=max_width * get_max(t["dused_dist"]) / max_values["md"],
+                max_width=max_width if max_values["md"] == 0 else max_width * get_max(t["dused_dist"]) / max_values["md"],
             )
 
         print()


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

The diagnostic tool crashes with a `ZeroDivisionError` in `table_checker.py` when `max_values["md"]` becomes `0` while calculating distribution width.

This happens at:

`max_width=max_width * get_max(t["dused_dist"]) / max_values["md"]`

Fixes #3887

* **What is the new behavior (if this is a feature change)?**

This PR adds a safeguard to avoid division by zero by using `max_width` directly when `max_values["md"] == 0`.
