### PR TITLE
fix: support scientific notation for float literals

### DIFF
--- a/hybridse/src/case/sql_case_test.cc
+++ b/hybridse/src/case/sql_case_test.cc
@@ -312,6 +312,29 @@ TEST_F(SqlCaseTest, ExtractInsertSqlTest) {
             create_sql);
     }
 }
+TEST_F(SqlCaseTest, ExtractScientificFloatInsertTest) {
+    const std::string schema_str =
+        "id:int64, name:string, age:int64, score:float, ts:double, dt:date";
+
+    type::TableDef output_table;
+    ASSERT_TRUE(SqlCase::ExtractSchema(schema_str, output_table));
+
+    std::vector<std::vector<std::string>> rows;
+    rows.push_back({
+        "1",
+        "Alice",
+        "25",
+        "1.1e0",
+        "1712911045",
+        "2024-01-01"
+    });
+
+    std::string create_sql;
+    ASSERT_TRUE(
+        SqlCase::BuildInsertSqlFromRows(output_table, rows, &create_sql));
+
+    ASSERT_NE(std::string::npos, create_sql.find("1.1e0"));
+}
 TEST_F(SqlCaseTest, ExtractRowTest) {
     const std::string schema_str =
         "col0:string, col1:int32, col2:int16, col3:float, col4:double, "

--- a/hybridse/src/planv2/ast_node_converter.cc
+++ b/hybridse/src/planv2/ast_node_converter.cc
@@ -454,7 +454,7 @@ base::Status ConvertExprNode(const zetasql::ASTExpression* ast_expression, node:
             bool is_null;
             if (literal->is_float32()) {
                 float float_value = 0.0;
-                hybridse::codec::StringRef str(literal->image().size() - 1, literal->image().data());
+                hybridse::codec::StringRef str(literal->image().size(), literal->image().data());
                 hybridse::udf::v1::string_to_float(&str, &float_value, &is_null);
                 CHECK_TRUE(!is_null, common::kSqlAstError, "Invalid float literal: ", literal->image());
                 *output = node_manager->MakeConstNode(float_value);

--- a/hybridse/src/planv2/ast_node_converter.cc
+++ b/hybridse/src/planv2/ast_node_converter.cc
@@ -454,7 +454,7 @@ base::Status ConvertExprNode(const zetasql::ASTExpression* ast_expression, node:
             bool is_null;
             if (literal->is_float32()) {
                 float float_value = 0.0;
-                hybridse::codec::StringRef str(literal->image().size(), literal->image().data());
+                hybridse::codec::StringRef str(literal->image().size() - 1, literal->image().data());
                 hybridse::udf::v1::string_to_float(&str, &float_value, &is_null);
                 CHECK_TRUE(!is_null, common::kSqlAstError, "Invalid float literal: ", literal->image());
                 *output = node_manager->MakeConstNode(float_value);


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Float literals using scientific notation, such as `1.1e0`, may fail when converted as float literals.

In the float32 path, the literal image was truncated by one character before conversion:

`literal->image().size() - 1`

For a value like `1.1e0`, this turns the literal into `1.1e`, which is invalid.

Fixes #3872

* **What is the new behavior (if this is a feature change)?**

This PR preserves the full float literal image when converting float32 literals, allowing values like `1.1e0` to be parsed correctly.
