### PR TITLE
feat(batch): enable window column pruning config

### DIFF
--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/OpenmldbBatchConfig.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/OpenmldbBatchConfig.scala
@@ -91,6 +91,9 @@ class OpenmldbBatchConfig extends Serializable {
   @ConfigOption(name = "openmldb.window.parallelization", doc = "Enable window compute parallelization optimization")
   var enableWindowParallelization: Boolean = false
 
+  @ConfigOption(name = "openmldb.window.column.pruning", doc = "Enable window column pruning optimization")
+  var enableWindowColumnPruning: Boolean = false
+
   @ConfigOption(name = "openmldb.window.sampleFilter", doc =
     """
       | Filter condition for window sample, currently only support simple equalities

--- a/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/SparkPlanner.scala
+++ b/java/openmldb-batch/src/main/scala/com/_4paradigm/openmldb/batch/SparkPlanner.scala
@@ -19,7 +19,7 @@ package com._4paradigm.openmldb.batch
 import com._4paradigm.hybridse.`type`.TypeOuterClass.Database
 import com._4paradigm.hybridse.node.{DataType, JoinType}
 import com._4paradigm.hybridse.sdk.{SqlEngine, UnsupportedHybridSeException}
-import com._4paradigm.hybridse.vm.{CoreAPI, Engine, PhysicalConstProjectNode, PhysicalCreateTableNode,
+import com._4paradigm.hybridse.vm.{CoreAPI, Engine, EngineOptions, PhysicalConstProjectNode, PhysicalCreateTableNode,
   PhysicalDataProviderNode, PhysicalFilterNode, PhysicalGroupAggrerationNode, PhysicalGroupNode, PhysicalInsertNode,
   PhysicalJoinNode, PhysicalLimitNode, PhysicalLoadDataNode, PhysicalOpNode, PhysicalOpType, PhysicalProjectNode,
   PhysicalRenameNode, PhysicalSelectIntoNode, PhysicalSetOperationNode, PhysicalSimpleProjectNode, PhysicalSortNode,
@@ -334,14 +334,7 @@ class SparkPlanner(session: SparkSession, config: OpenmldbBatchConfig, sparkAppN
   private def withSQLEngine[T](sql: String, dbs: List[Database],
                                config: OpenmldbBatchConfig)(body: SqlEngine => T): T = {
     var sqlEngine: SqlEngine = null
-    val engineOptions = SqlEngine.createDefaultEngineOptions()
-
-    if (config.enableWindowParallelization) {
-      logger.info("Enable window parallelization optimization")
-      engineOptions.SetEnableBatchWindowParallelization(true)
-    } else {
-      logger.info("Disable window parallelization optimization, enable by setting openmldb.window.parallelization")
-    }
+    val engineOptions = createEngineOptions(config)
 
     try {
       sqlEngine = new SqlEngine(seqAsJavaList(dbs), engineOptions)
@@ -402,5 +395,26 @@ class SparkPlanner(session: SparkSession, config: OpenmldbBatchConfig, sparkAppN
         sqlEngine.close()
       }
     }
+  }
+
+  private[batch] def createEngineOptions(config: OpenmldbBatchConfig): EngineOptions = {
+    val engineOptions = SqlEngine.createDefaultEngineOptions()
+
+    if (config.enableWindowParallelization) {
+      logger.info("Enable window parallelization optimization")
+      engineOptions.SetEnableBatchWindowParallelization(true)
+    } else {
+      logger.info("Disable window parallelization optimization, enable by setting openmldb.window.parallelization")
+    }
+
+    if (config.enableWindowColumnPruning) {
+      logger.info("Enable window column pruning optimization")
+      engineOptions.SetEnableWindowColumnPruning(true)
+    } else {
+      logger.info("Disable window column pruning optimization, " +
+        "enable by setting openmldb.window.column.pruning")
+    }
+
+    engineOptions
   }
 }

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/TestOpenmldbBatchConfig.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/TestOpenmldbBatchConfig.scala
@@ -27,22 +27,26 @@ class TestOpenmldbBatchConfig extends FunSuite {
     val sess = SparkSession.builder()
         .config("spark.openmldb.groupby.partitions", 100)
         .config("spark.openmldb.test.print", value=true)
+        .config("spark.openmldb.window.column.pruning", value=true)
         .master("local[1]")
         .getOrCreate()
     val config = OpenmldbBatchConfig.fromSparkSession(sess)
     assert(config.groupbyPartitions == 100)
     assert(config.print)
+    assert(config.enableWindowColumnPruning)
     sess.close()
   }
 
   test("Test make config from dict") {
     val dict = Map(
       "openmldb.groupby.partitions" -> 100,
-      "openmldb.test.print" -> true
+      "openmldb.test.print" -> true,
+      "openmldb.window.column.pruning" -> true
     )
     val config = OpenmldbBatchConfig.fromDict(dict)
     assert(config.groupbyPartitions == 100)
     assert(config.print)
+    assert(config.enableWindowColumnPruning)
   }
 
   test("Test config of openmldb.sparksql") {

--- a/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/TestSparkPlanner.scala
+++ b/java/openmldb-batch/src/test/scala/com/_4paradigm/openmldb/batch/TestSparkPlanner.scala
@@ -23,6 +23,20 @@ import scala.collection.JavaConverters.seqAsJavaListConverter
 
 class TestSparkPlanner extends SparkTestSuite {
 
+  test("Test window column pruning engine option") {
+    val config = new OpenmldbBatchConfig
+    config.enableWindowColumnPruning = true
+
+    val planner = new SparkPlanner(getSparkSession, config)
+    val engineOptions = planner.createEngineOptions(config)
+
+    try {
+      assert(engineOptions.IsEnableWindowColumnPruning())
+    } finally {
+      engineOptions.delete()
+    }
+  }
+
   test("Test project plan smoke") {
     val sess = getSparkSession
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?**

Feature.

* **What is the current behavior?**

Window column pruning cannot be enabled from openmldb-batch. Closes #939.

* **What is the new behavior (if this is a feature change)?**

`spark.openmldb.window.column.pruning=true` enables the engine optimization.
